### PR TITLE
Add OSFT implementation through mini-trainer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,29 @@ result = sft(
 )
 ```
 
+### Orthogonal Subspace Fine-Tuning (OSFT)
+
+The OSFT algorithm supports continual training of pre-trained or instruction-tuned models without requiring supplementary datasets to maintain the original model distribution. Based on [Nayak et al. (2025)](https://arxiv.org/abs/2504.07097), it enables efficient customization while preventing catastrophic forgetting.
+
+**Documentation:**
+- [OSFT Usage Guide](docs/osft_usage.md) - Comprehensive usage documentation with parameter reference and examples
+
+**Quick Example:**
+```python
+from training_hub import osft
+
+result = osft(
+    model_path="/path/to/model",
+    data_path="/path/to/data.jsonl", 
+    output_dir="/path/to/outputs",
+    unfreeze_rank_ratio=0.3,
+    batch_size=8,
+    max_tokens_per_gpu=2048,
+    max_seq_len=2048,
+    learning_rate=2e-5
+)
+```
+
 ## Getting Started
 
 1. **For detailed parameter documentation**: Check the relevant guide in `docs/`

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,9 +55,9 @@ from training_hub import osft
 result = osft(
     model_path="/path/to/model",
     data_path="/path/to/data.jsonl", 
-    output_dir="/path/to/outputs",
+    ckpt_output_dir="/path/to/outputs",
     unfreeze_rank_ratio=0.3,
-    batch_size=8,
+    effective_batch_size=8,
     max_tokens_per_gpu=2048,
     max_seq_len=2048,
     learning_rate=2e-5

--- a/examples/docs/osft_usage.md
+++ b/examples/docs/osft_usage.md
@@ -1,0 +1,273 @@
+# OSFT Algorithm Usage Examples
+
+This document shows how to use the OSFT (Orthogonal Subspace Fine-Tuning) algorithm in training_hub.
+
+## Overview
+
+The OSFT algorithm implements Orthogonal Subspace Fine-Tuning based on Nayak et al. (2025), arXiv:2504.07097. This algorithm allows for continual training of pre-trained or instruction-tuned models without the need of a supplementary dataset to maintain the distribution of the original model/dataset that was trained.
+
+**Key Benefits:**
+- Enables continual learning without catastrophic forgetting
+- No need for supplementary datasets to maintain original model distribution
+- Significantly reduces data requirements for customizing instruction-tuned models
+- Memory requirements similar to standard SFT
+
+## Data Format Requirements
+
+Training Hub's OSFT algorithm supports both **processed** and **unprocessed** data formats via the mini-trainer backend.
+
+### Option 1: Standard Messages Format (Recommended)
+
+Your training data should be a **JSON Lines (.jsonl)** file containing messages data:
+
+```json
+{"messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Hello!"}, {"role": "assistant", "content": "Hi there! How can I help you?"}]}
+{"messages": [{"role": "user", "content": "What is OSFT?"}, {"role": "assistant", "content": "OSFT stands for Orthogonal Subspace Fine-Tuning..."}]}
+```
+
+### Message Structure
+- **`role`**: One of `"system"`, `"user"`, `"assistant"`, or `"pretraining"`
+- **`content`**: The text content of the message
+- **`reasoning_content`** (optional): Additional reasoning traces
+
+### Masking Control with `unmask_messages` Parameter
+
+Control training behavior during data processing:
+
+**Standard instruction tuning (default):**
+```python
+osft(..., unmask_messages=False)  # Only assistant responses used for loss
+```
+
+**Pretraining mode:**
+```python
+osft(..., unmask_messages=True)   # All content except system messages used for loss
+```
+
+### Option 2: Pre-processed Dataset
+
+If you have pre-processed data with `input_ids` and `labels` fields:
+
+```json
+{"input_ids": [1, 2, 3, ...], "labels": [1, 2, 3, ...]}
+{"input_ids": [4, 5, 6, ...], "labels": [4, 5, 6, ...]}
+```
+
+Use with:
+```python
+osft(..., use_processed_dataset=True)
+```
+
+## Simple Usage with Convenience Function
+
+The easiest way to run OSFT training is using the convenience function:
+
+```python
+from training_hub import osft
+
+# Basic OSFT training
+result = osft(
+    model_path="/path/to/your/model",
+    data_path="/path/to/your/training/data.jsonl",
+    output_dir="/path/to/save/outputs",
+    unfreeze_rank_ratio=0.3,
+    batch_size=8,
+    max_tokens_per_gpu=2048,
+    max_seq_len=2048,
+    learning_rate=2e-5
+)
+
+# OSFT training with custom parameters
+result = osft(
+    model_path="/path/to/your/model",
+    data_path="/path/to/your/training/data.jsonl",
+    output_dir="/path/to/save/outputs",
+    unfreeze_rank_ratio=0.2,
+    batch_size=4,
+    max_tokens_per_gpu=4096,
+    max_seq_len=4096,
+    learning_rate=1e-5,
+    epochs=3,
+    warmup_steps=100,
+    use_liger=True,
+    seed=42
+)
+```
+
+## Using the Factory Pattern
+
+For more control over the algorithm instance:
+
+```python
+from training_hub import create_algorithm
+
+# Create an OSFT algorithm instance
+osft_algo = create_algorithm('osft', 'mini-trainer')
+
+# Run training
+result = osft_algo.train(
+    model_path="/path/to/your/model",
+    data_path="/path/to/your/training/data.jsonl",
+    output_dir="/path/to/save/outputs",
+    unfreeze_rank_ratio=0.25,
+    batch_size=6,
+    max_tokens_per_gpu=3072,
+    max_seq_len=2048,
+    learning_rate=1.5e-5,
+    epochs=2
+)
+
+# Check required parameters
+required_params = osft_algo.get_required_params()
+print("Required parameters:", list(required_params.keys()))
+```
+
+## Algorithm and Backend Discovery
+
+Explore available algorithms and backends:
+
+```python
+from training_hub import AlgorithmRegistry
+
+# List all available algorithms
+algorithms = AlgorithmRegistry.list_algorithms()
+print("Available algorithms:", algorithms)  # ['sft', 'osft']
+
+# List backends for OSFT
+osft_backends = AlgorithmRegistry.list_backends('osft')
+print("OSFT backends:", osft_backends)  # ['mini-trainer']
+
+# Get algorithm class directly
+OSFTAlgorithm = AlgorithmRegistry.get_algorithm('osft')
+```
+
+## Parameter Reference
+
+### Required Parameters
+
+- `model_path` (str): Local path or HuggingFace model ID to be used for fine-tuning
+- `data_path` (str): Path to the training data (processed or unprocessed)
+- `output_dir` (str): Directory where outputs from training will be saved
+- `unfreeze_rank_ratio` (float): Controls the amount that each matrix is unfrozen during OSFT (0.0-1.0)
+- `batch_size` (int): Batch size for training
+- `max_tokens_per_gpu` (int): Maximum number of tokens placed on a single GPU
+- `max_seq_len` (int): Maximum sequence length (in tokens) for training samples
+- `learning_rate` (float): Learning rate for model update size
+
+### Optional Training Parameters
+
+**OSFT-Specific Parameters:**
+- `target_patterns` (list[str]): Patterns to match when selecting modules for OSFT
+- `unfreeze_rank_ratio` (float): Valid values are between 0.0 and 1.0 (seldom need >0.5)
+
+**Data Processing Parameters:**
+- `use_processed_dataset` (bool): Whether to use pre-processed dataset format
+- `unmask_messages` (bool): Whether to unmask messages during data processing
+
+**Core Training Parameters:**
+- `epochs` (int): Number of epochs to train for
+- `seed` (int): Random seed for training
+- `use_liger` (bool): Whether to use Liger kernels for training
+
+**Learning Rate Scheduler:**
+- `lr_scheduler` (str): Name of the PyTorch learning rate scheduler to use
+- `warmup_steps` (int): Number of warmup steps for the learning rate scheduler
+- `lr_scheduler_kwargs` (dict[str, str]): Additional scheduler parameters
+
+**Checkpointing:**
+- `checkpoint_at_epoch` (bool): Whether to checkpoint at each epoch
+- `save_final_checkpoint` (bool): Whether to save final checkpoint
+
+**Multi-Node Parameters:**
+- `nproc_per_node` (int): Number of processes (GPUs) per node
+- `nnodes` (int): Total number of nodes in the cluster
+- `node_rank` (int): Rank of this node (0 to nnodes-1)
+- `rdzv_id` (int): Unique job ID for rendezvous
+- `rdzv_endpoint` (str): Master node endpoint (format: "host:port")
+
+### Backend Selection
+
+- `backend` (str, default="mini-trainer"): Backend implementation to use
+
+## Error Handling
+
+```python
+from training_hub import osft, AlgorithmRegistry
+
+try:
+    result = osft(
+        model_path="/valid/model/path",
+        data_path="/valid/data/path",
+        output_dir="/valid/output/path",
+        unfreeze_rank_ratio=0.3,
+        batch_size=8,
+        max_tokens_per_gpu=2048,
+        max_seq_len=2048,
+        learning_rate=2e-5
+    )
+except ValueError as e:
+    print(f"Configuration error: {e}")
+except Exception as e:
+    print(f"Training error: {e}")
+
+# Check if algorithm exists before using
+if 'osft' in AlgorithmRegistry.list_algorithms():
+    print("OSFT algorithm is available")
+
+# Check if backend exists
+if 'mini-trainer' in AlgorithmRegistry.list_backends('osft'):
+    print("Mini-trainer backend is available")
+```
+
+## Multi-Node Training
+
+The OSFT algorithm supports multi-node distributed training through torchrun parameters:
+
+```python
+from training_hub import osft
+
+# Single-node, multi-GPU training (2 GPUs)
+result = osft(
+    model_path="/path/to/model",
+    data_path="/path/to/data.jsonl",
+    output_dir="/path/to/outputs",
+    unfreeze_rank_ratio=0.3,
+    batch_size=4,
+    max_tokens_per_gpu=2048,
+    max_seq_len=2048,
+    learning_rate=2e-5,
+    nproc_per_node=2,  # Number of GPUs per node
+    nnodes=1,          # Single node
+    node_rank=0,       # This node's rank
+    rdzv_id=12345,     # Rendezvous ID
+    rdzv_endpoint=""   # Empty for single node
+)
+
+# Multi-node training (2 nodes, 4 GPUs each)
+# Run this on the first node (rank 0):
+result = osft(
+    model_path="/path/to/model",
+    data_path="/path/to/data.jsonl",
+    output_dir="/path/to/outputs",
+    unfreeze_rank_ratio=0.25,
+    batch_size=2,
+    max_tokens_per_gpu=1024,
+    max_seq_len=2048,
+    learning_rate=1e-5,
+    nproc_per_node=4,           # 4 GPUs per node
+    nnodes=2,                   # 2 total nodes
+    node_rank=0,                # This is node 0
+    rdzv_id=12345,              # Shared rendezvous ID
+    rdzv_endpoint="node0:29500" # Master node endpoint
+)
+```
+
+## Best Practices
+
+1. **unfreeze_rank_ratio**: Start with values between 0.1-0.5. Values >0.5 are rarely needed for general continual-learning regimes.
+
+2. **Memory Management**: OSFT doesn't reduce memory requirements compared to SFT, so adjust `max_tokens_per_gpu` accordingly.
+
+3. **Data Processing**: The algorithm handles data processing automatically. Use `use_processed_dataset=True` only if you have pre-tokenized data.
+
+4. **Continual Learning**: OSFT is particularly effective for adapting instruction-tuned models to new domains without catastrophic forgetting.

--- a/examples/docs/osft_usage.md
+++ b/examples/docs/osft_usage.md
@@ -69,9 +69,9 @@ from training_hub import osft
 result = osft(
     model_path="/path/to/your/model",
     data_path="/path/to/your/training/data.jsonl",
-    output_dir="/path/to/save/outputs",
+    ckpt_output_dir="/path/to/save/outputs",
     unfreeze_rank_ratio=0.3,
-    batch_size=8,
+    effective_batch_size=16,
     max_tokens_per_gpu=2048,
     max_seq_len=2048,
     learning_rate=2e-5
@@ -81,13 +81,13 @@ result = osft(
 result = osft(
     model_path="/path/to/your/model",
     data_path="/path/to/your/training/data.jsonl",
-    output_dir="/path/to/save/outputs",
+    ckpt_output_dir="/path/to/save/outputs",
     unfreeze_rank_ratio=0.2,
-    batch_size=4,
+    effective_batch_size=16,
     max_tokens_per_gpu=4096,
     max_seq_len=4096,
     learning_rate=1e-5,
-    epochs=3,
+    num_epochs=3,
     warmup_steps=100,
     use_liger=True,
     seed=42
@@ -108,13 +108,13 @@ osft_algo = create_algorithm('osft', 'mini-trainer')
 result = osft_algo.train(
     model_path="/path/to/your/model",
     data_path="/path/to/your/training/data.jsonl",
-    output_dir="/path/to/save/outputs",
+    ckpt_output_dir="/path/to/save/outputs",
     unfreeze_rank_ratio=0.25,
     batch_size=6,
     max_tokens_per_gpu=3072,
     max_seq_len=2048,
     learning_rate=1.5e-5,
-    epochs=2
+    num_epochs=2
 )
 
 # Check required parameters
@@ -147,9 +147,9 @@ OSFTAlgorithm = AlgorithmRegistry.get_algorithm('osft')
 
 - `model_path` (str): Local path or HuggingFace model ID to be used for fine-tuning
 - `data_path` (str): Path to the training data (processed or unprocessed)
-- `output_dir` (str): Directory where outputs from training will be saved
+- `ckpt_output_dir` (str): Directory where outputs from training will be saved
 - `unfreeze_rank_ratio` (float): Controls the amount that each matrix is unfrozen during OSFT (0.0-1.0)
-- `batch_size` (int): Batch size for training
+- `effective_batch_size` (int): Batch size for training
 - `max_tokens_per_gpu` (int): Maximum number of tokens placed on a single GPU
 - `max_seq_len` (int): Maximum sequence length (in tokens) for training samples
 - `learning_rate` (float): Learning rate for model update size
@@ -165,7 +165,7 @@ OSFTAlgorithm = AlgorithmRegistry.get_algorithm('osft')
 - `unmask_messages` (bool): Whether to unmask messages during data processing
 
 **Core Training Parameters:**
-- `epochs` (int): Number of epochs to train for
+- `num_epochs` (int): Number of epochs to train for
 - `seed` (int): Random seed for training
 - `use_liger` (bool): Whether to use Liger kernels for training
 
@@ -198,9 +198,9 @@ try:
     result = osft(
         model_path="/valid/model/path",
         data_path="/valid/data/path",
-        output_dir="/valid/output/path",
+        ckpt_output_dir="/valid/output/path",
         unfreeze_rank_ratio=0.3,
-        batch_size=8,
+        effective_batch_size=8,
         max_tokens_per_gpu=2048,
         max_seq_len=2048,
         learning_rate=2e-5
@@ -230,9 +230,9 @@ from training_hub import osft
 result = osft(
     model_path="/path/to/model",
     data_path="/path/to/data.jsonl",
-    output_dir="/path/to/outputs",
+    ckpt_output_dir="/path/to/outputs",
     unfreeze_rank_ratio=0.3,
-    batch_size=4,
+    effective_batch_size=4,
     max_tokens_per_gpu=2048,
     max_seq_len=2048,
     learning_rate=2e-5,
@@ -248,9 +248,9 @@ result = osft(
 result = osft(
     model_path="/path/to/model",
     data_path="/path/to/data.jsonl",
-    output_dir="/path/to/outputs",
+    ckpt_output_dir="/path/to/outputs",
     unfreeze_rank_ratio=0.25,
-    batch_size=2,
+    effective_batch_size=2,
     max_tokens_per_gpu=1024,
     max_seq_len=2048,
     learning_rate=1e-5,

--- a/examples/docs/sft_usage.md
+++ b/examples/docs/sft_usage.md
@@ -241,7 +241,6 @@ This architecture supports adding new algorithms and backends:
 # Future algorithms might include:
 # - DPO (Direct Preference Optimization)
 # - LoRA (Low-Rank Adaptation)
-# - OSFT (Continual Learning via OSFT)
 
 # Example of what future usage might look like:
 # from training_hub import dpo, lora

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "packaging>=24.2",
     "wheel>=0.43",
     "instructlab-training>=0.11.1",
+    "rhai-innovation-mini-trainer>=0.1.0",
     "torch>=2.6.0",
     "numba>=0.50",
     "datasets>=2.15.0",
@@ -50,6 +51,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 cuda = [
     "instructlab-training[cuda]>=0.11.1",
+    "rhai-innovation-mini-trainer[cuda]>=0.1.0",
     "flash-attn>=2.8",
     "einops>=0.8"
 ]

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -1,5 +1,6 @@
 from .algorithms import Algorithm, Backend, AlgorithmRegistry, create_algorithm
 from .algorithms.sft import sft, SFTAlgorithm, InstructLabTrainingSFTBackend
+from .algorithms.osft import OSFTAlgorithm, MiniTrainerOSFTBackend, osft
 from .hub_core import welcome
 
 __all__ = [
@@ -8,7 +9,10 @@ __all__ = [
     'AlgorithmRegistry',
     'create_algorithm',
     'sft',
+    'osft',
     'SFTAlgorithm',
     'InstructLabTrainingSFTBackend',
+    'OSFTAlgorithm',
+    'MiniTrainerOSFTBackend',
     'welcome'
 ]

--- a/src/training_hub/algorithms/__init__.py
+++ b/src/training_hub/algorithms/__init__.py
@@ -16,6 +16,10 @@ class Algorithm(ABC):
         """Return dictionary of required parameter names and their types."""
         pass
 
+    @abstractmethod
+    def get_optional_params(self) -> Dict[str, Type]:
+        """Return dictionary of optional parameter names and their types."""
+        pass
 
 class Backend(ABC):
     """Base class for all backend implementations."""

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -1,0 +1,461 @@
+import os
+import shutil
+from typing import Literal, get_origin, get_args, Union
+from itertools import chain
+from dataclasses import fields
+
+import datasets
+from training_hub.algorithms import Algorithm, Backend, AlgorithmRegistry
+from training_hub.utils import format_type_name
+
+
+class OSFTAlgorithm(Algorithm):
+    """
+    Implements the Orthogonal Subspace Fine-Tuning (OSFT) algorithm,
+    based on Nayak et al. (2025), arXiv:2504.07097
+
+    This algorithm allows for continual training of pre-trained or instruction-tuned
+    models without the need of a supplementary dataset to maintain the distribution
+    of the original model/dataset that was trained.
+    """
+
+    def __init__(self, backend: Backend, **kwargs) -> None:
+        self.backend = backend
+        self.kwargs = kwargs
+
+    def train(
+        self,
+        model_path: str,
+        data_path: str,
+        batch_size: int,
+        max_tokens_per_gpu: int,
+        max_seq_len: int,
+        learning_rate: float,
+        output_dir: str,
+        unfreeze_rank_ratio: float,
+
+        # patterns that we want to match against when selecting
+        # modules for OSFT
+        target_patterns: list[str] | None = None,  
+
+        # settings for training mode
+        seed: int | None = None,
+        use_liger: bool | None = None,
+
+        # learning rate scheduler
+        lr_scheduler: str = None,
+        warmup_steps: int = None, 
+        lr_scheduler_kwargs: dict[str, str] | None = None,
+
+        # checkpointing
+        checkpoint_at_epoch: bool | None = None,
+        save_final_checkpoint: bool | None = None,
+        
+        # parameters for the training mode
+        epochs: int | None = None,
+
+        # whether to use the processed dataset
+        use_processed_dataset: bool | None = None,
+        unmask_messages: bool | None = None,
+
+        # Torchrun parameters for multi-node support
+        nproc_per_node: int | None = None,
+        nnodes: int | None = None,
+        node_rank: int | None = None,
+        rdzv_id: int | None = None,
+        rdzv_endpoint: str | None = None,
+        **kwargs,
+    ) -> any:
+        """
+        This algorithm implements Continual Training using the OSFT algorithm
+        with the mini-trainer backend.
+
+        **Note:** The OSFT algorithm does not reduce the memory requirement when compared,
+        to SFT, but it significantly reduces the data requirement for customizing an instruction-tuned
+        model compared to SFT.
+
+        **Note:**
+            While all values of `unfreeze_rank_ratio` are valid, in practice you will seldom
+            need values greater than 0.5 for general continual-learning regimes.
+        
+        Arguments:
+            model_path (str): Local path or HuggingFace model ID to be used for fine-tuning.
+            data_path (str):
+                Path to the training data. When `use_processed_dataset` is True,
+                this is the path to the processed dataset. When `use_processed_dataset` is False,
+                this is the path to the original dataset.
+            batch_size (int): Batch size for training.
+            max_tokens_per_gpu (int):
+                The maximum number of tokens placed on a single GPU for training.
+                When hitting OOMs, consider reducing this value.
+            max_seq_len (int):
+                Sets the maximum sequence length (in tokens) of samples that will be used for training.
+                Any sample exceeding this length will be dropped from the dataset.
+            learning_rate (float): Learning rate for model update size.
+            output_dir (str):
+                Directory where outputs from training will be saved, including checkpoints, logs, and 
+                any necessary intermediate files.
+            unfreeze_rank_ratio (float):
+                Controls the amount that each matrix is unfrozen during OSFT. 
+                Valid values are between 0.0 and 1.0.
+            target_patterns (list[str]):
+                List of patterns to match against when selecting modules for OSFT,
+                useful for custom training regimes or enabling OSFT for custom models which
+                do not have pre-defined defaults.
+            seed (int): Random seed for training.
+            use_liger (bool): Whether to use Liger kernels for training.
+            unmask_messages (bool):
+                Whether to unmask messages during data processing. This value is ignored
+                when `use_processed_dataset` is True.
+            use_processed_dataset (bool):
+                Whether to use the processed dataset. If False, the data is assumed to be in standard
+                messages format witha `messages` and optional `unmask` field on each sample.
+                When True, we assume that each sample has an `input_ids` and `labels` field containing
+                data tokenized for the model being trained.
+            lr_scheduler (str): Name of the PyTorchlearning rate scheduler to use.
+            warmup_steps (int): Number of warmup steps for the learning rate scheduler.
+            lr_scheduler_kwargs (dict[str, str]): Additional scheduler parameters.
+            checkpoint_at_epoch (bool): Whether to checkpoint at each epoch.
+            save_final_checkpoint (bool): Whether to save final checkpoint once training is complete.
+            epochs (int): Number of epochs to train for.
+            nproc_per_node (int): Number of processes (GPUs) per node for distributed training.
+            nnodes (int): Total number of nodes for distributed training.
+            node_rank (int): Rank of this node (0 to nnodes-1) for distributed training. 
+            rdzv_id (int): Unique job ID for rendezvous in distributed training.
+            rdzv_endpoint (str): Master node endpoint for multi-node training.
+            **kwargs: Additional parameters passed to the backend.
+
+        Returns:
+            None
+        """
+
+        # param validation
+        if not (0.0 <= unfreeze_rank_ratio <= 1.0):
+            raise ValueError(f"unfreeze_rank_ratio must be between 0.0 and 1.0, but got {unfreeze_rank_ratio}")
+        
+
+        required_params = {
+            'model_path': model_path,
+            'data_path': data_path,
+            'batch_size': batch_size,
+            'max_tokens_per_gpu': max_tokens_per_gpu,
+            'max_seq_len': max_seq_len,
+            'learning_rate': learning_rate,
+            'output_dir': output_dir,
+            'unfreeze_rank_ratio': unfreeze_rank_ratio,
+        }
+
+        optional_params = {
+            'target_patterns': target_patterns,
+            
+            # for data processing
+            'use_processed_dataset': use_processed_dataset,
+            'unmask_messages': unmask_messages,
+            
+            # scheduler params
+            'lr_scheduler': lr_scheduler,
+            'lr_scheduler_kwargs': lr_scheduler_kwargs,
+            'warmup_steps': warmup_steps, 
+
+            # checkpointing settings
+            'checkpoint_at_epoch': checkpoint_at_epoch,
+            'save_final_checkpoint': save_final_checkpoint,
+
+            # mini trainer supports a few different modes, but we fix this one for simplicty
+            # another mode can be selected by overriding via kwargs
+            'training_mode': 'epoch',  
+            'epochs': epochs,
+
+            'use_liger': use_liger, 
+            'seed': seed,
+
+            # torchrun params
+            'nproc_per_node': nproc_per_node,
+            'nnodes': nnodes,
+            'node_rank': node_rank,
+            'rdzv_id': rdzv_id,
+            'rdzv_endpoint': rdzv_endpoint,
+        }
+
+        # now do validation now that we've set everything up
+        for required_param in self.get_required_params().keys():
+            if required_param not in required_params:
+                raise ValueError(f"error: required parameter not provided: {required_param}")
+        
+        all_params = dict(
+            **required_params,
+        )
+        all_params.update(optional_params)
+        all_params.update(kwargs)
+        
+        # validate types of all parameters
+        self._validate_param_types(all_params)
+
+        # Apply parameter renaming for backend compatibility
+        renames = {
+            'use_liger': 'use_liger_kernels',
+            'warmup_steps': 'num_warmup_steps',
+            'target_patterns': 'osft_target_patterns',
+            'unfreeze_rank_ratio': 'osft_unfreeze_rank_ratio',
+            'model_path': 'model_name_or_path',
+            'epochs': 'max_epochs',
+        }
+        
+        # Rename parameters before sending to backend
+        renamed_params = {renames.get(k, k): v for k, v in all_params.items()}
+        return self.backend.execute_training(renamed_params)
+        
+    def get_required_params(self) -> dict[str, type]:
+        """Return dictionary of required parameter names and their types."""
+        return {
+            'model_path': str,
+            'data_path': str,
+            'unfreeze_rank_ratio': float,
+            'batch_size': int,
+            'max_tokens_per_gpu': int,
+            'max_seq_len': int,
+            'learning_rate': float,
+            'output_dir': str,
+        }
+
+    def get_optional_params(self) -> dict[str, type]:
+        """Return dictionary of optional parameter names and their types."""
+        return {
+            'target_patterns': list[str],
+            'unmask_messages': bool,
+            'lr_scheduler': str,
+            'lr_scheduler_kwargs': dict[str, str],
+            'warmup_steps': int,
+            'checkpoint_at_epoch': bool,
+            'save_final_checkpoint': bool,
+            'training_mode': str,
+            'max_epochs': int,
+            'use_liger': bool,
+            'seed': int,
+            'nproc_per_node': int,
+            'nnodes': int,
+            'node_rank': int,
+            'rdzv_id': int,
+            'rdzv_endpoint': str,
+            'use_processed_dataset': bool,
+        }
+
+    def _validate_param_types(self, params: dict[str, any]):
+        """Type-check given parameters, handling modern Python typing constructs."""
+        required_param_types = self.get_required_params()
+        optional_param_types = self.get_optional_params()
+        all_param_types = {**required_param_types, **optional_param_types}
+        
+        for param, value in params.items():
+            # use 'any' here to handle the case when the param is not defined by
+            # either optional or required
+            param_type = all_param_types.get(param, any)
+
+            # allow optional params to be None
+            if param in optional_param_types and value is None:
+                continue  # None is allowed for optional params
+                
+            if not self._check_type(value, param_type):
+                err_msg = (
+                    f"error: param '{param}' received unexpected type, "
+                    f"expected '{format_type_name(param_type)}' but got '{format_type_name(type(value))}'"
+                )
+                raise ValueError(err_msg)
+    
+    def _check_type(self, value, expected_type) -> bool:
+        """Check if value matches expected_type, handling modern typing constructs."""
+        # Handle 'any' type (accepts anything)
+        if expected_type is any:
+            return True
+            
+        # Handle basic types that work with isinstance
+        try:
+            if isinstance(expected_type, type):
+                return isinstance(value, expected_type)
+        except TypeError:
+            pass  # Fall through to handle complex types
+        
+        # Handle parameterized generics and unions
+        origin = get_origin(expected_type)
+        args = get_args(expected_type)
+        
+        # Handle Union types (including X | None syntax)
+        if origin is Union:
+            return any(self._check_type(value, arg) for arg in args)
+        
+        # Handle list types
+        if origin is list:
+            if not isinstance(value, list):
+                return False
+            if args and value:  # Check element types if specified and list is not empty
+                element_type = args[0]
+                return all(self._check_type(item, element_type) for item in value)
+            return True
+            
+        # Handle dict types
+        if origin is dict:
+            if not isinstance(value, dict):
+                return False
+            if args and value:  # Check key/value types if specified and dict is not empty
+                key_type, val_type = args[0], args[1]
+                return all(
+                    self._check_type(k, key_type) and self._check_type(v, val_type)
+                    for k, v in value.items()
+                )
+            return True
+        
+        # Fallback for basic isinstance check
+        try:
+            return isinstance(value, expected_type)
+        except TypeError:
+            # If we can't check the type, assume it's valid
+            return True
+            
+    
+
+
+class MiniTrainerOSFTBackend(Backend):
+    """MiniTrainer backend for OSFT algorithm."""
+
+    def execute_training(self, algorithm_params: dict[str, any]) -> any:
+        """
+        Execute OSFT training using MiniTrainer.
+
+        Since this backend doesn't do its own data processing, it delegates that to the instructlab-training
+        backend.
+        
+        
+        """
+        from mini_trainer import run_training, TrainingArgs, TorchrunArgs, TrainingMode
+
+        # get the already-renamed parameters from the algorithm
+        
+        
+        # since mini trainer itself does not process data, we delegate this to
+        # a separate backend, and expect to receive the correct data path
+        training_ready_data_path = self._process_data(algorithm_params)
+
+
+        # Separate parameters into their respective dataclass fields
+        torchrun_args_fields = {f.name for f in fields(TorchrunArgs)}
+        training_args_fields = {f.name for f in fields(TrainingArgs)}
+
+        # adjust arguments to align with the API definition 
+        training_args_pre = {k: v for k, v in algorithm_params.items() if k in training_args_fields and v is not None}
+        training_args_pre['data_path'] = training_ready_data_path  # replaces raw data path with processed
+        training_args_pre['training_mode'] = TrainingMode(training_args_pre['training_mode'])
+        training_args_pre['osft'] = True
+
+        torchrun_args_pre = {k: v for k, v in algorithm_params.items() if k in torchrun_args_fields and v is not None}
+
+        # now we run training
+        return run_training(
+            torch_args=TorchrunArgs(**torchrun_args_pre),
+            train_args=TrainingArgs(**training_args_pre),
+        )
+    
+    def _process_data(self, algorithm_params: dict[str, any]) -> str:
+        """
+        Process the data into a format that can be used for training.
+
+        Returns the path to the processed dataset.
+        """
+        # mini trainer doesn't do its own data processing, so we use the one from
+        # instructlab training
+        from instructlab.training.data_process import process_messages_into_input_ids
+
+        # if we're using the processed dataset, then we don't need to do any data processing
+        if algorithm_params['use_processed_dataset']:
+            return algorithm_params['data_path']
+
+        # otherwise we need to process the data
+        output_dir = algorithm_params['output_dir']
+        data_output_path = os.path.join(output_dir, '_internal_data_processing')
+        os.makedirs(data_output_path, exist_ok=True)
+
+        # if we received unmask then we need to add that
+        processing_data_path = algorithm_params['data_path']
+        unmask_messages = algorithm_params.get('unmask_messages', False)
+        if unmask_messages:
+            ds = datasets.load_dataset(algorithm_params['data_path'], split='train')
+            ds = ds.map(lambda _: { "unmask": True }) 
+            processing_data_path = os.path.join(data_output_path, 'intermediate_data.jsonl')
+            ds.to_json(processing_data_path)
+        
+        # now we process the data
+        process_messages_into_input_ids(
+            data_path=processing_data_path,
+            data_output_path=data_output_path,
+            model_path=algorithm_params['model_name_or_path'],  # use renamed parameter
+            max_seq_len=algorithm_params['max_seq_len'],
+            num_cpu_procs=8,
+        )
+
+        # above function will save to this file, so we pass this to the trainer
+        return os.path.join(data_output_path, 'data.jsonl')
+    
+            
+
+
+
+AlgorithmRegistry.register_algorithm('osft', OSFTAlgorithm)
+AlgorithmRegistry.register_backend('osft', 'mini-trainer', MiniTrainerOSFTBackend)
+
+def osft(
+    model_path: str,
+    data_path: str,
+    output_dir: str,
+    unfreeze_rank_ratio: float,
+    batch_size: int,
+    max_tokens_per_gpu: int,
+    max_seq_len: int,
+    learning_rate: float,
+    backend: str = "mini-trainer",
+    # Optional parameters
+    target_patterns: list[str] | None = None,
+    seed: int | None = None,
+    use_liger: bool | None = None,
+    unmask_messages: bool | None = None,
+    lr_scheduler: str | None = None,
+    warmup_steps: int | None = None,
+    lr_scheduler_kwargs: dict[str, str] | None = None,
+    checkpoint_at_epoch: bool | None = None,
+    save_final_checkpoint: bool | None = None,
+    epochs: int | None = None,
+    # Torchrun parameters for multi-node support
+    nproc_per_node: int | None = None,
+    nnodes: int | None = None,
+    node_rank: int | None = None,
+    rdzv_id: int | None = None,
+    rdzv_endpoint: str | None = None,
+    **kwargs
+) -> any:
+    from . import create_algorithm
+    
+    algorithm = create_algorithm('osft', backend)
+    return algorithm.train(
+        model_path=model_path,
+        data_path=data_path,
+        output_dir=output_dir,
+        unfreeze_rank_ratio=unfreeze_rank_ratio,
+        batch_size=batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+        max_seq_len=max_seq_len,
+        learning_rate=learning_rate,
+        target_patterns=target_patterns,
+        seed=seed,
+        use_liger=use_liger,
+        unmask_messages=unmask_messages,
+        lr_scheduler=lr_scheduler,
+        warmup_steps=warmup_steps,
+        lr_scheduler_kwargs=lr_scheduler_kwargs,
+        checkpoint_at_epoch=checkpoint_at_epoch,
+        save_final_checkpoint=save_final_checkpoint,
+        epochs=epochs,
+        nproc_per_node=nproc_per_node,
+        nnodes=nnodes,
+        node_rank=node_rank,
+        rdzv_id=rdzv_id,
+        rdzv_endpoint=rdzv_endpoint,
+        **kwargs
+    )

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -152,13 +152,28 @@ class SFTAlgorithm(Algorithm):
             'max_batch_len': int,
         }
 
+    def get_optional_params(self) -> Dict[str, Type]:
+        """Return optional parameters for SFT."""
+        return {
+            'max_tokens_per_gpu': int,
+            'data_output_dir': str,
+            'save_samples': int,
+            'warmup_steps': int,
+            'accelerate_full_state_at_epoch': bool,
+            'checkpoint_at_epoch': bool,
+            'nproc_per_node': int,
+            'nnodes': int,
+            'node_rank': int,
+            'rdzv_id': int,
+            'rdzv_endpoint': str,
+        }
+
 
 # Register the algorithm and backend
 AlgorithmRegistry.register_algorithm('sft', SFTAlgorithm)
 AlgorithmRegistry.register_backend('sft', 'instructlab-training', InstructLabTrainingSFTBackend)
 
 
-# Convenience function for backwards compatibility
 def sft(model_path: str, 
         data_path: str, 
         ckpt_output_dir: str,

--- a/src/training_hub/utils.py
+++ b/src/training_hub/utils.py
@@ -1,0 +1,29 @@
+from typing import get_origin, get_args
+import sys
+
+def format_type_name(tp):
+    # Handle None
+    if tp is type(None):
+        return 'None'
+    
+    # Handle basic types
+    if hasattr(tp, '__name__'):
+        return tp.__name__
+    
+    # Handle typing generics
+    origin = get_origin(tp)
+    args = get_args(tp)
+    
+    if origin is not None:
+        origin_name = getattr(origin, '__name__', str(origin))
+        if args:
+            arg_names = [format_type_name(arg) for arg in args]
+            return f"{origin_name}[{', '.join(arg_names)}]"
+        return origin_name
+    
+    # Fallback: clean up the string representation
+    type_str = str(tp)
+    if type_str.startswith("<class '") and type_str.endswith("'>"):
+        return type_str[8:-2]
+    
+    return type_str

--- a/src/training_hub/utils.py
+++ b/src/training_hub/utils.py
@@ -1,5 +1,4 @@
 from typing import get_origin, get_args
-import sys
 
 def format_type_name(tp):
     # Handle None


### PR DESCRIPTION
This PR adds Orthogonal Subspace Fine-Tuning (OSFT) into the training hub. 

This is mostly done but still needs the final components:
- [x] Documentation 
- [x] `pyproject.toml` should have the `mini-trainer` dependency pointing to a valid pypi release

