### PR TITLE
add OSFT notebook for different batch sizes

### DIFF
--- a/examples/notebooks/osft_dataset_scaling_guide.ipynb
+++ b/examples/notebooks/osft_dataset_scaling_guide.ipynb
@@ -1,0 +1,477 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# OSFT Dataset Scaling Guide: Adapting Hyperparameters to Data Size\n",
+        "\n",
+        "This notebook demonstrates how to adapt OSFT (Orthogonal Subspace Fine-Tuning) hyperparameters based on your dataset size. As OSFT is suitable for training on datasets of any scale - from small domain-specific sets to large-scale instruction tuning datasets - understanding how to properly scale your hyperparameters is crucial for optimal performance.\n",
+        "\n",
+        "## Key Principle: Scale Your Batch Size with Your Data\n",
+        "\n",
+        "One of the most important hyperparameters to adjust based on dataset size is the **batch size**. Larger datasets generally benefit from larger batch sizes for several reasons:\n",
+        "\n",
+        "1. **Training Efficiency**: Larger batches better utilize GPU resources with bigger datasets\n",
+        "2. **Gradient Stability**: More samples per update provide more stable gradient estimates\n",
+        "3. **Convergence**: Appropriate batch sizes help the model converge effectively\n",
+        "\n",
+        "**⚠️ Important**: The configurations shown here are **illustrative examples**, not prescriptions. Finding the optimal hyperparameters for your specific use case requires experimentation and iterative refinement.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Why Batch Size Matters at Different Scales\n",
+        "\n",
+        "### Small Datasets (1K samples)\n",
+        "- **Risk**: Large batches might see the entire dataset in just a few steps\n",
+        "- **Solution**: Use smaller batch sizes (e.g., 16) for more gradient updates per epoch\n",
+        "- **Benefit**: Model gets more opportunities to learn from limited data\n",
+        "\n",
+        "### Medium Datasets (10K samples)  \n",
+        "- **Balance**: Need efficiency without overfitting\n",
+        "- **Solution**: Moderate batch sizes (e.g., 128) provide good gradient estimates\n",
+        "- **Benefit**: Efficient training with stable convergence\n",
+        "\n",
+        "### Large Datasets (100K+ samples)\n",
+        "- **Challenge**: Training time becomes a major factor\n",
+        "- **Solution**: Large batch sizes (e.g., 1024) maximize throughput\n",
+        "- **Benefit**: Faster training with stable gradients from diverse samples\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Common Configuration\n",
+        "\n",
+        "First, let's define the parameters that remain constant across different dataset sizes.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Common Configuration:\n",
+            "  Model: meta-llama/Meta-Llama-3.1-8B-Instruct\n",
+            "  OSFT Unfreeze Ratio: 0.3\n",
+            "  Max Sequence Length: 8,192\n",
+            "  Learning Rate: 5e-06\n",
+            "  Training Epochs: 3\n",
+            "  GPUs: 8\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Model configuration - using Llama 3.1 8B Instruct\n",
+        "MODEL_PATH = \"meta-llama/Meta-Llama-3.1-8B-Instruct\"\n",
+        "\n",
+        "# OSFT-specific parameters (constant across dataset sizes)\n",
+        "UNFREEZE_RANK_RATIO = 0.3  # Balanced preservation vs adaptation\n",
+        "MAX_SEQ_LEN = 8192         # Llama 3.1 supports up to 128K, but 8K is practical\n",
+        "LEARNING_RATE = 5e-6       # Standard learning rate for fine-tuning\n",
+        "NUM_EPOCHS = 3             # Adjust based on convergence\n",
+        "\n",
+        "# Hardware constraints (adjust based on your GPU)\n",
+        "MAX_TOKENS_PER_GPU = 10000  # For A100 40GB or similar\n",
+        "\n",
+        "# Distributed training setup (single node, 8 GPUs)\n",
+        "NPROC_PER_NODE = 8\n",
+        "\n",
+        "print(\"Common Configuration:\")\n",
+        "print(f\"  Model: {MODEL_PATH}\")\n",
+        "print(f\"  OSFT Unfreeze Ratio: {UNFREEZE_RANK_RATIO}\")\n",
+        "print(f\"  Max Sequence Length: {MAX_SEQ_LEN:,}\")\n",
+        "print(f\"  Learning Rate: {LEARNING_RATE}\")\n",
+        "print(f\"  Training Epochs: {NUM_EPOCHS}\")\n",
+        "print(f\"  GPUs: {NPROC_PER_NODE}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 1: Small Dataset (1K samples)\n",
+        "\n",
+        "For small, specialized datasets, we use smaller batch sizes to ensure the model sees sufficient gradient updates.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "🔬 Small Dataset Configuration (1K samples):\n",
+            "  Effective Batch Size: 16\n",
+            "  Steps per Epoch: ~62\n",
+            "  Total Training Steps: ~186\n",
+            "  Use Case: Domain-specific terminology or specialized knowledge\n",
+            "\n",
+            "💡 Rationale: Small batch size ensures sufficient gradient updates\n",
+            "   despite limited data, helping the model learn nuanced patterns.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Configuration for 1K sample dataset\n",
+        "small_dataset_config = {\n",
+        "    \"dataset_size\": \"1K samples\",\n",
+        "    \"data_path\": \"/path/to/your/small_dataset_1k_samples.jsonl\",  # Replace with your path\n",
+        "    \"effective_batch_size\": 16,  # Small batch size for more gradient updates\n",
+        "    \"warmup_steps\": 50,          # Quick warmup for small dataset\n",
+        "    \"use_case\": \"Domain-specific terminology or specialized knowledge\"\n",
+        "}\n",
+        "\n",
+        "# Calculate training dynamics\n",
+        "steps_per_epoch_1k = 1000 // small_dataset_config[\"effective_batch_size\"]\n",
+        "total_steps_1k = steps_per_epoch_1k * NUM_EPOCHS\n",
+        "\n",
+        "print(\"🔬 Small Dataset Configuration (1K samples):\")\n",
+        "print(f\"  Effective Batch Size: {small_dataset_config['effective_batch_size']}\")\n",
+        "print(f\"  Steps per Epoch: ~{steps_per_epoch_1k}\")\n",
+        "print(f\"  Total Training Steps: ~{total_steps_1k}\")\n",
+        "print(f\"  Use Case: {small_dataset_config['use_case']}\")\n",
+        "print()\n",
+        "print(\"💡 Rationale: Small batch size ensures sufficient gradient updates\")\n",
+        "print(\"   despite limited data, helping the model learn nuanced patterns.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 2: Medium Dataset (10K samples)\n",
+        "\n",
+        "For medium-sized datasets, we increase the batch size to balance training efficiency with learning effectiveness.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "📊 Medium Dataset Configuration (10K samples):\n",
+            "  Effective Batch Size: 128\n",
+            "  Steps per Epoch: ~78\n",
+            "  Total Training Steps: ~234\n",
+            "  Use Case: Domain adaptation or moderate-scale instruction tuning\n",
+            "\n",
+            "💡 Rationale: Moderate batch size balances training efficiency\n",
+            "   with gradient quality, suitable for most domain adaptation tasks.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Configuration for 10K sample dataset\n",
+        "medium_dataset_config = {\n",
+        "    \"dataset_size\": \"10K samples\",\n",
+        "    \"data_path\": \"/path/to/your/medium_dataset_10k_samples.jsonl\",  # Replace with your path\n",
+        "    \"effective_batch_size\": 128,  # Moderate batch size for efficiency\n",
+        "    \"warmup_steps\": 100,          # Standard warmup\n",
+        "    \"use_case\": \"Domain adaptation or moderate-scale instruction tuning\"\n",
+        "}\n",
+        "\n",
+        "# Calculate training dynamics\n",
+        "steps_per_epoch_10k = 10000 // medium_dataset_config[\"effective_batch_size\"]\n",
+        "total_steps_10k = steps_per_epoch_10k * NUM_EPOCHS\n",
+        "\n",
+        "print(\"📊 Medium Dataset Configuration (10K samples):\")\n",
+        "print(f\"  Effective Batch Size: {medium_dataset_config['effective_batch_size']}\")\n",
+        "print(f\"  Steps per Epoch: ~{steps_per_epoch_10k}\")\n",
+        "print(f\"  Total Training Steps: ~{total_steps_10k}\")\n",
+        "print(f\"  Use Case: {medium_dataset_config['use_case']}\")\n",
+        "print()\n",
+        "print(\"💡 Rationale: Moderate batch size balances training efficiency\")\n",
+        "print(\"   with gradient quality, suitable for most domain adaptation tasks.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Example 3: Large Dataset (100K samples)\n",
+        "\n",
+        "For large-scale datasets, we use larger batch sizes to maximize training efficiency and throughput.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "📈 Large Dataset Configuration (100K samples):\n",
+            "  Effective Batch Size: 1024\n",
+            "  Steps per Epoch: ~97\n",
+            "  Total Training Steps: ~291\n",
+            "  Use Case: Large-scale instruction tuning or comprehensive domain coverage\n",
+            "\n",
+            "💡 Rationale: Large batch size maximizes GPU utilization and\n",
+            "   training throughput while maintaining stable gradients.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Configuration for 100K sample dataset\n",
+        "large_dataset_config = {\n",
+        "    \"dataset_size\": \"100K samples\",\n",
+        "    \"data_path\": \"/path/to/your/large_dataset_100k_samples.jsonl\",  # Replace with your path\n",
+        "    \"effective_batch_size\": 1024,  # Large batch size for efficiency\n",
+        "    \"warmup_steps\": 500,           # Extended warmup for large batch\n",
+        "    \"use_case\": \"Large-scale instruction tuning or comprehensive domain coverage\"\n",
+        "}\n",
+        "\n",
+        "# Calculate training dynamics\n",
+        "steps_per_epoch_100k = 100000 // large_dataset_config[\"effective_batch_size\"]\n",
+        "total_steps_100k = steps_per_epoch_100k * NUM_EPOCHS\n",
+        "\n",
+        "print(\"📈 Large Dataset Configuration (100K samples):\")\n",
+        "print(f\"  Effective Batch Size: {large_dataset_config['effective_batch_size']}\")\n",
+        "print(f\"  Steps per Epoch: ~{steps_per_epoch_100k}\")\n",
+        "print(f\"  Total Training Steps: ~{total_steps_100k}\")\n",
+        "print(f\"  Use Case: {large_dataset_config['use_case']}\")\n",
+        "print()\n",
+        "print(\"💡 Rationale: Large batch size maximizes GPU utilization and\")\n",
+        "print(\"   training throughput while maintaining stable gradients.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Batch Size Scaling Summary\n",
+        "\n",
+        "Here's a visual summary of how batch size scales with dataset size:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "📊 Batch Size Scaling Summary:\n",
+            "============================================================\n",
+            "Dataset Size    Batch Size   Steps/Epoch  Total Steps \n",
+            "============================================================\n",
+            "1K samples      16           62           186         \n",
+            "10K samples     128          78           234         \n",
+            "100K samples    1024         97           291         \n",
+            "============================================================\n",
+            "\n",
+            "📈 Scaling Pattern:\n",
+            "   As dataset size increases 10x → batch size increases ~8x\n",
+            "   This maintains a reasonable number of gradient updates\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(\"📊 Batch Size Scaling Summary:\")\n",
+        "print(\"=\"*60)\n",
+        "print(f\"{'Dataset Size':<15} {'Batch Size':<12} {'Steps/Epoch':<12} {'Total Steps':<12}\")\n",
+        "print(\"=\"*60)\n",
+        "print(f\"{'1K samples':<15} {16:<12} {steps_per_epoch_1k:<12} {total_steps_1k:<12}\")\n",
+        "print(f\"{'10K samples':<15} {128:<12} {steps_per_epoch_10k:<12} {total_steps_10k:<12}\")\n",
+        "print(f\"{'100K samples':<15} {1024:<12} {steps_per_epoch_100k:<12} {total_steps_100k:<12}\")\n",
+        "print(\"=\"*60)\n",
+        "print()\n",
+        "print(\"📈 Scaling Pattern:\")\n",
+        "print(\"   As dataset size increases 10x → batch size increases ~8x\")\n",
+        "print(\"   This maintains a reasonable number of gradient updates\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Other Hyperparameters to Consider\n",
+        "\n",
+        "While batch size is a primary scaling factor, other hyperparameters may also need adjustment:\n",
+        "\n",
+        "### 1. Learning Rate\n",
+        "- **Small datasets**: Consider slightly lower LR (e.g., 1e-5) to avoid overfitting\n",
+        "- **Large datasets**: Can use standard or slightly higher LR (e.g., 2e-5 to 5e-5)\n",
+        "- **With large batches**: May need to scale LR with sqrt(batch_size) or linear scaling\n",
+        "\n",
+        "### 2. Number of Epochs\n",
+        "- **Small datasets**: More epochs (3-5) might be beneficial\n",
+        "- **Large datasets**: Fewer epochs (1-3) often sufficient\n",
+        "- Monitor validation metrics to avoid overfitting\n",
+        "\n",
+        "### 3. Warmup Steps\n",
+        "- Scale with batch size: larger batches often benefit from longer warmup\n",
+        "- Rule of thumb: 5-10% of total training steps\n",
+        "\n",
+        "### 4. OSFT-Specific: unfreeze_rank_ratio\n",
+        "- Generally consistent across dataset sizes (0.25-0.35)\n",
+        "- Depends more on task complexity than dataset size\n",
+        "- May slightly increase for very large, diverse datasets\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Important Considerations\n",
+        "\n",
+        "### ⚠️ These Are Starting Points, Not Rules\n",
+        "\n",
+        "The configurations shown are **illustrative examples** to demonstrate the scaling principle. Your optimal settings will depend on:\n",
+        "\n",
+        "1. **Data Characteristics**:\n",
+        "   - Domain complexity\n",
+        "   - Sample diversity\n",
+        "   - Average sequence length\n",
+        "   - Task difficulty\n",
+        "\n",
+        "2. **Model Factors**:\n",
+        "   - Model size (7B, 13B, 70B, etc.)\n",
+        "   - Pre-training quality\n",
+        "   - Current capabilities\n",
+        "\n",
+        "3. **Hardware Constraints**:\n",
+        "   - GPU memory\n",
+        "   - Number of GPUs\n",
+        "   - Training time budget\n",
+        "\n",
+        "4. **Quality Requirements**:\n",
+        "   - Acceptable performance threshold\n",
+        "   - Preservation vs adaptation balance\n",
+        "   - Downstream task needs\n",
+        "\n",
+        "### 🔬 Experimentation is Key\n",
+        "\n",
+        "Always validate your hyperparameters through:\n",
+        "- Small-scale experiments first\n",
+        "- Monitoring training metrics\n",
+        "- Validation set performance\n",
+        "- Downstream task evaluation\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Practical Experimentation Strategy\n",
+        "\n",
+        "Here's a suggested approach for finding optimal hyperparameters:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "🔬 **Hyperparameter Tuning Strategy:**\n",
+        "\n",
+        "1. **Start with a subset of your data (10-20%)**\n",
+        "2. **Try 3 different batch sizes:**\n",
+        "   - Conservative: `dataset_size / 100`\n",
+        "   - Moderate: `dataset_size / 50`\n",
+        "   - Aggressive: `dataset_size / 25`\n",
+        "\n",
+        "3. **For each batch size, monitor:**\n",
+        "   - Training loss curve\n",
+        "   - Validation performance\n",
+        "   - Training time per epoch\n",
+        "   - GPU memory utilization\n",
+        "\n",
+        "4. **Select the configuration that balances:**\n",
+        "   - Best validation performance\n",
+        "   - Reasonable training time\n",
+        "   - Stable convergence\n",
+        "\n",
+        "5. **Scale to full dataset with chosen parameters**\n",
+        "\n",
+        "💡 *Pro tip: Create a simple grid search script to automate this process!*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Conclusion\n",
+        "\n",
+        "OSFT's ability to handle datasets of any scale makes it a versatile replacement for traditional LAB multiphase approaches. The key insight is that **batch size should scale with dataset size** to maintain training efficiency and model quality.\n",
+        "\n",
+        "### Key Takeaways:\n",
+        "\n",
+        "1. **Small datasets (1K)**: Use small batch sizes (16-32) for sufficient gradient updates\n",
+        "2. **Medium datasets (10K)**: Use moderate batch sizes (128-256) for balanced training\n",
+        "3. **Large datasets (100K+)**: Use large batch sizes (512-2048) for efficiency\n",
+        "\n",
+        "### Remember:\n",
+        "\n",
+        "- These are **starting points**, not prescriptions\n",
+        "- **Experimentation** is essential for finding optimal settings\n",
+        "- **Monitor metrics** to guide your hyperparameter choices\n",
+        "- **Document what works** for future reference\n",
+        "\n",
+        "### Next Steps:\n",
+        "\n",
+        "1. Prepare your dataset in the required JSONL format\n",
+        "2. Start with the suggested batch size for your data scale\n",
+        "3. Run initial experiments with a data subset\n",
+        "4. Iterate and refine based on results\n",
+        "5. Scale to full training once parameters are optimized\n",
+        "\n",
+        "Happy training with OSFT! 🚀\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Note on `effective_batch_size` vs `max_tokens_per_gpu`\n",
+        "\n",
+        "- `effective_batch_size`: controls how many samples are aggregated per optimization step (including any gradient accumulation). This directly impacts the number of updates per epoch and training dynamics.\n",
+        "- `max_tokens_per_gpu`: a hardware-capacity setting that limits how many tokens are placed on a single GPU at once to avoid OOM. It constrains per-step memory usage but does not change the `effective_batch_size`.\n",
+        "\n",
+        "Put simply: adjusting `max_tokens_per_gpu` helps you fit training into memory; it does not increase or decrease the `effective_batch_size`. If you need a larger `effective_batch_size`, increase the batch size and/or use gradient accumulation; if you hit memory limits, reduce `max_tokens_per_gpu`, the per-device micro-batch, or sequence length.\n",
+        "\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.8"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a notebook which showcases how the batch size is a function of the dataset size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Jupyter notebook "OSFT Dataset Scaling Guide" in examples/notebooks.
  * Explains batch-size scaling for small (1K), medium (10K), and large (100K+) datasets with a common configuration and dataset-specific examples.
  * Computes steps-per-epoch and total steps; includes example training invocations and command-line snippets.
  * Provides a summary table, hyperparameter tuning and experimentation strategies, and key takeaways.
  * Uses illustrative paths/values only; no changes to code or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->