### PR TITLE
Update backend implementation dep versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "setuptools>=80.0",
     "packaging>=24.2",
     "wheel>=0.43",
-    "instructlab-training>=0.12.0",
-    "rhai-innovation-mini-trainer>=0.2.0",
+    "instructlab-training>=0.12.1",
+    "rhai-innovation-mini-trainer>=0.3.0",
     "torch>=2.6.0",
     "numba>=0.62.0",
     "transformers>=4.57.0",
@@ -52,8 +52,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 cuda = [
-    "instructlab-training[cuda]>=0.12.0",
-    "rhai-innovation-mini-trainer[cuda]>=0.2.0",
+    "instructlab-training[cuda]>=0.12.1",
+    "rhai-innovation-mini-trainer[cuda]>=0.3.0",
     "flash-attn>=2.8",
     "einops>=0.8",
     "kernels>=0.9.0",


### PR DESCRIPTION
Updating to `instructlab-training>=0.12.1` and `rhai-innovation-mini-trainer>=0.3.0` for compatibility with expanded torchrun datatypes and more accurate memory estimates given OSFT improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated third-party libraries to the latest versions across core and CUDA configurations.
  * Improves overall compatibility and stability with current environments.
  * No changes to features or user workflows are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->