### PR TITLE
Adding min dependencies for Granite 4 / Mamba support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "instructlab-training>=0.12.0",
     "rhai-innovation-mini-trainer>=0.2.0",
     "torch>=2.6.0",
-    "transformers>=4.55.0",
+    "transformers>=4.57.0",
     "numba>=0.50",
     "datasets>=4.0.0",
     "numpy>=1.26.4,<2.3",
@@ -59,6 +59,7 @@ cuda = [
     "kernels>=0.9.0",
     "bitsandbytes>=0.47.0",
     "liger-kernel>=0.5.10",
+    "mamba-ssm[causal-conv1d]>=2.2.5",
 ]
 
 dev = [


### PR DESCRIPTION
Updating `transformers` minimum version to `4.57.0` for Granite 4 support, as well as including `mamba-ssm[causal-conv1d]>=2.2.5` for efficient Mamba model support (Granite 4 included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CUDA acceleration via the mamba-ssm package (causal-conv1d), enabling faster inference and training on supported GPUs. Users can opt in by installing the CUDA extras.

* **Chores**
  * Updated the Transformers dependency to >=4.57.0 to improve compatibility, stability, and access to newer model features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->