### PR TITLE
refactor: make SFT/LoRA backend deps optional

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,12 +18,12 @@
 
 ## Support Matrix
 
-| Algorithm | InstructLab-Training | RHAI Innovation Mini-Trainer | PEFT | Unsloth | VERL | Status |
+| Algorithm | InstructLab-Training | RHAI Innovation Mini-Trainer | PEFT | Unsloth | verl | Status |
 |-----------|----------------------|------------------------------|------|---------|------|--------|
 | **Supervised Fine-tuning (SFT)** | ✅ | - | - | - | - | Implemented |
 | Continual Learning (OSFT) | 🔄 | ✅ | 🔄 | - | - | Implemented |
 | **Low-Rank Adaptation (LoRA) + SFT** | - | - | - | ✅ | - | Implemented |
-| **LoRA + GRPO (Agentic RLVR)** | - | - | - | ✅ | ✅ | Implemented |
+| **LoRA + GRPO (Adapter-Based RLVR)** | - | - | - | ✅ | ✅ | Implemented |
 | Direct Preference Optimization (DPO) | - | - | - | - | 🔄 | Planned |
 
 **Legend:**
@@ -106,11 +106,11 @@ result = lora_sft(
 ```
 
 
-### [LoRA + GRPO (Agentic RLVR)](./algorithms/lora_grpo)
+### [LoRA + GRPO (Adapter-Based RLVR)](./algorithms/lora_grpo)
 
 Train LoRA adapters on tool-calling agents using Group Relative Policy Optimization with reinforcement learning from verifiable rewards. Features:
 - Single-turn and multi-turn tool-call verification with automatic per-turn decomposition
-- Two backends: ART (single-GPU, fast iteration) and verl (multi-GPU, scales to 70B+)
+- Two backends: OpenPipe ART + Unsloth GRPO (single-GPU, fast iteration) and verl (multi-GPU, scales to 70B+)
 - Built-in reward functions for tool-call correctness, or bring your own
 - Zero API cost training using ground-truth trace decomposition
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,8 @@
 | **Supervised Fine-tuning (SFT)** | ✅ | - | - | - | - | Implemented |
 | Continual Learning (OSFT) | 🔄 | ✅ | 🔄 | - | - | Implemented |
 | **Low-Rank Adaptation (LoRA) + SFT** | - | - | - | ✅ | - | Implemented |
+| **LoRA + GRPO (Agentic RLVR)** | - | - | - | ✅ | ✅ | Implemented |
 | Direct Preference Optimization (DPO) | - | - | - | - | 🔄 | Planned |
-| Group Relative Policy Optimization (GRPO) | - | - | - | - | 🔄 | Planned |
 
 **Legend:**
 - ✅ Implemented and tested
@@ -106,6 +106,38 @@ result = lora_sft(
 ```
 
 
+### [LoRA + GRPO (Agentic RLVR)](./algorithms/lora_grpo)
+
+Train LoRA adapters on tool-calling agents using Group Relative Policy Optimization with reinforcement learning from verifiable rewards. Features:
+- Single-turn and multi-turn tool-call verification with automatic per-turn decomposition
+- Two backends: ART (single-GPU, fast iteration) and verl (multi-GPU, scales to 70B+)
+- Built-in reward functions for tool-call correctness, or bring your own
+- Zero API cost training using ground-truth trace decomposition
+
+```python
+from training_hub import lora_grpo
+
+# Single GPU (ART backend)
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./grpo_output",
+    backend="art",
+    lora_r=32,
+    lora_alpha=64,
+    num_iterations=15,
+)
+
+# Multi GPU (verl backend)
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./grpo_output",
+    backend="verl",
+    n_gpus=4,
+)
+```
+
 ## Installation
 
 ### Basic Installation
@@ -135,6 +167,12 @@ pip install -e .[lora]
 ```
 
 **Note:** The LoRA extras include Unsloth optimizations and PyTorch-optimized xformers for better performance and compatibility.
+
+### GRPO Support
+For LoRA + GRPO training (both ART and verl backends):
+```bash
+pip install training-hub[grpo,lora]
+```
 
 ### CUDA Support
 For GPU training with CUDA support:

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,17 +142,23 @@ result = lora_grpo(
 
 ### Basic Installation
 
-This installs the base package, but doesn't install the CUDA-related dependencies which are required for GPU training.
+This installs the base package, but doesn't install SFT/OSFT/LoRA backends, GRPO runtime dependencies, or CUDA-related dependencies.
 
 ```bash
 pip install training-hub
+```
+
+### SFT / OSFT Support
+For SFT and OSFT training (requires `instructlab-training` and `rhai-innovation-mini-trainer`):
+```bash
+pip install training-hub[lab]
 ```
 
 ### Development Installation
 ```bash
 git clone https://github.com/Red-Hat-AI-Innovation-Team/training_hub
 cd training_hub
-pip install -e .
+pip install -e .[lab]
 ```
 
 **For developers:** See the [Development Guide](./DEVELOPING.md) for detailed instructions on setting up your development environment, running local documentation, and contributing to Training Hub.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,6 +12,7 @@
   * [SFT - Supervised Fine-Tuning](/algorithms/sft)
   * [OSFT - Orthogonal Subspace Fine-Tuning](/algorithms/osft)
   * [LoRA - Low-Rank Adaptation](/algorithms/lora)
+  * [LoRA + GRPO - Agentic RLVR](/algorithms/lora_grpo)
 
 * API Reference
   * [API Overview](/api/)
@@ -19,6 +20,7 @@
     * [sft()](/api/functions/sft)
     * [osft()](/api/functions/osft)
     * [lora_sft()](/api/functions/lora_sft)
+    * [lora_grpo()](/api/functions/lora_grpo)
     * [create_algorithm()](/api/functions/create-algorithm)
   * Classes
     * [Algorithm](/api/classes/Algorithm)
@@ -26,6 +28,7 @@
     * [SFTAlgorithm](/api/classes/SFTAlgorithm)
     * [OSFTAlgorithm](/api/classes/OSFTAlgorithm)
     * [LoRASFTAlgorithm](/api/classes/LoRASFTAlgorithm)
+    * [LoRAGRPOAlgorithm](/api/classes/LoRAGRPOAlgorithm)
     * [PEFTExtender](/api/classes/PEFTExtender)
     * [LoRAPEFTExtender](/api/classes/LoRAPEFTExtender)
     * [AlgorithmRegistry](/api/classes/AlgorithmRegistry)
@@ -34,6 +37,8 @@
     * [InstructLab Training](/api/backends/instructlab-training)
     * [Mini-Trainer](/api/backends/mini-trainer)
     * [Unsloth](/api/backends/unsloth)
+    * [ART (GRPO)](/api/backends/art-grpo)
+    * [verl (GRPO)](/api/backends/verl)
   * [Data Formats](/api/data-formats)
 
 * Guides

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,7 +12,7 @@
   * [SFT - Supervised Fine-Tuning](/algorithms/sft)
   * [OSFT - Orthogonal Subspace Fine-Tuning](/algorithms/osft)
   * [LoRA - Low-Rank Adaptation](/algorithms/lora)
-  * [LoRA + GRPO - Agentic RLVR](/algorithms/lora_grpo)
+  * [LoRA + GRPO - Adapter RLVR](/algorithms/lora_grpo)
 
 * API Reference
   * [API Overview](/api/)

--- a/docs/algorithms/lora_grpo.md
+++ b/docs/algorithms/lora_grpo.md
@@ -16,14 +16,14 @@ Both backends support single-turn and multi-turn tool-call data. Multi-turn trac
 
 **Use when you want to:**
 - Improve a model's tool-calling accuracy without expensive API-based training
-- Train on ground-truth tool-call traces from stronger models (distillation)
+- Train on ground-truth tool-call or verifiable traces from stronger models (distillation)
 - Scale RL training to larger models across multiple GPUs
 - Fine-tune agents for specific tool-calling domains (retail, support, etc.)
 
 **Works best when:**
-- You have ground-truth tool-call traces (from GPT-4, Claude, etc.)
+- You have ground-truth tool-call or verifiable traces
 - The task involves structured tool/function calling with verifiable outputs
-- You want to train LoRA adapters (not full fine-tuning) for efficiency
+- You want to train LoRA adapters (not full fine-tuning) for efficiency or agentic design
 - You need fast iteration ($0 API cost, no user simulator required)
 
 > **Note:** For supervised fine-tuning without RL, see [LoRA + SFT](/algorithms/lora).

--- a/docs/algorithms/lora_grpo.md
+++ b/docs/algorithms/lora_grpo.md
@@ -1,0 +1,189 @@
+# LoRA + GRPO (Agentic RLVR)
+
+> **Conceptual Overview** - For complete API reference, see [`lora_grpo()` Function Reference](/api/functions/lora_grpo)
+
+## What is LoRA + GRPO?
+
+LoRA + GRPO trains LoRA adapters on tool-calling agents using Group Relative Policy Optimization (GRPO) with reinforcement learning from verifiable rewards (RLVR). Instead of supervised fine-tuning on demonstrations, the model learns by generating tool calls and receiving reward signals based on correctness.
+
+Training Hub provides two backends for this algorithm:
+- **ART** (`backend="art"`) — Single-GPU training using OpenPipe's ART framework with co-located vLLM + Unsloth
+- **verl** (`backend="verl"`) — Multi-GPU distributed training using verl with FSDP + vLLM via Ray
+
+Both backends support single-turn and multi-turn tool-call data. Multi-turn traces are automatically decomposed into per-turn training samples, where each sample contains the ground-truth conversation prefix and the expected tool call at that turn.
+
+## When to Use LoRA + GRPO
+
+**Use when you want to:**
+- Improve a model's tool-calling accuracy without expensive API-based training
+- Train on ground-truth tool-call traces from stronger models (distillation)
+- Scale RL training to larger models across multiple GPUs
+- Fine-tune agents for specific tool-calling domains (retail, support, etc.)
+
+**Works best when:**
+- You have ground-truth tool-call traces (from GPT-4, Claude, etc.)
+- The task involves structured tool/function calling with verifiable outputs
+- You want to train LoRA adapters (not full fine-tuning) for efficiency
+- You need fast iteration ($0 API cost, no user simulator required)
+
+> **Note:** For supervised fine-tuning without RL, see [LoRA + SFT](/algorithms/lora).
+
+## Quick Start
+
+```python
+from training_hub import lora_grpo
+
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./grpo_output",
+    num_iterations=15,
+    group_size=8,
+    lora_r=32,
+    lora_alpha=64,
+)
+```
+
+### Data Format
+
+The data should be a JSONL file where each line is a multi-turn conversation trace:
+
+```json
+{
+  "messages": "[{\"role\": \"system\", ...}, {\"role\": \"user\", ...}, {\"role\": \"assistant\", \"tool_calls\": [...], ...}, {\"role\": \"tool\", ...}, ...]",
+  "tools": [{"type": "function", "function": {"name": "...", "parameters": {...}}}],
+  "question": "User's initial query"
+}
+```
+
+Single-turn data is also supported with `{question, tools, target_tool_name, target_arguments, system_prompt}` fields.
+
+Multi-turn traces are automatically decomposed: a conversation with N tool calls becomes N independent training samples, each with the ground-truth prefix as context.
+
+## Backends
+
+### ART Backend (Single GPU)
+
+Best for fast iteration with small models (4B-8B) on a single GPU.
+
+```python
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    backend="art",
+    num_iterations=15,
+    tasks_per_iteration=100,
+    group_size=8,
+    lora_r=32,
+    lora_alpha=64,
+    learning_rate=1e-5,
+)
+```
+
+ART uses co-located vLLM + Unsloth on the same GPU with time-sharing: vLLM generates rollouts, then sleeps while Unsloth trains the LoRA adapter, then wakes for the next rollout.
+
+### verl Backend (Multi GPU)
+
+Best for scaling to larger models and production training across multiple GPUs.
+
+```python
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    backend="verl",
+    n_gpus=4,
+    num_iterations=3,
+    group_size=4,
+    lora_r=32,
+    lora_alpha=64,
+    learning_rate=1e-5,
+)
+```
+
+verl uses FSDP for distributed LoRA training and vLLM for rollout generation, orchestrated by Ray. The model is sharded across GPUs during training and weights are synced to vLLM between iterations.
+
+## Key Concepts
+
+### GRPO (Group Relative Policy Optimization)
+
+GRPO generates multiple rollouts (controlled by `group_size`) for each training sample and computes advantages relative to the group. This eliminates the need for a separate critic/value model (unlike PPO), reducing memory requirements.
+
+### Per-Turn Decomposition
+
+Multi-turn tool-call traces are decomposed into independent per-turn samples. A conversation with 5 tool calls becomes 5 training samples:
+
+1. `[system, user] → tool_call_1` (no prior context)
+2. `[system, user, gt_assistant_1, gt_tool_result_1] → tool_call_2`
+3. `[system, user, gt_assistant_1, gt_tool_result_1, gt_assistant_2, gt_tool_result_2] → tool_call_3`
+4. ...and so on
+
+Each sample is scored independently using `tool_call_reward` (1.0 = correct name + args, 0.5 = correct name, 0.0 = wrong).
+
+### Custom Reward Functions
+
+You can provide your own reward function:
+
+```python
+def my_reward(response, expected_name, expected_args):
+    # Your scoring logic
+    return 1.0  # or 0.5, 0.0, etc.
+
+result = lora_grpo(
+    ...,
+    reward_fn=my_reward,
+)
+```
+
+For fully custom rollout logic (e.g., live environment interaction), provide a `rollout_fn`:
+
+```python
+async def my_rollout(model, task):
+    client = model.openai_client()
+    # ... your agentic loop ...
+    trajectory = art.Trajectory(messages_and_choices=[...])
+    trajectory.reward = compute_reward(...)
+    return trajectory
+
+result = lora_grpo(
+    ...,
+    rollout_fn=my_rollout,
+    tasks=my_task_list,
+)
+```
+
+> **Note:** Custom `rollout_fn` must be a top-level function (not a lambda or closure) due to subprocess pickling.
+
+## Performance Tips
+
+1. **Start with a small test** — Use `num_iterations=2, tasks_per_iteration=10` to verify the pipeline works before long runs
+2. **Match LoRA rank to model size** — r=16-32 for 4B models, r=64-128 for larger or MoE models
+3. **Lower learning rate for stability** — 5e-6 to 1e-5 works well; higher rates cause oscillation
+4. **Strip thinking blocks** — For Qwen3 models, ensure `<think>` blocks are stripped from conversation history during evaluation
+5. **Watch for overfitting** — With small datasets (<2000 samples), training reward can climb while eval performance degrades. Use early stopping or fewer epochs.
+
+## Installation
+
+```bash
+pip install training-hub[grpo,lora]
+```
+
+This installs both ART and verl backends along with LoRA dependencies (Unsloth, TRL, vLLM).
+
+## Next Steps
+
+**Learn more about LoRA + GRPO:**
+- [`lora_grpo()` Function Reference](/api/functions/lora_grpo)
+- [`LoRAGRPOAlgorithm` Class Reference](/api/classes/LoRAGRPOAlgorithm)
+- [ART Backend](/api/backends/art-grpo)
+- [verl Backend](/api/backends/verl)
+
+**Related topics:**
+- [LoRA + SFT](/algorithms/lora) — Supervised fine-tuning with LoRA (non-RL)
+- [Data Preparation](/guides/data-preparation)
+- [Extending the Framework](/guides/extending-framework)
+
+**Working examples:**
+- [Examples Directory](/examples/)
+- [LoRA GRPO Example Script](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/blob/main/examples/scripts/lora_grpo_example.py)

--- a/docs/algorithms/lora_grpo.md
+++ b/docs/algorithms/lora_grpo.md
@@ -1,4 +1,4 @@
-# LoRA + GRPO (Agentic RLVR)
+# LoRA + GRPO (Adapter-Based RLVR)
 
 > **Conceptual Overview** - For complete API reference, see [`lora_grpo()` Function Reference](/api/functions/lora_grpo)
 
@@ -7,8 +7,8 @@
 LoRA + GRPO trains LoRA adapters on tool-calling agents using Group Relative Policy Optimization (GRPO) with reinforcement learning from verifiable rewards (RLVR). Instead of supervised fine-tuning on demonstrations, the model learns by generating tool calls and receiving reward signals based on correctness.
 
 Training Hub provides two backends for this algorithm:
-- **ART** (`backend="art"`) — Single-GPU training using OpenPipe's ART framework with co-located vLLM + Unsloth
-- **verl** (`backend="verl"`) — Multi-GPU distributed training using verl with FSDP + vLLM via Ray
+- **ART** (`backend="art"`) — Single-GPU training using [OpenPipe ART](https://github.com/OpenPipe/ART) with co-located vLLM + [Unsloth](https://github.com/unslothai/unsloth) GRPO
+- **verl** (`backend="verl"`) — Multi-GPU distributed training using [verl](https://github.com/volcengine/verl) with FSDP + vLLM via Ray
 
 Both backends support single-turn and multi-turn tool-call data. Multi-turn traces are automatically decomposed into per-turn training samples, where each sample contains the ground-truth conversation prefix and the expected tool call at that turn.
 
@@ -46,19 +46,48 @@ result = lora_grpo(
 
 ### Data Format
 
-The data should be a JSONL file where each line is a multi-turn conversation trace:
+Two data formats are supported: **multi-turn traces** (recommended) and **pre-processed single-turn samples**.
+
+#### Multi-Turn Traces (Recommended)
+
+A JSONL file where each line is a full tool-calling conversation. Multi-turn traces are automatically decomposed into per-turn training samples (see [Per-Turn Decomposition](#per-turn-decomposition) below).
 
 ```json
 {
-  "messages": "[{\"role\": \"system\", ...}, {\"role\": \"user\", ...}, {\"role\": \"assistant\", \"tool_calls\": [...], ...}, {\"role\": \"tool\", ...}, ...]",
-  "tools": [{"type": "function", "function": {"name": "...", "parameters": {...}}}],
-  "question": "User's initial query"
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Check weather alerts for California"},
+    {"role": "assistant", "content": null, "tool_calls": [
+      {"id": "call_abc123", "type": "function", "function": {"name": "get_alerts", "arguments": "{\"state\": \"CA\"}"}}
+    ]},
+    {"role": "tool", "tool_call_id": "call_abc123", "name": "get_alerts", "content": "{\"alerts\": [...]}"},
+    {"role": "assistant", "content": "Here are the current weather alerts..."}
+  ],
+  "question": "Check weather alerts for California"
 }
 ```
 
-Single-turn data is also supported with `{question, tools, target_tool_name, target_arguments, system_prompt}` fields.
+Tool definitions can be provided either as a top-level `tools` field or embedded in the system message (e.g., using Qwen's `<|im_system|>tool_declare<|im_middle|>...<|im_end|>` format — both are auto-detected).
 
-Multi-turn traces are automatically decomposed: a conversation with N tool calls becomes N independent training samples, each with the ground-truth prefix as context.
+Messages must use the **modern `tool_calls`/`tool` format** (not the deprecated `function_call`/`function` format). The `messages` field can be either a JSON array or a JSON-encoded string.
+
+#### Pre-Processed Single-Turn Samples
+
+Alternatively, provide pre-processed samples where each line is one training example:
+
+```json
+{
+  "question": "Check weather alerts for California",
+  "tools": [{"type": "function", "function": {"name": "get_alerts", "parameters": {...}}}],
+  "target_tool_name": "get_alerts",
+  "target_arguments": {"state": "CA"},
+  "system_prompt": "You are a helpful assistant."
+}
+```
+
+#### HuggingFace Datasets
+
+HuggingFace datasets like `Agent-Ark/Toucan-1.5M` are also supported. Specify the dataset ID as `data_path` and the config as `data_config` (default: `"Qwen3"`).
 
 ## Backends
 
@@ -81,7 +110,7 @@ result = lora_grpo(
 )
 ```
 
-ART uses co-located vLLM + Unsloth on the same GPU with time-sharing: vLLM generates rollouts, then sleeps while Unsloth trains the LoRA adapter, then wakes for the next rollout.
+ART uses co-located vLLM + Unsloth GRPO on the same GPU with time-sharing: vLLM generates rollouts, then sleeps while Unsloth trains the LoRA adapter using its optimized GRPO implementation, then wakes for the next rollout.
 
 ### verl Backend (Multi GPU)
 
@@ -169,7 +198,7 @@ result = lora_grpo(
 pip install training-hub[grpo,lora]
 ```
 
-This installs both ART and verl backends along with LoRA dependencies (Unsloth, TRL, vLLM).
+This installs both ART and verl backends along with LoRA dependencies ([Unsloth](https://github.com/unslothai/unsloth), TRL, vLLM).
 
 ## Next Steps
 

--- a/docs/algorithms/lora_grpo.md
+++ b/docs/algorithms/lora_grpo.md
@@ -180,6 +180,7 @@ This installs both ART and verl backends along with LoRA dependencies (Unsloth, 
 - [verl Backend](/api/backends/verl)
 
 **Related topics:**
+- [Experiment Tracking & Logging](/guides/logging) — W&B and MLflow integration
 - [LoRA + SFT](/algorithms/lora) — Supervised fine-tuning with LoRA (non-RL)
 - [Data Preparation](/guides/data-preparation)
 - [Extending the Framework](/guides/extending-framework)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -13,6 +13,7 @@ Training Hub provides convenient top-level functions for common training tasks:
 | [`sft()`](/api/functions/sft) | Supervised fine-tuning of language models | [Details](/api/functions/sft) |
 | [`osft()`](/api/functions/osft) | Orthogonal subspace fine-tuning for continual learning | [Details](/api/functions/osft) |
 | [`lora_sft()`](/api/functions/lora_sft) | Parameter-efficient fine-tuning with LoRA | [Details](/api/functions/lora_sft) |
+| [`lora_grpo()`](/api/functions/lora_grpo) | LoRA + GRPO for tool-calling agents (RLVR) | [Details](/api/functions/lora_grpo) |
 | [`create_algorithm()`](/api/functions/create-algorithm) | Factory function to create algorithm instances | [Details](/api/functions/create-algorithm) |
 
 ### Classes
@@ -26,6 +27,7 @@ Training Hub uses an object-oriented architecture with algorithms and pluggable 
 | [`SFTAlgorithm`](/api/classes/SFTAlgorithm) | Supervised fine-tuning algorithm implementation | [Details](/api/classes/SFTAlgorithm) |
 | [`OSFTAlgorithm`](/api/classes/OSFTAlgorithm) | OSFT algorithm implementation | [Details](/api/classes/OSFTAlgorithm) |
 | [`LoRASFTAlgorithm`](/api/classes/LoRASFTAlgorithm) | LoRA fine-tuning algorithm implementation | [Details](/api/classes/LoRASFTAlgorithm) |
+| [`LoRAGRPOAlgorithm`](/api/classes/LoRAGRPOAlgorithm) | LoRA + GRPO for tool-calling agents | [Details](/api/classes/LoRAGRPOAlgorithm) |
 | [`PEFTExtender`](/api/classes/PEFTExtender) | Base class for parameter-efficient fine-tuning extensions | [Details](/api/classes/PEFTExtender) |
 | [`LoRAPEFTExtender`](/api/classes/LoRAPEFTExtender) | LoRA-specific PEFT extension implementation | [Details](/api/classes/LoRAPEFTExtender) |
 | [`AlgorithmRegistry`](/api/classes/AlgorithmRegistry) | Central registry for algorithms and backends | [Details](/api/classes/AlgorithmRegistry) |
@@ -39,6 +41,8 @@ Backend implementations that power the algorithms:
 | [`InstructLabTrainingSFTBackend`](/api/backends/instructlab-training) | SFT | [Details](/api/backends/instructlab-training) |
 | [`MiniTrainerOSFTBackend`](/api/backends/mini-trainer) | OSFT | [Details](/api/backends/mini-trainer) |
 | [`UnslothLoRABackend`](/api/backends/unsloth) | LoRA | [Details](/api/backends/unsloth) |
+| [`ARTLoRAGRPOBackend`](/api/backends/art-grpo) | LoRA + GRPO (single-GPU) | [Details](/api/backends/art-grpo) |
+| [`VeRLLoRAGRPOBackend`](/api/backends/verl) | LoRA + GRPO (multi-GPU) | [Details](/api/backends/verl) |
 
 For an overview of the backend system, see [Backends Overview](/api/backends/).
 

--- a/docs/api/backends/README.md
+++ b/docs/api/backends/README.md
@@ -68,6 +68,42 @@ Features:
 
 **Learn more:** [Unsloth Backend Documentation](/api/backends/unsloth)
 
+### ART (OpenPipe)
+
+**Class:** [`ARTLoRAGRPOBackend`](/api/backends/art-grpo)
+
+**Algorithm Support:** LoRA + GRPO
+
+**Package:** `openpipe-art`
+
+**Use Case:** Single-GPU LoRA + GRPO training for tool-calling agents
+
+Features:
+- Co-located vLLM inference + Unsloth LoRA training on a single GPU
+- Structured tool-call generation via OpenAI-compatible API
+- Built-in tool-call reward verification
+- Fast iteration for small models (4B-8B)
+
+**Learn more:** [ART Backend Documentation](/api/backends/art-grpo)
+
+### verl (Volcano Engine RL)
+
+**Class:** [`VeRLLoRAGRPOBackend`](/api/backends/verl)
+
+**Algorithm Support:** LoRA + GRPO
+
+**Package:** `verl`
+
+**Use Case:** Multi-GPU distributed LoRA + GRPO training, scales to 70B+ models
+
+Features:
+- FSDP for distributed LoRA training across multiple GPUs
+- vLLM rollout generation with co-located weight sharing
+- Ray-based orchestration for scalable training
+- Supports GRPO, Dr.GRPO, DAPO and other RL algorithms
+
+**Learn more:** [verl Backend Documentation](/api/backends/verl)
+
 ## Backend Architecture
 
 ```mermaid

--- a/docs/api/backends/art-grpo.md
+++ b/docs/api/backends/art-grpo.md
@@ -1,6 +1,6 @@
 # ART Backend (GRPO)
 
-> Single-GPU LoRA + GRPO training using OpenPipe's ART framework.
+> Single-GPU LoRA + GRPO training using OpenPipe ART with Unsloth GRPO.
 
 ## Overview
 
@@ -12,11 +12,11 @@
 
 **Status:** Implemented
 
-The ART backend runs LoRA + GRPO training on a single GPU using co-located vLLM inference and Unsloth LoRA training with time-sharing. During rollout generation, vLLM serves the model with the current LoRA adapter. During training, vLLM sleeps and Unsloth trains the adapter. This cycle repeats each iteration.
+The ART backend runs LoRA + GRPO training on a single GPU using [OpenPipe ART](https://github.com/OpenPipe/ART) (Agent Reinforcement Trainer) with co-located vLLM inference and [Unsloth](https://github.com/unslothai/unsloth) GRPO training via time-sharing. During rollout generation, vLLM serves the model with the current LoRA adapter. During training, vLLM sleeps while Unsloth trains the LoRA adapter using its optimized GRPO implementation. This cycle repeats each iteration.
 
 ## Features
 
-- Co-located vLLM + Unsloth on a single GPU
+- Co-located vLLM + Unsloth GRPO on a single GPU
 - Structured tool-call generation via OpenAI-compatible API
 - Built-in tool-call reward verification (`tool_call_reward`)
 - Automatic checkpoint saving and resume

--- a/docs/api/backends/art-grpo.md
+++ b/docs/api/backends/art-grpo.md
@@ -1,0 +1,75 @@
+# ART Backend (GRPO)
+
+> Single-GPU LoRA + GRPO training using OpenPipe's ART framework.
+
+## Overview
+
+**Class:** `ARTLoRAGRPOBackend`
+
+**Algorithm Support:** LoRA + GRPO
+
+**Package:** `openpipe-art`
+
+**Status:** Implemented
+
+The ART backend runs LoRA + GRPO training on a single GPU using co-located vLLM inference and Unsloth LoRA training with time-sharing. During rollout generation, vLLM serves the model with the current LoRA adapter. During training, vLLM sleeps and Unsloth trains the adapter. This cycle repeats each iteration.
+
+## Features
+
+- Co-located vLLM + Unsloth on a single GPU
+- Structured tool-call generation via OpenAI-compatible API
+- Built-in tool-call reward verification (`tool_call_reward`)
+- Automatic checkpoint saving and resume
+- Support for custom rollout functions and reward functions
+
+## Usage
+
+### Via Convenience Function
+
+```python
+from training_hub import lora_grpo
+
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    backend="art",
+    lora_r=32,
+    lora_alpha=64,
+    num_iterations=15,
+)
+```
+
+### Via Class-Based API
+
+```python
+from training_hub import create_algorithm
+
+algo = create_algorithm("lora_grpo", "art")
+result = algo.train(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+)
+```
+
+## Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `gpu_memory_utilization` | `float` | `0.45` | GPU memory fraction for vLLM |
+| `art_model_name` | `str` | auto | Model name for ART registration |
+| `art_project` | `str` | `"training-hub-grpo"` | ART project name |
+| `concurrency` | `int` | `32` | Max concurrent rollouts |
+
+## Limitations
+
+- Single GPU only (no multi-GPU support)
+- Best suited for models up to ~8B parameters
+- Requires `openpipe-art` package
+
+## See Also
+
+- [LoRA + GRPO Algorithm Guide](/algorithms/lora_grpo)
+- [verl Backend](/api/backends/verl) — Multi-GPU alternative
+- [`lora_grpo()` Function Reference](/api/functions/lora_grpo)

--- a/docs/api/backends/art-grpo.md
+++ b/docs/api/backends/art-grpo.md
@@ -21,6 +21,7 @@ The ART backend runs LoRA + GRPO training on a single GPU using co-located vLLM 
 - Built-in tool-call reward verification (`tool_call_reward`)
 - Automatic checkpoint saving and resume
 - Support for custom rollout functions and reward functions
+- Weights & Biases experiment tracking (auto-detects `WANDB_API_KEY`)
 
 ## Usage
 

--- a/docs/api/backends/verl.md
+++ b/docs/api/backends/verl.md
@@ -1,6 +1,6 @@
 # verl Backend (GRPO)
 
-> Multi-GPU distributed LoRA + GRPO training using verl (Volcano Engine RL).
+> Multi-GPU distributed LoRA + GRPO training using [verl](https://github.com/volcengine/verl) (Volcano Engine Reinforcement Learning for LLMs).
 
 ## Overview
 

--- a/docs/api/backends/verl.md
+++ b/docs/api/backends/verl.md
@@ -1,0 +1,95 @@
+# verl Backend (GRPO)
+
+> Multi-GPU distributed LoRA + GRPO training using verl (Volcano Engine RL).
+
+## Overview
+
+**Class:** `VeRLLoRAGRPOBackend`
+
+**Algorithm Support:** LoRA + GRPO
+
+**Package:** `verl`
+
+**Status:** Implemented
+
+The verl backend uses FSDP for distributed LoRA training across multiple GPUs and vLLM for parallel rollout generation, orchestrated by Ray. It supports scaling to 70B+ models and provides epoch-based training over the full dataset.
+
+## Features
+
+- FSDP-sharded LoRA training across multiple GPUs
+- vLLM rollout generation with co-located weight syncing
+- Ray-based orchestration for distributed workers
+- Epoch-based training for systematic data coverage
+- Supports GRPO with group-based advantage estimation
+- Automatic checkpoint saving and resume
+
+## Usage
+
+### Via Convenience Function
+
+```python
+from training_hub import lora_grpo
+
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    backend="verl",
+    n_gpus=4,
+    lora_r=32,
+    lora_alpha=64,
+    num_iterations=3,
+)
+```
+
+### Via Class-Based API
+
+```python
+from training_hub import create_algorithm
+
+algo = create_algorithm("lora_grpo", "verl")
+result = algo.train(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    n_gpus=4,
+)
+```
+
+## Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `n_gpus` | `int` | `1` | Number of GPUs for distributed training |
+| `tensor_parallel_size` | `int` | `1` | Tensor parallelism for vLLM inference |
+| `gpu_memory_utilization` | `float` | `0.35` | GPU memory fraction for vLLM |
+
+## Memory Considerations
+
+verl co-locates FSDP training and vLLM inference on the same GPUs. Key memory factors:
+
+- **Logits tensor**: `micro_batch * seq_len * vocab_size * 2 bytes` — can be large for models with large vocabularies (e.g., Qwen3's 152K vocab). Reduce micro batch size if OOM occurs.
+- **FSDP sharding**: Model parameters are sharded across GPUs but gathered during forward/backward passes.
+- **gpu_memory_utilization**: Set lower (0.3-0.4) to leave room for training. Default 0.35 works well for 4B models on H100.
+
+## Checkpoints
+
+verl saves checkpoints in:
+```
+ckpt_output_dir/checkpoints/global_step_N/actor/lora_adapter/
+```
+
+Each checkpoint contains `adapter_config.json` and `adapter_model.safetensors`, compatible with HuggingFace PEFT for loading.
+
+## Limitations
+
+- Requires Ray for distributed orchestration
+- Tool calls generated as text (not structured API), parsed via regex
+- `num_iterations` maps to epochs (full passes over the dataset), not random-sampling iterations
+- Custom `rollout_fn` not supported (verl manages its own rollout pipeline)
+
+## See Also
+
+- [LoRA + GRPO Algorithm Guide](/algorithms/lora_grpo)
+- [ART Backend](/api/backends/art-grpo) — Single-GPU alternative
+- [`lora_grpo()` Function Reference](/api/functions/lora_grpo)

--- a/docs/api/backends/verl.md
+++ b/docs/api/backends/verl.md
@@ -22,6 +22,7 @@ The verl backend uses FSDP for distributed LoRA training across multiple GPUs an
 - Epoch-based training for systematic data coverage
 - Supports GRPO with group-based advantage estimation
 - Automatic checkpoint saving and resume
+- Experiment tracking via W&B, MLflow, TensorBoard, and more
 
 ## Usage
 

--- a/docs/api/classes/LoRAGRPOAlgorithm.md
+++ b/docs/api/classes/LoRAGRPOAlgorithm.md
@@ -1,0 +1,54 @@
+# `LoRAGRPOAlgorithm` - LoRA + GRPO Algorithm
+
+> Reinforcement learning from verifiable rewards for tool-calling agents using LoRA adapters and Group Relative Policy Optimization.
+
+## Class Signature
+
+```python
+class LoRAGRPOAlgorithm(Algorithm):
+    def __init__(self, backend: Backend, **kwargs): ...
+    def train(self, model_path, ckpt_output_dir, **kwargs) -> dict: ...
+    def get_required_params(self) -> Dict[str, Type]: ...
+    def get_optional_params(self) -> Dict[str, Type]: ...
+```
+
+## Overview
+
+`LoRAGRPOAlgorithm` implements the GRPO training loop for tool-calling agents with LoRA parameter-efficient training. It supports two modes:
+
+1. **Built-in tool-call verification** — Provide a dataset with tool-call traces, and the algorithm handles rollout generation, reward computation, and training automatically.
+2. **Custom rollout** — Provide your own async rollout function for arbitrary environments.
+
+## Backends
+
+| Backend | Class | Use Case |
+|---------|-------|----------|
+| `art` | [`ARTLoRAGRPOBackend`](/api/backends/art-grpo) | Single-GPU with co-located vLLM + Unsloth |
+| `verl` | [`VeRLLoRAGRPOBackend`](/api/backends/verl) | Multi-GPU with FSDP + vLLM via Ray |
+
+## Usage
+
+```python
+from training_hub import create_algorithm
+
+# Using default backend (art)
+algo = create_algorithm("lora_grpo")
+
+# Using specific backend
+algo = create_algorithm("lora_grpo", "verl")
+
+# Train
+result = algo.train(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+)
+```
+
+Most users should use the [`lora_grpo()`](/api/functions/lora_grpo) convenience function instead of the class-based API.
+
+## See Also
+
+- [`lora_grpo()` Function Reference](/api/functions/lora_grpo)
+- [Algorithm Guide](/algorithms/lora_grpo)
+- [`Algorithm` Base Class](/api/classes/Algorithm)

--- a/docs/api/classes/LoRAGRPOAlgorithm.md
+++ b/docs/api/classes/LoRAGRPOAlgorithm.md
@@ -1,6 +1,6 @@
 # `LoRAGRPOAlgorithm` - LoRA + GRPO Algorithm
 
-> Reinforcement learning from verifiable rewards for tool-calling agents using LoRA adapters and Group Relative Policy Optimization.
+> Adapter-based reinforcement learning from verifiable rewards for tool-calling agents using LoRA and Group Relative Policy Optimization.
 
 ## Class Signature
 
@@ -23,7 +23,7 @@ class LoRAGRPOAlgorithm(Algorithm):
 
 | Backend | Class | Use Case |
 |---------|-------|----------|
-| `art` | [`ARTLoRAGRPOBackend`](/api/backends/art-grpo) | Single-GPU with co-located vLLM + Unsloth |
+| `art` | [`ARTLoRAGRPOBackend`](/api/backends/art-grpo) | Single-GPU with OpenPipe ART + Unsloth GRPO |
 | `verl` | [`VeRLLoRAGRPOBackend`](/api/backends/verl) | Multi-GPU with FSDP + vLLM via Ray |
 
 ## Usage

--- a/docs/api/functions/lora_grpo.md
+++ b/docs/api/functions/lora_grpo.md
@@ -39,6 +39,13 @@ def lora_grpo(
     tensor_parallel_size: int = 1,
     # Backend
     backend: str = "art",
+    # Experiment tracking
+    wandb_project: Optional[str] = None,
+    wandb_entity: Optional[str] = None,
+    wandb_run_name: Optional[str] = None,
+    mlflow_tracking_uri: Optional[str] = None,
+    mlflow_experiment_name: Optional[str] = None,
+    mlflow_run_name: Optional[str] = None,
     **kwargs,
 ) -> dict
 ```
@@ -119,6 +126,19 @@ result = lora_grpo(
 |-----------|------|---------|-------------|
 | `backend` | `str` | `"art"` | Backend to use: `"art"` (single-GPU) or `"verl"` (multi-GPU) |
 
+### Experiment Tracking
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `wandb_project` | `str` | `None` | Weights & Biases project name. Enables W&B logging. |
+| `wandb_entity` | `str` | `None` | Weights & Biases team/entity name. |
+| `wandb_run_name` | `str` | `None` | Weights & Biases run name. |
+| `mlflow_tracking_uri` | `str` | `None` | MLflow tracking server URI. Enables MLflow logging (verl backend only). |
+| `mlflow_experiment_name` | `str` | `None` | MLflow experiment name (verl backend only). |
+| `mlflow_run_name` | `str` | `None` | MLflow run name (verl backend only). |
+
+> **Note:** The ART backend supports W&B natively (auto-detects `WANDB_API_KEY`). MLflow is only supported with the verl backend.
+
 ## Returns
 
 `dict` with keys:
@@ -175,6 +195,32 @@ result = lora_grpo(
     group_size=4,
     lora_r=32,
     lora_alpha=64,
+)
+```
+
+### With Experiment Tracking
+
+```python
+# W&B tracking (both backends)
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    wandb_project="my-grpo-project",
+    wandb_entity="my-team",
+    wandb_run_name="qwen3-grpo-run",
+)
+
+# MLflow tracking (verl backend only)
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./output",
+    backend="verl",
+    n_gpus=4,
+    mlflow_tracking_uri="http://localhost:5000",
+    mlflow_experiment_name="grpo-experiments",
+    mlflow_run_name="qwen3-grpo-run",
 )
 ```
 

--- a/docs/api/functions/lora_grpo.md
+++ b/docs/api/functions/lora_grpo.md
@@ -1,6 +1,6 @@
 # `lora_grpo()` - LoRA + GRPO Training
 
-> Convenience function for LoRA + GRPO training on tool-calling agents using reinforcement learning from verifiable rewards.
+> Convenience function for adapter-based RLVR — LoRA + GRPO training on tool-calling agents using reinforcement learning from verifiable rewards.
 
 ?> **New to LoRA + GRPO?** See the [Algorithm Guide](../../algorithms/lora_grpo.md) for overview and quick start.
 

--- a/docs/api/functions/lora_grpo.md
+++ b/docs/api/functions/lora_grpo.md
@@ -1,0 +1,186 @@
+# `lora_grpo()` - LoRA + GRPO Training
+
+> Convenience function for LoRA + GRPO training on tool-calling agents using reinforcement learning from verifiable rewards.
+
+?> **New to LoRA + GRPO?** See the [Algorithm Guide](../../algorithms/lora_grpo.md) for overview and quick start.
+
+## Signature
+
+```python
+def lora_grpo(
+    model_path: str,
+    ckpt_output_dir: str,
+    # Data source
+    data_path: Optional[str] = None,
+    data_config: str = "Qwen3",
+    n_train: int = 5000,
+    n_val: int = 500,
+    # Custom rollout
+    rollout_fn: Optional[Callable] = None,
+    tasks: Optional[List[Any]] = None,
+    reward_fn: Optional[Callable] = None,
+    # GRPO hyperparameters
+    num_iterations: int = 15,
+    group_size: int = 8,
+    tasks_per_iteration: int = 100,
+    learning_rate: float = 1e-5,
+    temperature: float = 0.7,
+    max_tokens: int = 512,
+    concurrency: int = 32,
+    # LoRA configuration
+    lora_r: int = 16,
+    lora_alpha: int = 8,
+    target_modules: Optional[List[str]] = None,
+    max_grad_norm: float = 0.1,
+    # vLLM configuration
+    gpu_memory_utilization: float = 0.45,
+    # Multi-GPU
+    n_gpus: int = 1,
+    tensor_parallel_size: int = 1,
+    # Backend
+    backend: str = "art",
+    **kwargs,
+) -> dict
+```
+
+## Quick Example
+
+```python
+from training_hub import lora_grpo
+
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./output",
+    backend="art",
+    lora_r=32,
+    num_iterations=15,
+)
+```
+
+## Parameters
+
+### Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model_path` | `str` | HuggingFace model ID or local path to base model |
+| `ckpt_output_dir` | `str` | Directory to save checkpoints and training results |
+
+### Data Source
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `data_path` | `str` | `None` | HuggingFace dataset ID (e.g., `Agent-Ark/Toucan-1.5M`) or local JSON/JSONL path |
+| `data_config` | `str` | `"Qwen3"` | HuggingFace dataset config name |
+| `n_train` | `int` | `5000` | Number of training samples to load |
+| `n_val` | `int` | `500` | Number of validation samples to load |
+
+### Custom Rollout
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `rollout_fn` | `Callable` | `None` | Async function `(model, task) -> art.Trajectory`. Must be a top-level function (not lambda/closure). |
+| `tasks` | `list` | `None` | List of task objects passed to `rollout_fn` |
+| `reward_fn` | `Callable` | `None` | Custom reward function `(response, name, args) -> float` |
+
+### GRPO Hyperparameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_iterations` | `int` | `15` | Number of GRPO training iterations (ART) or epochs (verl) |
+| `group_size` | `int` | `8` | Rollouts per task for advantage estimation |
+| `tasks_per_iteration` | `int` | `100` | Tasks sampled per iteration |
+| `learning_rate` | `float` | `1e-5` | Learning rate |
+| `temperature` | `float` | `0.7` | Sampling temperature for rollouts |
+| `max_tokens` | `int` | `512` | Maximum response tokens per rollout |
+| `concurrency` | `int` | `32` | Maximum concurrent rollouts |
+
+### LoRA Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `lora_r` | `int` | `16` | LoRA rank |
+| `lora_alpha` | `int` | `8` | LoRA alpha scaling parameter |
+| `target_modules` | `list[str]` | `None` | Modules to apply LoRA to (default: auto-detect) |
+| `max_grad_norm` | `float` | `0.1` | Gradient clipping norm |
+
+### Multi-GPU Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `n_gpus` | `int` | `1` | Number of GPUs (verl backend) |
+| `tensor_parallel_size` | `int` | `1` | Tensor parallelism size for vLLM inference |
+| `gpu_memory_utilization` | `float` | `0.45` | GPU memory fraction for vLLM |
+
+### Backend Selection
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `backend` | `str` | `"art"` | Backend to use: `"art"` (single-GPU) or `"verl"` (multi-GPU) |
+
+## Returns
+
+`dict` with keys:
+- `status` — `"success"` on completion
+- `checkpoint_path` — Path to saved checkpoints
+- `reward_history` — List of per-iteration mean rewards
+- `full_match_history` — List of per-iteration full match rates
+- `total_time_seconds` — Total training wall time
+- `total_rollouts` — Total number of rollouts generated
+
+## Examples
+
+### Single-Turn Tool-Call Training
+
+```python
+from training_hub import lora_grpo
+
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="Agent-Ark/Toucan-1.5M",
+    ckpt_output_dir="./toucan_grpo",
+    num_iterations=15,
+    group_size=8,
+    tasks_per_iteration=100,
+    lora_r=32,
+    lora_alpha=64,
+)
+```
+
+### Multi-Turn Traces (e.g., tau-bench)
+
+```python
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tau_retail_traces.jsonl",
+    ckpt_output_dir="./tau_grpo",
+    num_iterations=20,
+    lora_r=32,
+    lora_alpha=64,
+    learning_rate=5e-6,
+)
+```
+
+### Multi-GPU with verl
+
+```python
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./verl_output",
+    backend="verl",
+    n_gpus=4,
+    num_iterations=3,
+    group_size=4,
+    lora_r=32,
+    lora_alpha=64,
+)
+```
+
+## See Also
+
+- [LoRA + GRPO Algorithm Guide](/algorithms/lora_grpo) — Conceptual overview and detailed usage
+- [ART Backend](/api/backends/art-grpo) — Single-GPU backend details
+- [verl Backend](/api/backends/verl) — Multi-GPU backend details
+- [`lora_sft()`](/api/functions/lora_sft) — LoRA + SFT (supervised, non-RL)

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -4,12 +4,12 @@ Training Hub supports multiple experiment tracking backends so you can monitor t
 
 ## Supported Loggers
 
-| Logger | Description | SFT | OSFT | LoRA |
-|--------|-------------|:---:|:----:|:----:|
-| [MLflow](#mlflow) | Open-source platform for ML lifecycle management | Yes | Yes | Yes |
-| [Weights & Biases](#weights--biases-wandb) | Cloud-based experiment tracking and visualization | Yes | Yes | Yes |
-| [TensorBoard](#tensorboard) | TensorFlow's visualization toolkit for training metrics | Yes | No | Yes |
-| [JSONL Metrics](#built-in-jsonl-metrics) | Built-in local file logging (always active) | Yes | Yes | Yes |
+| Logger | Description | SFT | OSFT | LoRA | LoRA GRPO |
+|--------|-------------|:---:|:----:|:----:|:---------:|
+| [MLflow](#mlflow) | Open-source platform for ML lifecycle management | Yes | Yes | Yes | verl only |
+| [Weights & Biases](#weights--biases-wandb) | Cloud-based experiment tracking and visualization | Yes | Yes | Yes | Yes |
+| [TensorBoard](#tensorboard) | TensorFlow's visualization toolkit for training metrics | Yes | No | Yes | No |
+| [JSONL Metrics](#built-in-jsonl-metrics) | Built-in local file logging (always active) | Yes | Yes | Yes | Yes |
 
 ?> **Zero-config detection** -- Training Hub automatically enables each logger when its trigger parameter is set. No additional flags or boilerplate code is needed.
 
@@ -199,6 +199,26 @@ lora_sft(
 )
 ```
 
+### Usage with LoRA GRPO
+
+!> **verl backend only** -- MLflow is supported with the verl backend. The ART backend uses W&B for experiment tracking.
+
+```python
+from training_hub import lora_grpo
+
+lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./checkpoints",
+    backend="verl",
+    n_gpus=4,
+    # MLflow configuration
+    mlflow_tracking_uri="http://localhost:5000",
+    mlflow_experiment_name="grpo-training",
+    mlflow_run_name="qwen-grpo-run",
+)
+```
+
 ### Viewing Results
 
 Open your MLflow UI in a browser at the tracking URI (e.g., `http://localhost:5000`) to view logged metrics, compare runs, and inspect hyperparameters.
@@ -275,6 +295,27 @@ lora_sft(
     wandb_run_name="qwen-lora-run",
 )
 ```
+
+### Usage with LoRA GRPO
+
+```python
+from training_hub import lora_grpo
+
+lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./traces.jsonl",
+    ckpt_output_dir="./checkpoints",
+    lora_r=32,
+    lora_alpha=64,
+    num_iterations=15,
+    # W&B configuration
+    wandb_project="grpo-training",
+    wandb_entity="my-team",
+    wandb_run_name="qwen-grpo-run",
+)
+```
+
+?> **Both backends supported** -- W&B works with both the ART backend (auto-detects `WANDB_API_KEY`) and the verl backend.
 
 ### Viewing Results
 
@@ -446,6 +487,7 @@ sft(
 - [**sft() Function**](/api/functions/sft) - Full SFT parameter reference including logging
 - [**osft() Function**](/api/functions/osft) - Full OSFT parameter reference including logging
 - [**lora_sft() Function**](/api/functions/lora_sft) - Full LoRA parameter reference including logging
+- [**lora_grpo() Function**](/api/functions/lora_grpo) - Full LoRA GRPO parameter reference including logging
 - [**Distributed Training Guide**](/guides/distributed-training) - Multi-GPU and multi-node setup
 - [**LoRA Logging Examples**](/algorithms/lora#logging--experiment-tracking) - LoRA-specific logging details
 - [**Example Scripts**](/examples/) - Runnable scripts including MLflow and wandb examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -124,9 +124,9 @@ result = lora_sft(
 )
 ```
 
-### LoRA + GRPO (Agentic RLVR)
+### LoRA + GRPO (Adapter-Based RLVR)
 
-LoRA + GRPO trains LoRA adapters on tool-calling agents using reinforcement learning from verifiable rewards. It supports both single-turn and multi-turn tool-call data, with automatic per-turn decomposition of multi-turn traces. Two backends are available: ART for single-GPU and verl for multi-GPU training.
+LoRA + GRPO trains LoRA adapters on tool-calling agents using reinforcement learning from verifiable rewards. It supports both single-turn and multi-turn tool-call data, with automatic per-turn decomposition of multi-turn traces. Two backends are available: OpenPipe ART + Unsloth GRPO for single-GPU and verl for multi-GPU training.
 
 **Documentation:**
 - [LoRA + GRPO Usage Guide](https://ai-innovation.team/training_hub/#/algorithms/lora_grpo) - Comprehensive usage documentation with parameter reference and examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -124,6 +124,41 @@ result = lora_sft(
 )
 ```
 
+### LoRA + GRPO (Agentic RLVR)
+
+LoRA + GRPO trains LoRA adapters on tool-calling agents using reinforcement learning from verifiable rewards. It supports both single-turn and multi-turn tool-call data, with automatic per-turn decomposition of multi-turn traces. Two backends are available: ART for single-GPU and verl for multi-GPU training.
+
+**Documentation:**
+- [LoRA + GRPO Usage Guide](https://ai-innovation.team/training_hub/#/algorithms/lora_grpo) - Comprehensive usage documentation with parameter reference and examples
+
+**Scripts:**
+- [LoRA GRPO Example](scripts/lora_grpo_example.py) - Tool-call GRPO training with ART backend, supports HuggingFace datasets and local JSONL
+
+**Quick Example:**
+```python
+from training_hub import lora_grpo
+
+# Single GPU (ART backend)
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./grpo_output",
+    backend="art",
+    lora_r=32,
+    lora_alpha=64,
+    num_iterations=15,
+)
+
+# Multi GPU (verl backend)
+result = lora_grpo(
+    model_path="Qwen/Qwen3-4B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./grpo_output",
+    backend="verl",
+    n_gpus=4,
+)
+```
+
 ### Memory Estimation (Experimental / In-Development)
 
 training_hub includes a library for estimating the expected amount of GPU memory that will be allocated during the fine-tuning of a given model using SFT or OSFT. The calculations are built off of formulas presented in the blog post [How To Calculate GPU VRAM Requirements for an Large-Language Model](https://apxml.com/posts/how-to-calculate-vram-requirements-for-an-llm).

--- a/examples/scripts/lora_grpo_example.py
+++ b/examples/scripts/lora_grpo_example.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+LoRA + GRPO Training Example
+
+Demonstrates reinforcement learning from verifiable rewards (RLVR) using
+adapter-based training with Group Relative Policy Optimization (GRPO).
+
+Two modes are shown:
+1. Built-in tool-call verification (single-turn, uses Toucan dataset)
+2. Custom rollout function (multi-turn, user-defined environment)
+
+Example usage:
+    # Single-turn tool-call training with Toucan dataset
+    python lora_grpo_example.py \\
+        --ckpt-output-dir ./grpo_output
+
+    # Custom model
+    python lora_grpo_example.py \\
+        --model-path ibm-granite/granite-4.0-h-tiny \\
+        --ckpt-output-dir ./grpo_output \\
+        --lora-r 128 --lora-alpha 256
+
+    # Quick test run
+    python lora_grpo_example.py \\
+        --ckpt-output-dir ./grpo_output \\
+        --num-iterations 2 --tasks-per-iteration 5
+"""
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime
+
+from training_hub import lora_grpo
+
+
+# =============================================================================
+# DEFAULT CONFIGURATION
+# =============================================================================
+
+default_model_path = "Qwen/Qwen3-4B"
+default_lora_r = 16
+default_lora_alpha = 8
+default_learning_rate = 1e-5
+default_num_iterations = 15
+default_group_size = 8
+default_tasks_per_iteration = 100
+default_data_path = "Agent-Ark/Toucan-1.5M"
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="LoRA + GRPO Training (Reinforcement Learning from Verifiable Rewards)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Quick test (2 iterations, 5 tasks each)
+  python lora_grpo_example.py --ckpt-output-dir ./grpo_test --num-iterations 2 --tasks-per-iteration 5
+
+  # Full training run
+  python lora_grpo_example.py --ckpt-output-dir ./grpo_output --num-iterations 15 --tasks-per-iteration 100
+
+  # Granite MoE model (needs higher LoRA rank)
+  python lora_grpo_example.py --model-path ibm-granite/granite-4.0-h-tiny --ckpt-output-dir ./grpo_granite --lora-r 128 --lora-alpha 256
+        """
+    )
+
+    # Required
+    parser.add_argument('--ckpt-output-dir', required=True,
+                        help='Directory to save checkpoints and results')
+
+    # Model
+    parser.add_argument('--model-path', default=default_model_path,
+                        help=f'HuggingFace model ID or local path (default: {default_model_path})')
+
+    # Dataset
+    parser.add_argument('--data-path', default=default_data_path,
+                        help=f'HuggingFace dataset ID or local JSON/JSONL (default: {default_data_path})')
+    parser.add_argument('--data-config', default='Qwen3',
+                        help='HuggingFace dataset config (default: Qwen3)')
+    parser.add_argument('--n-train', type=int, default=5000,
+                        help='Number of training samples (default: 5000)')
+
+    # GRPO hyperparameters
+    parser.add_argument('--num-iterations', type=int, default=default_num_iterations,
+                        help=f'Number of GRPO iterations (default: {default_num_iterations})')
+    parser.add_argument('--group-size', type=int, default=default_group_size,
+                        help=f'Rollouts per task for advantage estimation (default: {default_group_size})')
+    parser.add_argument('--tasks-per-iteration', type=int, default=default_tasks_per_iteration,
+                        help=f'Tasks per iteration (default: {default_tasks_per_iteration})')
+    parser.add_argument('--learning-rate', type=float, default=default_learning_rate,
+                        help=f'Learning rate (default: {default_learning_rate})')
+    parser.add_argument('--concurrency', type=int, default=32,
+                        help='Max concurrent rollouts (default: 32)')
+
+    # LoRA configuration
+    parser.add_argument('--lora-r', type=int, default=default_lora_r,
+                        help=f'LoRA rank (default: {default_lora_r})')
+    parser.add_argument('--lora-alpha', type=int, default=default_lora_alpha,
+                        help=f'LoRA alpha parameter (default: {default_lora_alpha})')
+
+    # vLLM
+    parser.add_argument('--gpu-memory-utilization', type=float, default=0.45,
+                        help='GPU memory fraction for vLLM (default: 0.45)')
+
+    # Logging
+    parser.add_argument('--wandb-project', help='Weights & Biases project name')
+    parser.add_argument('--mlflow-tracking-uri', help='MLflow tracking URI')
+    parser.add_argument('--mlflow-experiment-name', help='MLflow experiment name')
+
+    # Utility
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print configuration and exit without training')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+
+    rollouts_per_iter = args.tasks_per_iteration * args.group_size
+    total_rollouts = rollouts_per_iter * args.num_iterations
+
+    # Print configuration
+    print("LoRA + GRPO Training (RLVR)")
+    print("=" * 60)
+    print(f"Model:              {args.model_path}")
+    print(f"Dataset:            {args.data_path} ({args.data_config})")
+    print(f"Output:             {args.ckpt_output_dir}")
+    print()
+    print("GRPO Configuration:")
+    print(f"  Iterations:       {args.num_iterations}")
+    print(f"  Tasks/iteration:  {args.tasks_per_iteration}")
+    print(f"  Group size:       {args.group_size}")
+    print(f"  Rollouts/iter:    {rollouts_per_iter}")
+    print(f"  Total rollouts:   {total_rollouts}")
+    print(f"  Learning rate:    {args.learning_rate}")
+    print(f"  Concurrency:      {args.concurrency}")
+    print()
+    print("LoRA Configuration:")
+    print(f"  Rank (r):         {args.lora_r}")
+    print(f"  Alpha:            {args.lora_alpha}")
+    print(f"  GPU mem util:     {args.gpu_memory_utilization}")
+    print("=" * 60)
+
+    if args.dry_run:
+        print("\nDry run mode - configuration validated, exiting without training")
+        return
+
+    print(f"\nStarting training at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
+    start_time = time.time()
+
+    try:
+        result = lora_grpo(
+            model_path=args.model_path,
+            ckpt_output_dir=args.ckpt_output_dir,
+            data_path=args.data_path,
+            data_config=args.data_config,
+            n_train=args.n_train,
+            num_iterations=args.num_iterations,
+            group_size=args.group_size,
+            tasks_per_iteration=args.tasks_per_iteration,
+            learning_rate=args.learning_rate,
+            concurrency=args.concurrency,
+            lora_r=args.lora_r,
+            lora_alpha=args.lora_alpha,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            wandb_project=args.wandb_project,
+            mlflow_tracking_uri=args.mlflow_tracking_uri,
+            mlflow_experiment_name=args.mlflow_experiment_name,
+        )
+
+        elapsed = time.time() - start_time
+        print()
+        print("=" * 60)
+        print("GRPO training completed successfully!")
+        print(f"Training time:     {elapsed:.0f}s ({elapsed/3600:.1f}h)")
+        print(f"Total rollouts:    {result['total_rollouts']}")
+        print(f"Final reward:      {result['final_mean_reward']:.3f}")
+        print(f"Reward history:    {[f'{r:.3f}' for r in result['reward_history']]}")
+        print(f"Checkpoint saved:  {result['checkpoint_path']}")
+        print("=" * 60)
+
+    except Exception as e:
+        elapsed = time.time() - start_time
+        print()
+        print("=" * 60)
+        print(f"GRPO training failed after {elapsed:.1f}s")
+        print(f"Error: {e}")
+        print()
+        print("Troubleshooting:")
+        print("  - Ensure openpipe-art is installed: pip install openpipe-art")
+        print("  - Reduce GPU memory usage: --gpu-memory-utilization 0.35")
+        print("  - Reduce concurrency: --concurrency 8")
+        print("  - Try fewer tasks: --tasks-per-iteration 10 --num-iterations 2")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,17 +70,10 @@ lora = [
 ]
 
 grpo = [
-    # Single-GPU GRPO via ART backend (backend="art")
     "openpipe-art",
+    "verl>=0.7",  # no [vllm] extra — verl works with ART's vllm 0.15+ despite its conservative cap
     "litellm>=1.82.0,<1.82.7",  # 1.82.7-1.82.8 compromised (TeamPCP supply chain attack, 2026-03-24)
     "transformers>=4.51.3,<5.0",  # trl<=0.24 (capped by unsloth) breaks with transformers 5.x
-]
-
-grpo-verl = [
-    # Multi-GPU GRPO via verl backend (backend="verl")
-    # Install verl core without [vllm] extra to avoid vllm<=0.12 cap.
-    # verl works with vllm 0.15+ at runtime despite the conservative cap.
-    "verl>=0.7",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ lora = [
     "xformers>=0.0.33.post1",
 ]
 
+grpo = [
+    "openpipe-art",
+    "litellm>=1.82.0,<1.82.7",  # 1.82.7-1.82.8 compromised (TeamPCP supply chain attack, 2026-03-24)
+]
+
 dev = [
     "ipykernel",
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,15 @@ lora = [
 ]
 
 grpo = [
+    # Single-GPU GRPO via ART backend. Do not combine with [grpo-verl] (vLLM version conflict).
     "openpipe-art",
     "litellm>=1.82.0,<1.82.7",  # 1.82.7-1.82.8 compromised (TeamPCP supply chain attack, 2026-03-24)
     "transformers>=4.51.3,<5.0",  # trl<=0.24 (capped by unsloth) breaks with transformers 5.x
+]
+
+grpo-verl = [
+    # Multi-GPU GRPO via verl backend. Do not combine with [grpo] (vLLM version conflict).
+    "verl[vllm]>=0.7",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ lora = [
 grpo = [
     "openpipe-art",
     "litellm>=1.82.0,<1.82.7",  # 1.82.7-1.82.8 compromised (TeamPCP supply chain attack, 2026-03-24)
+    "transformers>=4.51.3,<5.0",  # trl<=0.24 (capped by unsloth) breaks with transformers 5.x
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,15 +70,17 @@ lora = [
 ]
 
 grpo = [
-    # Single-GPU GRPO via ART backend. Do not combine with [grpo-verl] (vLLM version conflict).
+    # Single-GPU GRPO via ART backend (backend="art")
     "openpipe-art",
     "litellm>=1.82.0,<1.82.7",  # 1.82.7-1.82.8 compromised (TeamPCP supply chain attack, 2026-03-24)
     "transformers>=4.51.3,<5.0",  # trl<=0.24 (capped by unsloth) breaks with transformers 5.x
 ]
 
 grpo-verl = [
-    # Multi-GPU GRPO via verl backend. Do not combine with [grpo] (vLLM version conflict).
-    "verl[vllm]>=0.7",
+    # Multi-GPU GRPO via verl backend (backend="verl")
+    # Install verl core without [vllm] extra to avoid vllm<=0.12 cap.
+    # verl works with vllm 0.15+ at runtime despite the conservative cap.
+    "verl>=0.7",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,7 @@ dependencies = [
     "setuptools>=80.0",
     "packaging>=24.2",
     "wheel>=0.43",
-    "instructlab-training>=0.14.0",
-    "rhai-innovation-mini-trainer>=0.6.0",
     "torch>=2.6.0",
-    "numba>=0.62.0",
     "transformers>=4.57.6",
     "datasets>=4.0.0",
     "numpy>=1.26.4",
@@ -36,7 +33,6 @@ dependencies = [
     "aiohttp>=3.12",
     "pyparsing>=3.0",
     "regex>=2025.0",
-    "llvmlite>=0.42",
     "psutil>=6.0",
     "urllib3>=2.4",
     "frozenlist>=1.7",
@@ -52,7 +48,15 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+lab = [
+    "instructlab-training>=0.14.0",
+    "rhai-innovation-mini-trainer>=0.6.0",
+    "numba>=0.62.0",
+    "llvmlite>=0.42",
+]
+
 cuda = [
+    "training-hub[lab]",
     "instructlab-training[cuda]>=0.14.0",
     "rhai-innovation-mini-trainer[cuda]>=0.6.0",
     "flash-attn>=2.8",
@@ -64,6 +68,7 @@ cuda = [
 ]
 
 lora = [
+    "training-hub[lab]",
     "unsloth>=2026.1.1",
     "trl>=0.18.0",
     "xformers>=0.0.33.post1",

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -3,6 +3,7 @@ from .algorithms.sft import sft, SFTAlgorithm, InstructLabTrainingSFTBackend
 from .algorithms.osft import OSFTAlgorithm, MiniTrainerOSFTBackend, osft
 from .algorithms.lora import lora_sft, LoRASFTAlgorithm, UnslothLoRABackend
 from .algorithms.lora_grpo import lora_grpo, LoRAGRPOAlgorithm, ARTLoRAGRPOBackend
+from .algorithms.lora_grpo_verl import VeRLLoRAGRPOBackend
 from .algorithms.rewards import tool_call_reward, binary_reward
 from .hub_core import welcome
 from .profiling.memory_estimator import BasicEstimator, OSFTEstimatorExperimental, estimate, OSFTEstimator, LoRAEstimator, QLoRAEstimator
@@ -25,6 +26,7 @@ __all__ = [
     'UnslothLoRABackend',
     'LoRAGRPOAlgorithm',
     'ARTLoRAGRPOBackend',
+    'VeRLLoRAGRPOBackend',
     'tool_call_reward',
     'binary_reward',
     'welcome',

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -2,6 +2,8 @@ from .algorithms import Algorithm, Backend, AlgorithmRegistry, create_algorithm
 from .algorithms.sft import sft, SFTAlgorithm, InstructLabTrainingSFTBackend
 from .algorithms.osft import OSFTAlgorithm, MiniTrainerOSFTBackend, osft
 from .algorithms.lora import lora_sft, LoRASFTAlgorithm, UnslothLoRABackend
+from .algorithms.lora_grpo import lora_grpo, LoRAGRPOAlgorithm, ARTLoRAGRPOBackend
+from .algorithms.rewards import tool_call_reward, binary_reward
 from .hub_core import welcome
 from .profiling.memory_estimator import BasicEstimator, OSFTEstimatorExperimental, estimate, OSFTEstimator, LoRAEstimator, QLoRAEstimator
 from .visualization import plot_loss
@@ -14,12 +16,17 @@ __all__ = [
     'sft',
     'osft',
     'lora_sft',
+    'lora_grpo',
     'SFTAlgorithm',
     'InstructLabTrainingSFTBackend',
     'OSFTAlgorithm',
     'MiniTrainerOSFTBackend',
     'LoRASFTAlgorithm',
     'UnslothLoRABackend',
+    'LoRAGRPOAlgorithm',
+    'ARTLoRAGRPOBackend',
+    'tool_call_reward',
+    'binary_reward',
     'welcome',
     'BasicEstimator',
     'OSFTEstimatorExperimental',

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -1,12 +1,8 @@
 from .algorithms import Algorithm, Backend, AlgorithmRegistry, create_algorithm
-from .algorithms.sft import sft, SFTAlgorithm, InstructLabTrainingSFTBackend
-from .algorithms.osft import OSFTAlgorithm, MiniTrainerOSFTBackend, osft
-from .algorithms.lora import lora_sft, LoRASFTAlgorithm, UnslothLoRABackend
 from .algorithms.lora_grpo import lora_grpo, LoRAGRPOAlgorithm, ARTLoRAGRPOBackend
 from .algorithms.lora_grpo_verl import VeRLLoRAGRPOBackend
 from .algorithms.rewards import tool_call_reward, binary_reward
 from .hub_core import welcome
-from .profiling.memory_estimator import BasicEstimator, OSFTEstimatorExperimental, estimate, OSFTEstimator, LoRAEstimator, QLoRAEstimator
 from .visualization import plot_loss
 
 __all__ = [
@@ -14,27 +10,36 @@ __all__ = [
     'Backend',
     'AlgorithmRegistry',
     'create_algorithm',
-    'sft',
-    'osft',
-    'lora_sft',
     'lora_grpo',
-    'SFTAlgorithm',
-    'InstructLabTrainingSFTBackend',
-    'OSFTAlgorithm',
-    'MiniTrainerOSFTBackend',
-    'LoRASFTAlgorithm',
-    'UnslothLoRABackend',
     'LoRAGRPOAlgorithm',
     'ARTLoRAGRPOBackend',
     'VeRLLoRAGRPOBackend',
     'tool_call_reward',
     'binary_reward',
     'welcome',
-    'BasicEstimator',
-    'OSFTEstimatorExperimental',
-    'OSFTEstimator',
-    'LoRAEstimator',
-    'QLoRAEstimator',
-    'estimate',
     'plot_loss',
 ]
+
+try:
+    from .algorithms.sft import sft, SFTAlgorithm, InstructLabTrainingSFTBackend
+    __all__ += ['sft', 'SFTAlgorithm', 'InstructLabTrainingSFTBackend']
+except ImportError:
+    pass
+
+try:
+    from .algorithms.osft import OSFTAlgorithm, MiniTrainerOSFTBackend, osft
+    __all__ += ['osft', 'OSFTAlgorithm', 'MiniTrainerOSFTBackend']
+except ImportError:
+    pass
+
+try:
+    from .algorithms.lora import lora_sft, LoRASFTAlgorithm, UnslothLoRABackend
+    __all__ += ['lora_sft', 'LoRASFTAlgorithm', 'UnslothLoRABackend']
+except ImportError:
+    pass
+
+try:
+    from .profiling.memory_estimator import BasicEstimator, OSFTEstimatorExperimental, estimate, OSFTEstimator, LoRAEstimator, QLoRAEstimator
+    __all__ += ['BasicEstimator', 'OSFTEstimatorExperimental', 'OSFTEstimator', 'LoRAEstimator', 'QLoRAEstimator', 'estimate']
+except ImportError:
+    pass

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -57,6 +57,25 @@ from .rewards import tool_call_reward
 logger = logging.getLogger(__name__)
 
 
+def _force_cleanup():
+    """Kill all child processes (vLLM engine, etc.) and force-exit.
+
+    ART/vLLM spawns subprocesses and threads that don't shut down cleanly
+    via backend.close(). This kills child processes and calls os._exit()
+    to avoid hanging on orphaned threads.
+    """
+    import psutil
+    current = psutil.Process()
+    children = current.children(recursive=True)
+    for child in children:
+        try:
+            child.kill()
+        except psutil.NoSuchProcess:
+            pass
+    psutil.wait_procs(children, timeout=5)
+    os._exit(0)
+
+
 # ---------------------------------------------------------------------------
 # Built-in dataset loading (Toucan-style tool-call data)
 # ---------------------------------------------------------------------------
@@ -469,20 +488,73 @@ class ARTLoRAGRPOBackend(Backend):
     """
 
     def execute_training(self, algorithm_params: Dict[str, Any]) -> Any:
-        """Execute LoRA GRPO training using ART."""
-        # ART requires VLLM_USE_V1=0 for compatibility
+        """Execute LoRA GRPO training using ART.
+
+        Runs training in a forked subprocess to ensure clean GPU/thread cleanup.
+        ART/vLLM spawns threads and processes that don't shut down cleanly,
+        so subprocess isolation prevents resource leaks in the caller.
+        """
+        import multiprocessing as mp
+
+        ckpt_output_dir = algorithm_params["ckpt_output_dir"]
+        os.makedirs(ckpt_output_dir, exist_ok=True)
+        results_path = os.path.join(ckpt_output_dir, "training_results.json")
+        error_path = os.path.join(ckpt_output_dir, ".training_error")
+
+        # Remove stale error file
+        if os.path.exists(error_path):
+            os.remove(error_path)
+
+        ctx = mp.get_context("spawn")
+        proc = ctx.Process(
+            target=self._subprocess_entry,
+            args=(algorithm_params, results_path, error_path),
+        )
+        proc.start()
+        proc.join()
+
+        # Check for errors
+        if os.path.exists(error_path):
+            with open(error_path) as f:
+                error_msg = f.read()
+            os.remove(error_path)
+            raise RuntimeError(f"GRPO training failed: {error_msg}")
+
+        if proc.exitcode != 0 and not os.path.exists(results_path):
+            raise RuntimeError(f"GRPO training subprocess exited with code {proc.exitcode}")
+
+        # Read results
+        with open(results_path) as f:
+            return json.load(f)
+
+    @staticmethod
+    def _subprocess_entry(algorithm_params, results_path, error_path):
+        """Entry point for the training subprocess."""
         os.environ["VLLM_USE_V1"] = "0"
 
         try:
             import art
             from art.local.backend import LocalBackend
         except ImportError:
-            raise ImportError(
-                "The 'openpipe-art' package is required for GRPO training. "
-                "Install with: pip install openpipe-art"
-            )
+            with open(error_path, "w") as f:
+                f.write("openpipe-art is not installed. Install with: pip install openpipe-art")
+            os._exit(1)
 
-        return asyncio.run(self._run_training(algorithm_params, art, LocalBackend))
+        async def _run_and_cleanup():
+            try:
+                result = await ARTLoRAGRPOBackend()._run_training(
+                    algorithm_params, art, LocalBackend
+                )
+                with open(results_path, "w") as f:
+                    json.dump(result, f, indent=2)
+            except Exception as e:
+                with open(error_path, "w") as f:
+                    f.write(str(e))
+            # Force cleanup before asyncio.run() tries to shut down the event loop
+            # (which hangs on vLLM's dangling threads)
+            _force_cleanup()
+
+        asyncio.run(_run_and_cleanup())
 
     async def _run_training(self, params: Dict[str, Any], art, LocalBackend) -> Dict[str, Any]:
         """Async training loop."""

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1,0 +1,1014 @@
+"""LoRA + GRPO (Group Relative Policy Optimization) algorithm.
+
+Adapter-based reinforcement learning from verifiable rewards (RLVR) for tool-calling
+agents. Uses the ART framework (OpenPipe) for co-located vLLM inference + Unsloth
+LoRA training on a single GPU with time-sharing.
+
+Supports:
+- Single-turn tool-call verification with built-in reward (default)
+- Multi-turn agentic rollouts with custom rollout functions
+- Custom reward functions
+- Co-located vLLM (default) with planned support for standalone vLLM
+
+Example (single-turn tool-call verification):
+    from training_hub import lora_grpo
+
+    result = lora_grpo(
+        model_path="Qwen/Qwen3-4B",
+        data_path="Agent-Ark/Toucan-1.5M",
+        ckpt_output_dir="./grpo_output",
+        num_iterations=15,
+        group_size=8,
+        tasks_per_iteration=100,
+    )
+
+Example (custom multi-turn rollout):
+    import art
+
+    async def my_rollout(model, task):
+        client = model.openai_client()
+        model_name = model.get_inference_name()
+        # ... run your agentic loop ...
+        trajectory = art.Trajectory(messages_and_choices=[...])
+        trajectory.reward = compute_reward(...)
+        return trajectory
+
+    result = lora_grpo(
+        model_path="Qwen/Qwen3-4B",
+        ckpt_output_dir="./grpo_output",
+        rollout_fn=my_rollout,
+        tasks=my_task_list,
+        num_iterations=10,
+    )
+"""
+
+import asyncio
+import json
+import logging
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+from . import Algorithm, Backend, AlgorithmRegistry
+from .rewards import tool_call_reward
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Built-in dataset loading (Toucan-style tool-call data)
+# ---------------------------------------------------------------------------
+
+def _load_tool_call_dataset(
+    data_path: str,
+    n_train: int = 5000,
+    n_val: int = 500,
+    data_config: str = "Qwen3",
+    cache_dir: Optional[str] = None,
+) -> tuple[list[dict], list[dict]]:
+    """Load a tool-call dataset for single-turn GRPO training.
+
+    Supports HuggingFace dataset IDs (e.g. 'Agent-Ark/Toucan-1.5M') or
+    local JSON/JSONL files with the required fields.
+
+    For HuggingFace datasets, each row should contain:
+    - messages: list of [system, user, assistant-with-tool-call] messages
+    - available_tools: list of tool definitions (OpenAI format)
+    - question: the user query
+
+    For local files, each sample should be a dict with:
+    - question: user query text
+    - tools: list of tool definitions (OpenAI format)
+    - target_tool_name: expected tool name
+    - target_arguments: expected arguments dict
+    - system_prompt: system prompt text
+
+    Returns:
+        (train_samples, val_samples) tuple
+    """
+    if cache_dir is None:
+        cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "training_hub", "grpo_data")
+
+    cache_path = Path(cache_dir)
+    train_cache = cache_path / f"train_{n_train}.json"
+    val_cache = cache_path / f"val_{n_val}.json"
+
+    # Return cached if available
+    if train_cache.exists() and val_cache.exists():
+        logger.info("Loading cached data from %s", cache_dir)
+        with open(train_cache) as f:
+            train = json.load(f)
+        with open(val_cache) as f:
+            val = json.load(f)
+        return train, val
+
+    # Local file
+    if data_path.endswith((".json", ".jsonl")):
+        return _load_local_dataset(data_path, n_train, n_val)
+
+    # HuggingFace dataset
+    logger.info("Downloading dataset '%s' (config=%s) from HuggingFace...", data_path, data_config)
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        raise ImportError(
+            "The 'datasets' package is required for HuggingFace dataset loading. "
+            "Install with: pip install datasets"
+        )
+
+    total_needed = n_train + n_val
+    buffer = int(total_needed * 1.5)
+
+    ds = load_dataset(data_path, data_config, split="train", streaming=True)
+
+    processed = []
+    skipped = 0
+    for row in ds:
+        if len(processed) >= buffer:
+            break
+
+        sample = _process_hf_row(row)
+        if sample is None:
+            skipped += 1
+            continue
+        processed.append(sample)
+
+    logger.info("Processed %d samples (%d skipped)", len(processed), skipped)
+
+    train = processed[:n_train]
+    val = processed[n_train:n_train + n_val]
+
+    # Cache
+    cache_path.mkdir(parents=True, exist_ok=True)
+    with open(train_cache, "w") as f:
+        json.dump(train, f)
+    with open(val_cache, "w") as f:
+        json.dump(val, f)
+
+    logger.info("Cached %d train, %d val samples to %s", len(train), len(val), cache_dir)
+    return train, val
+
+
+def _load_local_dataset(data_path: str, n_train: int, n_val: int) -> tuple[list[dict], list[dict]]:
+    """Load dataset from local JSON/JSONL file."""
+    logger.info("Loading local dataset from %s", data_path)
+
+    if data_path.endswith(".jsonl"):
+        samples = []
+        with open(data_path) as f:
+            for line in f:
+                if line.strip():
+                    samples.append(json.loads(line))
+    else:
+        with open(data_path) as f:
+            samples = json.load(f)
+
+    required_fields = {"question", "tools", "target_tool_name", "target_arguments"}
+    valid_samples = [s for s in samples if required_fields.issubset(s.keys())]
+
+    if len(valid_samples) < len(samples):
+        logger.warning(
+            "Filtered %d samples missing required fields (%s)",
+            len(samples) - len(valid_samples),
+            required_fields,
+        )
+
+    train = valid_samples[:n_train]
+    val = valid_samples[n_train:n_train + n_val]
+    return train, val
+
+
+def _process_hf_row(row: dict) -> Optional[dict]:
+    """Process a HuggingFace dataset row into tool-call training format."""
+    messages = row.get("messages", [])
+    if isinstance(messages, str):
+        try:
+            messages = json.loads(messages)
+        except json.JSONDecodeError:
+            return None
+
+    if len(messages) < 3:
+        return None
+
+    # Extract gold tool call from assistant message
+    assistant_msg = messages[2]
+    if assistant_msg.get("role") != "assistant":
+        return None
+
+    function_call = assistant_msg.get("function_call")
+    tool_calls = assistant_msg.get("tool_calls")
+
+    if function_call:
+        target_name = function_call["name"]
+        target_args_str = function_call.get("arguments", "{}")
+        if isinstance(target_args_str, str):
+            try:
+                target_args = json.loads(target_args_str)
+            except json.JSONDecodeError:
+                target_args = {}
+        else:
+            target_args = target_args_str
+    elif tool_calls and len(tool_calls) > 0:
+        tc = tool_calls[0]
+        target_name = tc["function"]["name"]
+        target_args_str = tc["function"].get("arguments", "{}")
+        if isinstance(target_args_str, str):
+            try:
+                target_args = json.loads(target_args_str)
+            except json.JSONDecodeError:
+                target_args = {}
+        else:
+            target_args = target_args_str
+    else:
+        return None
+
+    tools = row.get("available_tools", [])
+    if isinstance(tools, str):
+        try:
+            tools = json.loads(tools)
+        except json.JSONDecodeError:
+            return None
+
+    if not tools:
+        return None
+
+    system_prompt = messages[0].get("content", "") if messages[0].get("role") == "system" else ""
+
+    return {
+        "id": row.get("uuid", ""),
+        "question": row.get("question", ""),
+        "tools": tools,
+        "target_tool_name": target_name,
+        "target_arguments": target_args,
+        "system_prompt": system_prompt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Backend: ART-based LoRA GRPO
+# ---------------------------------------------------------------------------
+
+class ARTLoRAGRPOBackend(Backend):
+    """ART backend for LoRA + GRPO training.
+
+    Uses the ART framework (OpenPipe) which manages:
+    - vLLM inference server (co-located, time-shared with training)
+    - Unsloth LoRA adapter training
+    - GRPO optimization with trajectory groups
+
+    The backend supports two modes:
+    1. Built-in tool-call verification (data_path provided, no rollout_fn)
+    2. Custom rollout function (rollout_fn provided by user)
+    """
+
+    def execute_training(self, algorithm_params: Dict[str, Any]) -> Any:
+        """Execute LoRA GRPO training using ART."""
+        # ART requires VLLM_USE_V1=0 for compatibility
+        os.environ["VLLM_USE_V1"] = "0"
+
+        try:
+            import art
+            from art.local.backend import LocalBackend
+        except ImportError:
+            raise ImportError(
+                "The 'openpipe-art' package is required for GRPO training. "
+                "Install with: pip install openpipe-art"
+            )
+
+        return asyncio.run(self._run_training(algorithm_params, art, LocalBackend))
+
+    async def _run_training(self, params: Dict[str, Any], art, LocalBackend) -> Dict[str, Any]:
+        """Async training loop."""
+        # Extract parameters
+        model_path = params["model_path"]
+        ckpt_output_dir = params["ckpt_output_dir"]
+
+        # GRPO hyperparameters
+        num_iterations = params.get("num_iterations", 15)
+        group_size = params.get("group_size", 8)
+        tasks_per_iteration = params.get("tasks_per_iteration", 100)
+        learning_rate = params.get("learning_rate", 1e-5)
+        temperature = params.get("temperature", 0.7)
+        max_tokens = params.get("max_tokens", 512)
+        concurrency = params.get("concurrency", 32)
+
+        # LoRA configuration
+        lora_r = params.get("lora_r", 16)
+        lora_alpha = params.get("lora_alpha", 8)
+        target_modules = params.get("target_modules")
+        max_grad_norm = params.get("max_grad_norm", 0.1)
+
+        # vLLM configuration
+        gpu_memory_utilization = params.get("gpu_memory_utilization", 0.45)
+        max_lora_rank = params.get("max_lora_rank", None)
+        vllm_base_url = params.get("vllm_base_url", None)
+
+        # Custom rollout/reward
+        rollout_fn = params.get("rollout_fn")
+        tasks = params.get("tasks")
+        reward_fn = params.get("reward_fn")
+
+        # Dataset (for built-in tool-call mode)
+        data_path = params.get("data_path")
+        data_config = params.get("data_config", "Qwen3")
+        n_train = params.get("n_train", 5000)
+        n_val = params.get("n_val", 500)
+
+        # Callbacks
+        iteration_callback = params.get("iteration_callback")
+
+        # Model name for ART registration
+        model_name_slug = model_path.split("/")[-1].lower().replace(".", "-")
+        art_model_name = params.get("art_model_name", f"{model_name_slug}-grpo")
+        art_project = params.get("art_project", "training-hub-grpo")
+        art_path = params.get("art_path", os.path.join(ckpt_output_dir, ".art"))
+
+        # Resolve mode: built-in tool-call vs custom rollout
+        if rollout_fn is not None:
+            if tasks is None:
+                raise ValueError(
+                    "When using a custom rollout_fn, you must also provide 'tasks' "
+                    "(a list of task objects to pass to your rollout function)."
+                )
+            train_data = tasks
+            val_data = []
+            mode = "custom"
+        elif data_path is not None:
+            train_data, val_data = _load_tool_call_dataset(
+                data_path, n_train=n_train, n_val=n_val, data_config=data_config,
+            )
+            mode = "tool_call"
+        else:
+            raise ValueError(
+                "Either 'data_path' (for built-in tool-call verification) or "
+                "'rollout_fn' + 'tasks' (for custom rollouts) must be provided."
+            )
+
+        # Build ART model config
+        peft_kwargs = {"lora_alpha": lora_alpha}
+        if lora_r != 16:
+            peft_kwargs["r"] = lora_r
+        if target_modules is not None:
+            peft_kwargs["target_modules"] = target_modules
+
+        init_kwargs = {"gpu_memory_utilization": gpu_memory_utilization}
+
+        engine_kwargs = {}
+        effective_max_lora_rank = max_lora_rank if max_lora_rank else lora_r
+        if effective_max_lora_rank > 16:
+            engine_kwargs["max_lora_rank"] = effective_max_lora_rank
+
+        internal_config = art.dev.InternalModelConfig(
+            init_args=art.dev.InitArgs(**init_kwargs),
+            peft_args=art.dev.PeftArgs(**peft_kwargs),
+            trainer_args=art.dev.TrainerArgs(max_grad_norm=max_grad_norm),
+            **({"engine_args": art.dev.EngineArgs(**engine_kwargs)} if engine_kwargs else {}),
+        )
+
+        model = art.TrainableModel(
+            name=art_model_name,
+            project=art_project,
+            base_model=model_path,
+            _internal_config=internal_config,
+        )
+
+        # Register with backend
+        # TODO: Support standalone vLLM via vllm_base_url parameter
+        if vllm_base_url is not None:
+            logger.warning(
+                "Standalone vLLM (vllm_base_url) is not yet supported. "
+                "Falling back to co-located vLLM via ART LocalBackend."
+            )
+
+        backend = LocalBackend(in_process=True, path=art_path)
+        await model.register(backend)
+        logger.info("Model registered with ART backend at %s", art_path)
+
+        # Build the rollout function for built-in tool-call mode
+        sem = asyncio.Semaphore(concurrency)
+        actual_reward_fn = reward_fn or tool_call_reward
+
+        if mode == "tool_call":
+            async def _builtin_rollout(mdl, sample):
+                return await self._tool_call_rollout(
+                    mdl, sample, sem, art,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    reward_fn=actual_reward_fn,
+                )
+            effective_rollout = _builtin_rollout
+        else:
+            # Wrap user's rollout_fn with semaphore for concurrency control
+            async def _wrapped_rollout(mdl, task):
+                async with sem:
+                    return await rollout_fn(mdl, task)
+            effective_rollout = _wrapped_rollout
+
+        # Check for resume
+        current_step = await model.get_step()
+        start_iteration = current_step if current_step > 0 else 0
+        if start_iteration > 0:
+            logger.info("Resuming from step %d", start_iteration)
+
+        os.makedirs(ckpt_output_dir, exist_ok=True)
+        rollouts_per_iter = tasks_per_iteration * group_size
+
+        # Training loop
+        reward_history = []
+        timing_history = []
+        full_match_history = []
+        start_time = time.time()
+
+        logger.info(
+            "Starting GRPO training: %d iterations, %d tasks/iter, group_size=%d, "
+            "lr=%s, mode=%s",
+            num_iterations, tasks_per_iteration, group_size, learning_rate, mode,
+        )
+
+        for iteration in range(start_iteration, num_iterations):
+            iter_start = time.time()
+
+            # Sample tasks for this iteration
+            random.seed(42 + iteration)
+            n_tasks = min(tasks_per_iteration, len(train_data))
+            iter_samples = random.sample(train_data, n_tasks)
+
+            # Gather trajectory groups
+            train_groups = await art.gather_trajectory_groups(
+                (
+                    art.TrajectoryGroup(
+                        effective_rollout(model, sample) for _ in range(group_size)
+                    )
+                    for sample in iter_samples
+                ),
+                pbar_desc=f"Iter {iteration + 1}/{num_iterations}",
+            )
+
+            # Compute metrics
+            rewards = [t.reward for g in train_groups for t in g.trajectories]
+            mean_reward = sum(rewards) / len(rewards) if rewards else 0.0
+            full_match = sum(1 for r in rewards if r >= 1.0) / len(rewards) if rewards else 0.0
+            name_match = sum(1 for r in rewards if r >= 0.5) / len(rewards) if rewards else 0.0
+
+            reward_history.append(mean_reward)
+            full_match_history.append(full_match)
+
+            # Train GRPO step
+            await model.train(
+                train_groups,
+                config=art.TrainConfig(learning_rate=learning_rate),
+            )
+
+            iter_time = time.time() - iter_start
+            timing_history.append(iter_time)
+            elapsed = time.time() - start_time
+
+            logger.info(
+                "Iter %d/%d: mean_reward=%.3f full_match=%.1f%% name_match=%.1f%% "
+                "rollouts=%d time=%.0fs elapsed=%.0fs",
+                iteration + 1, num_iterations,
+                mean_reward, full_match * 100, name_match * 100,
+                len(rewards), iter_time, elapsed,
+            )
+
+            # Save results every iteration
+            results = {
+                "framework": "art",
+                "algorithm": "lora_grpo",
+                "base_model": model_path,
+                "mode": mode,
+                "iteration": iteration + 1,
+                "num_iterations": num_iterations,
+                "group_size": group_size,
+                "tasks_per_iteration": tasks_per_iteration,
+                "learning_rate": learning_rate,
+                "lora_r": lora_r,
+                "lora_alpha": lora_alpha,
+                "concurrency": concurrency,
+                "reward_history": reward_history,
+                "full_match_history": full_match_history,
+                "timing_history": timing_history,
+                "total_time_seconds": elapsed,
+                "total_rollouts": (iteration + 1) * rollouts_per_iter,
+                "final_mean_reward": mean_reward,
+                "final_full_match": full_match,
+            }
+            results_path = os.path.join(ckpt_output_dir, "training_results.json")
+            with open(results_path, "w") as f:
+                json.dump(results, f, indent=2)
+
+            # User callback
+            if iteration_callback is not None:
+                iteration_callback(iteration + 1, results)
+
+        total_time = time.time() - start_time
+
+        logger.info(
+            "GRPO training complete: %d iterations, %d total rollouts, "
+            "final_reward=%.3f, total_time=%.0fs (%.1fh)",
+            num_iterations, num_iterations * rollouts_per_iter,
+            reward_history[-1] if reward_history else 0.0,
+            total_time, total_time / 3600,
+        )
+
+        return {
+            "status": "success",
+            "checkpoint_path": art_path,
+            "reward_history": reward_history,
+            "full_match_history": full_match_history,
+            "timing_history": timing_history,
+            "total_time_seconds": total_time,
+            "total_rollouts": num_iterations * rollouts_per_iter,
+            "final_mean_reward": reward_history[-1] if reward_history else 0.0,
+        }
+
+    async def _tool_call_rollout(
+        self,
+        model,
+        sample: dict,
+        sem: asyncio.Semaphore,
+        art,
+        temperature: float = 0.7,
+        max_tokens: int = 512,
+        reward_fn: Callable = tool_call_reward,
+    ):
+        """Built-in single-turn rollout for tool-call verification."""
+        async with sem:
+            client = model.openai_client()
+            model_name = model.get_inference_name()
+
+            messages = [
+                {"role": "system", "content": sample.get("system_prompt", "")},
+                {"role": "user", "content": sample["question"]},
+            ]
+
+            try:
+                response = await client.chat.completions.create(
+                    model=model_name,
+                    messages=messages,
+                    tools=sample["tools"],
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+
+                choice = response.choices[0]
+
+                reward = reward_fn(
+                    choice,
+                    expected_name=sample["target_tool_name"],
+                    expected_args=sample["target_arguments"],
+                )
+
+                trajectory = art.Trajectory(
+                    messages_and_choices=[
+                        messages[0],  # system (context, not trainable)
+                        messages[1],  # user (context, not trainable)
+                        choice,       # model output (trainable, carries logprobs)
+                    ]
+                )
+                trajectory.reward = reward
+                return trajectory
+
+            except Exception as e:
+                logger.warning("Rollout failed for sample %s: %s", sample.get("id", "?"), e)
+                trajectory = art.Trajectory(
+                    messages_and_choices=[
+                        {"role": "system", "content": "failed"},
+                        {"role": "user", "content": "failed"},
+                    ]
+                )
+                trajectory.reward = 0.0
+                return trajectory
+
+
+# ---------------------------------------------------------------------------
+# Algorithm
+# ---------------------------------------------------------------------------
+
+class LoRAGRPOAlgorithm(Algorithm):
+    """LoRA + GRPO algorithm for reinforcement learning from verifiable rewards.
+
+    Combines LoRA parameter-efficient training with GRPO optimization.
+    Supports single-turn (tool-call verification) and multi-turn (custom rollout)
+    training modes.
+    """
+
+    def __init__(self, backend: Backend, **kwargs):
+        self.backend = backend
+        self.config = kwargs
+
+    def train(
+        self,
+        model_path: str,
+        ckpt_output_dir: str,
+        # Data source (for built-in tool-call mode)
+        data_path: Optional[str] = None,
+        data_config: Optional[str] = None,
+        n_train: Optional[int] = None,
+        n_val: Optional[int] = None,
+        # Custom rollout mode
+        rollout_fn: Optional[Callable] = None,
+        tasks: Optional[List[Any]] = None,
+        reward_fn: Optional[Callable] = None,
+        # GRPO hyperparameters
+        num_iterations: Optional[int] = None,
+        group_size: Optional[int] = None,
+        tasks_per_iteration: Optional[int] = None,
+        learning_rate: Optional[float] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        concurrency: Optional[int] = None,
+        # LoRA configuration
+        lora_r: Optional[int] = None,
+        lora_alpha: Optional[int] = None,
+        target_modules: Optional[List[str]] = None,
+        max_grad_norm: Optional[float] = None,
+        # vLLM configuration
+        gpu_memory_utilization: Optional[float] = None,
+        max_lora_rank: Optional[int] = None,
+        vllm_base_url: Optional[str] = None,
+        # ART configuration
+        art_model_name: Optional[str] = None,
+        art_project: Optional[str] = None,
+        art_path: Optional[str] = None,
+        # Callbacks
+        iteration_callback: Optional[Callable] = None,
+        # Logging
+        mlflow_tracking_uri: Optional[str] = None,
+        mlflow_experiment_name: Optional[str] = None,
+        mlflow_run_name: Optional[str] = None,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        **kwargs,
+    ) -> Any:
+        """Execute LoRA + GRPO training.
+
+        Two modes of operation:
+
+        1. Built-in tool-call verification (provide data_path):
+           Uses a tool-calling dataset (e.g., Toucan-1.5M) with built-in
+           single-turn rollout and tool_call_reward verification.
+
+        2. Custom rollout (provide rollout_fn + tasks):
+           User supplies an async rollout function and task list. The rollout
+           function receives (model, task) and returns an art.Trajectory with
+           reward set. Supports both single-turn and multi-turn traces.
+
+        Args:
+            model_path: HuggingFace model ID or local path to base model.
+            ckpt_output_dir: Directory to save checkpoints and results.
+
+            Built-in Tool-Call Mode:
+                data_path: HuggingFace dataset ID or local JSON/JSONL path.
+                data_config: HuggingFace dataset config (default: 'Qwen3').
+                n_train: Number of training samples (default: 5000).
+                n_val: Number of validation samples (default: 500).
+
+            Custom Rollout Mode:
+                rollout_fn: Async function (model, task) -> art.Trajectory.
+                    The returned trajectory must have .reward set.
+                tasks: List of task objects passed to rollout_fn.
+                reward_fn: Optional reward function to override the default
+                    tool_call_reward. Signature: (response, expected_name, expected_args) -> float.
+
+            GRPO Hyperparameters:
+                num_iterations: Number of GRPO training iterations (default: 15).
+                group_size: Rollouts per task for advantage estimation (default: 8).
+                tasks_per_iteration: Tasks sampled per iteration (default: 100).
+                learning_rate: Learning rate (default: 1e-5).
+                temperature: Sampling temperature for rollouts (default: 0.7).
+                max_tokens: Max tokens per rollout response (default: 512).
+                concurrency: Max concurrent rollouts (default: 32).
+
+            LoRA Configuration:
+                lora_r: LoRA rank (default: 16).
+                lora_alpha: LoRA alpha (default: 8).
+                target_modules: Modules to apply LoRA to (default: auto).
+                max_grad_norm: Gradient clipping norm (default: 0.1).
+
+            vLLM Configuration:
+                gpu_memory_utilization: GPU memory fraction for vLLM (default: 0.45).
+                max_lora_rank: Max LoRA rank for vLLM engine (default: matches lora_r).
+                vllm_base_url: URL for standalone vLLM server (planned, not yet supported).
+
+            ART Configuration:
+                art_model_name: Model name for ART registration.
+                art_project: ART project name.
+                art_path: Path for ART local backend storage.
+
+            Callbacks:
+                iteration_callback: Called after each iteration with (iteration, results_dict).
+
+        Returns:
+            Dict with training results including reward_history, timing, and checkpoint path.
+        """
+        params = {
+            "model_path": model_path,
+            "ckpt_output_dir": ckpt_output_dir,
+        }
+
+        optional_params = {
+            "data_path": data_path,
+            "data_config": data_config,
+            "n_train": n_train,
+            "n_val": n_val,
+            "rollout_fn": rollout_fn,
+            "tasks": tasks,
+            "reward_fn": reward_fn,
+            "num_iterations": num_iterations,
+            "group_size": group_size,
+            "tasks_per_iteration": tasks_per_iteration,
+            "learning_rate": learning_rate,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "concurrency": concurrency,
+            "lora_r": lora_r,
+            "lora_alpha": lora_alpha,
+            "target_modules": target_modules,
+            "max_grad_norm": max_grad_norm,
+            "gpu_memory_utilization": gpu_memory_utilization,
+            "max_lora_rank": max_lora_rank,
+            "vllm_base_url": vllm_base_url,
+            "art_model_name": art_model_name,
+            "art_project": art_project,
+            "art_path": art_path,
+            "iteration_callback": iteration_callback,
+            "mlflow_tracking_uri": mlflow_tracking_uri,
+            "mlflow_experiment_name": mlflow_experiment_name,
+            "mlflow_run_name": mlflow_run_name,
+            "wandb_project": wandb_project,
+            "wandb_entity": wandb_entity,
+            "wandb_run_name": wandb_run_name,
+        }
+
+        for key, value in optional_params.items():
+            if value is not None:
+                params[key] = value
+
+        params.update(kwargs)
+
+        return self.backend.execute_training(params)
+
+    def get_required_params(self) -> Dict[str, Type]:
+        return {
+            "model_path": str,
+            "ckpt_output_dir": str,
+        }
+
+    def get_optional_params(self) -> Dict[str, Type]:
+        return {
+            # Data source
+            "data_path": str,
+            "data_config": str,
+            "n_train": int,
+            "n_val": int,
+            # Custom rollout
+            "rollout_fn": Callable,
+            "tasks": list,
+            "reward_fn": Callable,
+            # GRPO hyperparameters
+            "num_iterations": int,
+            "group_size": int,
+            "tasks_per_iteration": int,
+            "learning_rate": float,
+            "temperature": float,
+            "max_tokens": int,
+            "concurrency": int,
+            # LoRA
+            "lora_r": int,
+            "lora_alpha": int,
+            "target_modules": list,
+            "max_grad_norm": float,
+            # vLLM
+            "gpu_memory_utilization": float,
+            "max_lora_rank": int,
+            "vllm_base_url": str,
+            # ART
+            "art_model_name": str,
+            "art_project": str,
+            "art_path": str,
+            # Callbacks
+            "iteration_callback": Callable,
+            # Logging
+            "mlflow_tracking_uri": str,
+            "mlflow_experiment_name": str,
+            "mlflow_run_name": str,
+            "wandb_project": str,
+            "wandb_entity": str,
+            "wandb_run_name": str,
+        }
+
+
+# Register algorithm and backend
+AlgorithmRegistry.register_algorithm("lora_grpo", LoRAGRPOAlgorithm)
+AlgorithmRegistry.register_backend("lora_grpo", "art", ARTLoRAGRPOBackend)
+
+
+# ---------------------------------------------------------------------------
+# Convenience function
+# ---------------------------------------------------------------------------
+
+def lora_grpo(
+    model_path: str,
+    ckpt_output_dir: str,
+    # Data source (built-in tool-call mode)
+    data_path: Optional[str] = None,
+    data_config: str = "Qwen3",
+    n_train: int = 5000,
+    n_val: int = 500,
+    # Custom rollout mode
+    rollout_fn: Optional[Callable] = None,
+    tasks: Optional[List[Any]] = None,
+    reward_fn: Optional[Callable] = None,
+    # GRPO hyperparameters
+    num_iterations: int = 15,
+    group_size: int = 8,
+    tasks_per_iteration: int = 100,
+    learning_rate: float = 1e-5,
+    temperature: float = 0.7,
+    max_tokens: int = 512,
+    concurrency: int = 32,
+    # LoRA configuration
+    lora_r: int = 16,
+    lora_alpha: int = 8,
+    target_modules: Optional[List[str]] = None,
+    max_grad_norm: float = 0.1,
+    # vLLM configuration
+    gpu_memory_utilization: float = 0.45,
+    max_lora_rank: Optional[int] = None,
+    vllm_base_url: Optional[str] = None,
+    # ART configuration
+    art_model_name: Optional[str] = None,
+    art_project: Optional[str] = None,
+    art_path: Optional[str] = None,
+    # Backend selection
+    backend: str = "art",
+    # Callbacks
+    iteration_callback: Optional[Callable] = None,
+    # Logging
+    mlflow_tracking_uri: Optional[str] = None,
+    mlflow_experiment_name: Optional[str] = None,
+    mlflow_run_name: Optional[str] = None,
+    wandb_project: Optional[str] = None,
+    wandb_entity: Optional[str] = None,
+    wandb_run_name: Optional[str] = None,
+    **kwargs,
+) -> Any:
+    """Run LoRA + GRPO training for reinforcement learning from verifiable rewards.
+
+    Two modes of operation:
+
+    1. Built-in tool-call verification (provide data_path):
+       Uses a tool-calling dataset with single-turn rollout and automatic
+       reward computation based on tool call correctness.
+
+    2. Custom rollout (provide rollout_fn + tasks):
+       User supplies an async rollout function for arbitrary environments.
+       Supports both single-turn and multi-turn agentic traces.
+
+    Args:
+        model_path: HuggingFace model ID or local path (e.g., 'Qwen/Qwen3-4B').
+        ckpt_output_dir: Directory to save checkpoints and training results.
+
+        data_path: Dataset for built-in tool-call mode. HuggingFace ID
+            (e.g., 'Agent-Ark/Toucan-1.5M') or local JSON/JSONL path.
+        data_config: HuggingFace dataset config name (default: 'Qwen3').
+        n_train: Number of training samples to load (default: 5000).
+        n_val: Number of validation samples to load (default: 500).
+
+        rollout_fn: Async function with signature (model, task) -> art.Trajectory.
+            The returned Trajectory must have .reward set.
+        tasks: List of task objects passed to rollout_fn each iteration.
+        reward_fn: Custom reward function for built-in tool-call mode.
+            Signature: (response, expected_name, expected_args) -> float.
+
+        num_iterations: GRPO training iterations (default: 15).
+        group_size: Rollouts per task for advantage estimation (default: 8).
+        tasks_per_iteration: Tasks sampled per iteration (default: 100).
+        learning_rate: Learning rate (default: 1e-5).
+        temperature: Sampling temperature (default: 0.7).
+        max_tokens: Max response tokens per rollout (default: 512).
+        concurrency: Max concurrent rollouts (default: 32).
+
+        lora_r: LoRA rank (default: 16).
+        lora_alpha: LoRA alpha scaling parameter (default: 8).
+        target_modules: Modules to apply LoRA to (default: auto-detect).
+        max_grad_norm: Gradient clipping norm (default: 0.1).
+
+        gpu_memory_utilization: vLLM GPU memory fraction (default: 0.45).
+        max_lora_rank: Max LoRA rank for vLLM engine (default: matches lora_r).
+        vllm_base_url: Standalone vLLM server URL (planned, not yet supported).
+
+        art_model_name: Custom name for ART model registration.
+        art_project: ART project name (default: 'training-hub-grpo').
+        art_path: Path for ART backend storage.
+
+        backend: Backend to use (default: 'art').
+        iteration_callback: Callback after each iteration: (iteration_num, results_dict).
+
+        mlflow_tracking_uri: MLflow tracking URI.
+        mlflow_experiment_name: MLflow experiment name.
+        mlflow_run_name: MLflow run name.
+        wandb_project: Weights & Biases project name.
+        wandb_entity: Weights & Biases entity.
+        wandb_run_name: Weights & Biases run name.
+
+    Returns:
+        Dict with keys: status, checkpoint_path, reward_history,
+        full_match_history, timing_history, total_time_seconds,
+        total_rollouts, final_mean_reward.
+
+    Examples:
+        # Single-turn tool-call verification with Toucan dataset
+        result = lora_grpo(
+            model_path="Qwen/Qwen3-4B",
+            data_path="Agent-Ark/Toucan-1.5M",
+            ckpt_output_dir="./grpo_output",
+            num_iterations=15,
+            group_size=8,
+            tasks_per_iteration=100,
+            lora_r=16,
+            lora_alpha=8,
+        )
+
+        # Multi-turn custom rollout
+        import art
+
+        async def agent_rollout(model, task):
+            client = model.openai_client()
+            model_name = model.get_inference_name()
+            messages = [{"role": "system", "content": task["system"]}]
+            choices = []
+
+            for turn in range(task["max_turns"]):
+                response = await client.chat.completions.create(
+                    model=model_name, messages=messages, tools=task["tools"],
+                    temperature=0.7, max_tokens=1024,
+                )
+                choice = response.choices[0]
+                choices.append(choice)
+                # ... execute tool calls, append results ...
+
+            # Build trajectory with interleaved messages and choices
+            messages_and_choices = []
+            for msg in messages:
+                if msg["role"] == "assistant":
+                    messages_and_choices.append(choices.pop(0))
+                else:
+                    messages_and_choices.append(msg)
+
+            trajectory = art.Trajectory(messages_and_choices=messages_and_choices)
+            trajectory.reward = evaluate_success(messages)
+            return trajectory
+
+        result = lora_grpo(
+            model_path="Qwen/Qwen3-4B",
+            ckpt_output_dir="./grpo_output",
+            rollout_fn=agent_rollout,
+            tasks=my_task_list,
+            num_iterations=10,
+            concurrency=16,
+        )
+    """
+    from . import create_algorithm
+
+    algorithm = create_algorithm("lora_grpo", backend)
+    return algorithm.train(
+        model_path=model_path,
+        ckpt_output_dir=ckpt_output_dir,
+        data_path=data_path,
+        data_config=data_config,
+        n_train=n_train,
+        n_val=n_val,
+        rollout_fn=rollout_fn,
+        tasks=tasks,
+        reward_fn=reward_fn,
+        num_iterations=num_iterations,
+        group_size=group_size,
+        tasks_per_iteration=tasks_per_iteration,
+        learning_rate=learning_rate,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        concurrency=concurrency,
+        lora_r=lora_r,
+        lora_alpha=lora_alpha,
+        target_modules=target_modules,
+        max_grad_norm=max_grad_norm,
+        gpu_memory_utilization=gpu_memory_utilization,
+        max_lora_rank=max_lora_rank,
+        vllm_base_url=vllm_base_url,
+        art_model_name=art_model_name,
+        art_project=art_project,
+        art_path=art_path,
+        iteration_callback=iteration_callback,
+        mlflow_tracking_uri=mlflow_tracking_uri,
+        mlflow_experiment_name=mlflow_experiment_name,
+        mlflow_run_name=mlflow_run_name,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
+        wandb_run_name=wandb_run_name,
+        **kwargs,
+    )

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -361,12 +361,13 @@ def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
         if user_msg is None:
             continue
 
-        # Try to extract tools from system prompt (may be embedded as JSON in chat template)
-        tools = _extract_tools_from_system_prompt(system_msg.get("content", ""))
-        # Clean system prompt of chat template markers if tools were extracted
+        # Get tools: prefer top-level field, fall back to extracting from system prompt
+        tools = trace.get("tools", [])
         system_content = system_msg.get("content", "")
-        if tools:
-            system_content = _clean_system_prompt(system_content)
+        if not tools:
+            tools = _extract_tools_from_system_prompt(system_content)
+            if tools:
+                system_content = _clean_system_prompt(system_content)
 
         # Walk through the conversation and find each assistant tool-call turn
         # Everything between user and current turn is GT context
@@ -409,8 +410,11 @@ def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
                 else:
                     target_args = target_args_str
             else:
-                # Final assistant message (no tool call) — skip, not a training turn
-                break
+                # Assistant message without tool call (text response, e.g., greeting
+                # or clarification). Add to context and continue looking for tool calls.
+                context_prefix.append(msg)
+                i += 1
+                continue
 
             # Create a sample for this turn
             sample = {

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1015,6 +1015,8 @@ class LoRAGRPOAlgorithm(Algorithm):
             Custom Rollout Mode:
                 rollout_fn: Async function (model, task) -> art.Trajectory.
                     The returned trajectory must have .reward set.
+                    Must be a top-level function (not a lambda or closure),
+                    as it is serialized to a subprocess via pickle.
                 tasks: List of task objects passed to rollout_fn.
                 reward_fn: Optional reward function to override the default
                     tool_call_reward. Signature: (response, expected_name, expected_args) -> float.

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -205,6 +205,65 @@ def _load_local_dataset(data_path: str, n_train: int, n_val: int) -> tuple[list[
     return [], []
 
 
+def _extract_tools_from_system_prompt(system_content: str) -> list[dict]:
+    """Extract tool definitions from a system prompt that may embed them.
+
+    Handles formats like Qwen chat template markers or raw JSON tool arrays
+    embedded in the system prompt text.
+    """
+    if not system_content:
+        return []
+
+    # Look for a JSON array of tool definitions in the content
+    start = system_content.find('[{"type"')
+    if start < 0:
+        start = system_content.find('[{\"type\"')
+    if start < 0:
+        return []
+
+    # Find matching closing bracket
+    depth = 0
+    for i in range(start, len(system_content)):
+        if system_content[i] == '[':
+            depth += 1
+        elif system_content[i] == ']':
+            depth -= 1
+            if depth == 0:
+                try:
+                    tools = json.loads(system_content[start:i + 1])
+                    if isinstance(tools, list) and tools:
+                        return tools
+                except json.JSONDecodeError:
+                    pass
+                break
+
+    return []
+
+
+def _clean_system_prompt(system_content: str) -> str:
+    """Remove chat template markers and embedded tool JSON from system prompt.
+
+    Returns a clean system prompt suitable for passing as message content
+    (tools will be passed separately via the tools= API parameter).
+    """
+    import re
+
+    # Remove Qwen-style tool_declare blocks: <|im_system|>tool_declare<|im_middle|>[...]<|im_end|>
+    cleaned = re.sub(
+        r'<\|im_system\|>tool_declare<\|im_middle\|>.*?<\|im_end\|>',
+        '',
+        system_content,
+        flags=re.DOTALL,
+    )
+
+    # If the entire content was just the tool declaration, provide a minimal system prompt
+    cleaned = cleaned.strip()
+    if not cleaned:
+        cleaned = "You are a helpful assistant."
+
+    return cleaned
+
+
 def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
     """Decompose multi-turn traces into per-turn single-call samples.
 
@@ -250,6 +309,13 @@ def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
 
         if user_msg is None:
             continue
+
+        # Try to extract tools from system prompt (may be embedded as JSON in chat template)
+        tools = _extract_tools_from_system_prompt(system_msg.get("content", ""))
+        # Clean system prompt of chat template markers if tools were extracted
+        system_content = system_msg.get("content", "")
+        if tools:
+            system_content = _clean_system_prompt(system_content)
 
         # Walk through the conversation and find each assistant tool-call turn
         # Everything between user and current turn is GT context
@@ -299,8 +365,8 @@ def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
             sample = {
                 "id": f"{trace.get('id', trace_idx)}_turn{len(samples)}",
                 "question": user_msg.get("content", ""),
-                "system_prompt": system_msg.get("content", ""),
-                "tools": [],  # tools are embedded in system prompt for this format
+                "system_prompt": system_content,
+                "tools": tools,
                 "context_messages": list(context_prefix),  # GT context up to this turn
                 "target_tool_name": target_name,
                 "target_arguments": target_args,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -850,25 +850,24 @@ class ARTLoRAGRPOBackend(Backend):
             reward_history.append(mean_reward)
             full_match_history.append(full_match)
 
-            # Train GRPO step
-            await model.train(
-                train_groups,
-                config=art.TrainConfig(learning_rate=learning_rate),
-            )
+            # Write rollout metrics to training_metrics.jsonl immediately
+            # (before model.train which may os._exit on final iteration)
+            metrics_path = os.path.join(ckpt_output_dir, "training_metrics.jsonl")
+            rollout_entry = {
+                "step": iteration + 1,
+                "epoch": (iteration + 1) / num_iterations,
+                "phase": "rollout",
+                "mean_reward": mean_reward,
+                "full_match_rate": full_match,
+                "name_match_rate": name_match,
+                "total_rollouts": len(rewards),
+            }
+            with open(metrics_path, "a") as f:
+                f.write(json.dumps(rollout_entry) + "\n")
+                f.flush()
 
-            iter_time = time.time() - iter_start
-            timing_history.append(iter_time)
+            # Save results before training (survives os._exit)
             elapsed = time.time() - start_time
-
-            logger.info(
-                "Iter %d/%d: mean_reward=%.3f full_match=%.1f%% name_match=%.1f%% "
-                "rollouts=%d time=%.0fs elapsed=%.0fs",
-                iteration + 1, num_iterations,
-                mean_reward, full_match * 100, name_match * 100,
-                len(rewards), iter_time, elapsed,
-            )
-
-            # Save results every iteration
             results = {
                 "framework": "art",
                 "algorithm": "lora_grpo",
@@ -893,6 +892,54 @@ class ARTLoRAGRPOBackend(Backend):
             results_path = os.path.join(ckpt_output_dir, "training_results.json")
             with open(results_path, "w") as f:
                 json.dump(results, f, indent=2)
+
+            # Train GRPO step — ART writes loss metrics to its own
+            # history.jsonl live during training
+            await model.train(
+                train_groups,
+                config=art.TrainConfig(learning_rate=learning_rate),
+            )
+
+            iter_time = time.time() - iter_start
+            timing_history.append(iter_time)
+
+            # Write training metrics (loss/grad/entropy) from ART's history.
+            # ART writes history.jsonl live during model.train(), so this
+            # data is available immediately after training completes.
+            history_path = os.path.join(
+                art_path, art_project, "models", art_model_name, "history.jsonl"
+            )
+            train_entry = {
+                "step": iteration + 1,
+                "epoch": (iteration + 1) / num_iterations,
+                "phase": "train",
+                "wall_time_s": iter_time,
+            }
+            if os.path.exists(history_path):
+                try:
+                    with open(history_path) as hf:
+                        last_line = None
+                        for last_line in hf:
+                            pass
+                        if last_line:
+                            h = json.loads(last_line)
+                            train_entry["loss"] = h.get("loss/train")
+                            train_entry["grad_norm"] = h.get("loss/grad_norm")
+                            train_entry["learning_rate"] = h.get("loss/learning_rate")
+                            train_entry["entropy"] = h.get("loss/entropy")
+                except Exception:
+                    pass
+            with open(metrics_path, "a") as f:
+                f.write(json.dumps(train_entry) + "\n")
+                f.flush()
+
+            logger.info(
+                "Iter %d/%d: mean_reward=%.3f full_match=%.1f%% name_match=%.1f%% "
+                "rollouts=%d time=%.0fs elapsed=%.0fs",
+                iteration + 1, num_iterations,
+                mean_reward, full_match * 100, name_match * 100,
+                len(rewards), iter_time, elapsed,
+            )
 
             # User callback
             if iteration_callback is not None:

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -49,7 +49,7 @@ import os
 import random
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from . import Algorithm, Backend, AlgorithmRegistry
 from .rewards import tool_call_reward
@@ -603,8 +603,6 @@ class ARTLoRAGRPOBackend(Backend):
         # vLLM configuration
         gpu_memory_utilization = params.get("gpu_memory_utilization", 0.45)
         max_lora_rank = params.get("max_lora_rank", None)
-        vllm_base_url = params.get("vllm_base_url", None)
-
         # Custom rollout/reward
         rollout_fn = params.get("rollout_fn")
         tasks = params.get("tasks")
@@ -619,10 +617,26 @@ class ARTLoRAGRPOBackend(Backend):
         # Callbacks
         iteration_callback = params.get("iteration_callback")
 
-        # Model name for ART registration
+        # Experiment tracking (with env var fallbacks, matching other algorithms)
+        wandb_project = params.get("wandb_project") or os.environ.get("WANDB_PROJECT")
+        wandb_entity = params.get("wandb_entity") or os.environ.get("WANDB_ENTITY")
+        wandb_run_name = params.get("wandb_run_name") or os.environ.get("WANDB_RUN_NAME")
+        mlflow_tracking_uri = params.get("mlflow_tracking_uri") or os.environ.get("MLFLOW_TRACKING_URI")
+
+        if mlflow_tracking_uri:
+            logger.warning(
+                "MLflow is not supported by the ART backend. "
+                "Use the verl backend for MLflow experiment tracking."
+            )
+
+        # Set W&B env vars so ART picks them up automatically
+        if wandb_entity:
+            os.environ["WANDB_ENTITY"] = wandb_entity
+
+        # Model name for ART registration (also used as W&B run name)
         model_name_slug = model_path.split("/")[-1].lower().replace(".", "-")
-        art_model_name = params.get("art_model_name", f"{model_name_slug}-grpo")
-        art_project = params.get("art_project", "training-hub-grpo")
+        art_model_name = wandb_run_name or params.get("art_model_name", f"{model_name_slug}-grpo")
+        art_project = wandb_project or params.get("art_project", "training-hub-grpo")
         art_path = params.get("art_path", os.path.join(ckpt_output_dir, ".art"))
 
         # Resolve mode: built-in tool-call vs custom rollout
@@ -675,13 +689,6 @@ class ARTLoRAGRPOBackend(Backend):
         )
 
         # Register with backend
-        # TODO: Support standalone vLLM via vllm_base_url parameter
-        if vllm_base_url is not None:
-            logger.warning(
-                "Standalone vLLM (vllm_base_url) is not yet supported. "
-                "Falling back to co-located vLLM via ART LocalBackend."
-            )
-
         backend = LocalBackend(in_process=True, path=art_path)
         await model.register(backend)
         logger.info("Model registered with ART backend at %s", art_path)
@@ -977,7 +984,6 @@ class LoRAGRPOAlgorithm(Algorithm):
         # vLLM configuration
         gpu_memory_utilization: Optional[float] = None,
         max_lora_rank: Optional[int] = None,
-        vllm_base_url: Optional[str] = None,
         # Multi-GPU configuration (verl backend)
         n_gpus: Optional[int] = None,
         tensor_parallel_size: Optional[int] = None,
@@ -987,13 +993,13 @@ class LoRAGRPOAlgorithm(Algorithm):
         art_path: Optional[str] = None,
         # Callbacks
         iteration_callback: Optional[Callable] = None,
-        # Logging
-        mlflow_tracking_uri: Optional[str] = None,
-        mlflow_experiment_name: Optional[str] = None,
-        mlflow_run_name: Optional[str] = None,
+        # Logging / experiment tracking
         wandb_project: Optional[str] = None,
         wandb_entity: Optional[str] = None,
         wandb_run_name: Optional[str] = None,
+        mlflow_tracking_uri: Optional[str] = None,
+        mlflow_experiment_name: Optional[str] = None,
+        mlflow_run_name: Optional[str] = None,
         **kwargs,
     ) -> Any:
         """Execute LoRA + GRPO training.
@@ -1046,8 +1052,6 @@ class LoRAGRPOAlgorithm(Algorithm):
             vLLM Configuration:
                 gpu_memory_utilization: GPU memory fraction for vLLM (default: 0.45).
                 max_lora_rank: Max LoRA rank for vLLM engine (default: matches lora_r).
-                vllm_base_url: URL for standalone vLLM server (planned, not yet supported).
-
             ART Configuration:
                 art_model_name: Model name for ART registration.
                 art_project: ART project name.
@@ -1055,6 +1059,14 @@ class LoRAGRPOAlgorithm(Algorithm):
 
             Callbacks:
                 iteration_callback: Called after each iteration with (iteration, results_dict).
+
+            Experiment Tracking:
+                wandb_project: Weights & Biases project name.
+                wandb_entity: Weights & Biases team/entity name.
+                wandb_run_name: Weights & Biases run name.
+                mlflow_tracking_uri: MLflow tracking server URI.
+                mlflow_experiment_name: MLflow experiment name.
+                mlflow_run_name: MLflow run name.
 
         Returns:
             Dict with training results including reward_history, timing, and checkpoint path.
@@ -1085,19 +1097,18 @@ class LoRAGRPOAlgorithm(Algorithm):
             "max_grad_norm": max_grad_norm,
             "gpu_memory_utilization": gpu_memory_utilization,
             "max_lora_rank": max_lora_rank,
-            "vllm_base_url": vllm_base_url,
             "n_gpus": n_gpus,
             "tensor_parallel_size": tensor_parallel_size,
             "art_model_name": art_model_name,
             "art_project": art_project,
             "art_path": art_path,
             "iteration_callback": iteration_callback,
-            "mlflow_tracking_uri": mlflow_tracking_uri,
-            "mlflow_experiment_name": mlflow_experiment_name,
-            "mlflow_run_name": mlflow_run_name,
             "wandb_project": wandb_project,
             "wandb_entity": wandb_entity,
             "wandb_run_name": wandb_run_name,
+            "mlflow_tracking_uri": mlflow_tracking_uri,
+            "mlflow_experiment_name": mlflow_experiment_name,
+            "mlflow_run_name": mlflow_run_name,
         }
 
         for key, value in optional_params.items():
@@ -1141,7 +1152,6 @@ class LoRAGRPOAlgorithm(Algorithm):
             # vLLM
             "gpu_memory_utilization": float,
             "max_lora_rank": int,
-            "vllm_base_url": str,
             "n_gpus": int,
             "tensor_parallel_size": int,
             # ART
@@ -1150,13 +1160,13 @@ class LoRAGRPOAlgorithm(Algorithm):
             "art_path": str,
             # Callbacks
             "iteration_callback": Callable,
-            # Logging
-            "mlflow_tracking_uri": str,
-            "mlflow_experiment_name": str,
-            "mlflow_run_name": str,
+            # Logging / experiment tracking
             "wandb_project": str,
             "wandb_entity": str,
             "wandb_run_name": str,
+            "mlflow_tracking_uri": str,
+            "mlflow_experiment_name": str,
+            "mlflow_run_name": str,
         }
 
 
@@ -1197,7 +1207,6 @@ def lora_grpo(
     # vLLM configuration
     gpu_memory_utilization: float = 0.45,
     max_lora_rank: Optional[int] = None,
-    vllm_base_url: Optional[str] = None,
     # Multi-GPU configuration (verl backend)
     n_gpus: int = 1,
     tensor_parallel_size: int = 1,
@@ -1209,13 +1218,13 @@ def lora_grpo(
     backend: str = "art",
     # Callbacks
     iteration_callback: Optional[Callable] = None,
-    # Logging
-    mlflow_tracking_uri: Optional[str] = None,
-    mlflow_experiment_name: Optional[str] = None,
-    mlflow_run_name: Optional[str] = None,
+    # Logging / experiment tracking
     wandb_project: Optional[str] = None,
     wandb_entity: Optional[str] = None,
     wandb_run_name: Optional[str] = None,
+    mlflow_tracking_uri: Optional[str] = None,
+    mlflow_experiment_name: Optional[str] = None,
+    mlflow_run_name: Optional[str] = None,
     **kwargs,
 ) -> Any:
     """Run LoRA + GRPO training for reinforcement learning from verifiable rewards.
@@ -1261,8 +1270,6 @@ def lora_grpo(
 
         gpu_memory_utilization: vLLM GPU memory fraction (default: 0.45).
         max_lora_rank: Max LoRA rank for vLLM engine (default: matches lora_r).
-        vllm_base_url: Standalone vLLM server URL (planned, not yet supported).
-
         art_model_name: Custom name for ART model registration.
         art_project: ART project name (default: 'training-hub-grpo').
         art_path: Path for ART backend storage.
@@ -1270,12 +1277,12 @@ def lora_grpo(
         backend: Backend to use (default: 'art').
         iteration_callback: Callback after each iteration: (iteration_num, results_dict).
 
-        mlflow_tracking_uri: MLflow tracking URI.
+        wandb_project: Weights & Biases project name.
+        wandb_entity: Weights & Biases team/entity name.
+        wandb_run_name: Weights & Biases run name.
+        mlflow_tracking_uri: MLflow tracking server URI.
         mlflow_experiment_name: MLflow experiment name.
         mlflow_run_name: MLflow run name.
-        wandb_project: Weights & Biases project name.
-        wandb_entity: Weights & Biases entity.
-        wandb_run_name: Weights & Biases run name.
 
     Returns:
         Dict with keys: status, checkpoint_path, reward_history,
@@ -1360,18 +1367,17 @@ def lora_grpo(
         max_grad_norm=max_grad_norm,
         gpu_memory_utilization=gpu_memory_utilization,
         max_lora_rank=max_lora_rank,
-        vllm_base_url=vllm_base_url,
         n_gpus=n_gpus,
         tensor_parallel_size=tensor_parallel_size,
         art_model_name=art_model_name,
         art_project=art_project,
         art_path=art_path,
         iteration_callback=iteration_callback,
-        mlflow_tracking_uri=mlflow_tracking_uri,
-        mlflow_experiment_name=mlflow_experiment_name,
-        mlflow_run_name=mlflow_run_name,
         wandb_project=wandb_project,
         wandb_entity=wandb_entity,
         wandb_run_name=wandb_run_name,
+        mlflow_tracking_uri=mlflow_tracking_uri,
+        mlflow_experiment_name=mlflow_experiment_name,
+        mlflow_run_name=mlflow_run_name,
         **kwargs,
     )

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -315,6 +315,47 @@ def _clean_system_prompt(system_content: str) -> str:
     return cleaned
 
 
+def _normalize_message(msg: dict) -> dict:
+    """Normalize a message from deprecated function_call/function format to tool_calls/tool.
+
+    Converts:
+    - assistant messages with function_call → assistant with tool_calls
+    - function role messages → tool role messages
+    This ensures compatibility with modern OpenAI API and vLLM servers.
+    """
+    role = msg.get("role")
+
+    if role == "assistant" and "function_call" in msg:
+        fc = msg["function_call"]
+        import uuid
+        tool_call_id = f"call_{uuid.uuid4().hex[:24]}"
+        normalized = {
+            "role": "assistant",
+            "content": msg.get("content") or None,
+            "tool_calls": [{
+                "id": tool_call_id,
+                "type": "function",
+                "function": {
+                    "name": fc["name"],
+                    "arguments": fc.get("arguments", "{}"),
+                },
+            }],
+        }
+        # Store tool_call_id so the paired function message can reference it
+        normalized["_tool_call_id"] = tool_call_id
+        return normalized
+
+    if role == "function":
+        return {
+            "role": "tool",
+            "content": msg.get("content", ""),
+            "tool_call_id": msg.get("_tool_call_id", "call_unknown"),
+            "name": msg.get("name", ""),
+        }
+
+    return msg
+
+
 def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
     """Decompose multi-turn traces into per-turn single-call samples.
 
@@ -417,24 +458,37 @@ def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
                 continue
 
             # Create a sample for this turn
+            # Strip internal _tool_call_id fields from context messages
+            clean_context = [
+                {k: v for k, v in m.items() if k != "_tool_call_id"}
+                for m in context_prefix
+            ]
             sample = {
                 "id": f"{trace.get('id', trace_idx)}_turn{len(samples)}",
                 "question": user_msg.get("content", ""),
                 "system_prompt": system_content,
                 "tools": tools,
-                "context_messages": list(context_prefix),  # GT context up to this turn
+                "context_messages": clean_context,
                 "target_tool_name": target_name,
                 "target_arguments": target_args,
             }
             samples.append(sample)
 
             # Add this assistant message + its tool result to context for next turn
-            context_prefix.append(msg)
+            # Normalize deprecated function_call format to tool_calls format
+            normalized_assistant = _normalize_message(msg)
+            context_prefix.append(normalized_assistant)
             i += 1
 
             # Consume the following function/tool result message
             if i < len(turn_messages) and turn_messages[i].get("role") in ("function", "tool"):
-                context_prefix.append(turn_messages[i])
+                result_msg = turn_messages[i]
+                # Link tool_call_id from the assistant message
+                if result_msg.get("role") == "function":
+                    result_msg = dict(result_msg)
+                    result_msg["_tool_call_id"] = normalized_assistant.get("_tool_call_id", "call_unknown")
+                normalized_result = _normalize_message(result_msg)
+                context_prefix.append(normalized_result)
                 i += 1
 
     return samples
@@ -975,6 +1029,7 @@ class LoRAGRPOAlgorithm(Algorithm):
         learning_rate: Optional[float] = None,
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
+        max_prompt_length: Optional[int] = None,
         concurrency: Optional[int] = None,
         # LoRA configuration
         lora_r: Optional[int] = None,
@@ -1041,6 +1096,8 @@ class LoRAGRPOAlgorithm(Algorithm):
                 learning_rate: Learning rate (default: 1e-5).
                 temperature: Sampling temperature for rollouts (default: 0.7).
                 max_tokens: Max tokens per rollout response (default: 512).
+                max_prompt_length: Max prompt length in tokens; prompts exceeding
+                    this are filtered (verl backend only, default: 16384).
                 concurrency: Max concurrent rollouts (default: 32).
 
             LoRA Configuration:
@@ -1090,6 +1147,7 @@ class LoRAGRPOAlgorithm(Algorithm):
             "learning_rate": learning_rate,
             "temperature": temperature,
             "max_tokens": max_tokens,
+            "max_prompt_length": max_prompt_length,
             "concurrency": concurrency,
             "lora_r": lora_r,
             "lora_alpha": lora_alpha,
@@ -1143,6 +1201,7 @@ class LoRAGRPOAlgorithm(Algorithm):
             "learning_rate": float,
             "temperature": float,
             "max_tokens": int,
+            "max_prompt_length": int,
             "concurrency": int,
             # LoRA
             "lora_r": int,
@@ -1198,6 +1257,7 @@ def lora_grpo(
     learning_rate: float = 1e-5,
     temperature: float = 0.7,
     max_tokens: int = 512,
+    max_prompt_length: int = 16384,
     concurrency: int = 32,
     # LoRA configuration
     lora_r: int = 16,
@@ -1261,6 +1321,7 @@ def lora_grpo(
         learning_rate: Learning rate (default: 1e-5).
         temperature: Sampling temperature (default: 0.7).
         max_tokens: Max response tokens per rollout (default: 512).
+        max_prompt_length: Max prompt length in tokens (verl backend, default: 16384).
         concurrency: Max concurrent rollouts (default: 32).
 
         lora_r: LoRA rank (default: 16).
@@ -1360,6 +1421,7 @@ def lora_grpo(
         learning_rate=learning_rate,
         temperature=temperature,
         max_tokens=max_tokens,
+        max_prompt_length=max_prompt_length,
         concurrency=concurrency,
         lora_r=lora_r,
         lora_alpha=lora_alpha,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -152,32 +152,171 @@ def _load_tool_call_dataset(
 
 
 def _load_local_dataset(data_path: str, n_train: int, n_val: int) -> tuple[list[dict], list[dict]]:
-    """Load dataset from local JSON/JSONL file."""
+    """Load dataset from local JSON/JSONL file.
+
+    Auto-detects format:
+    - Single-turn: each sample has {question, tools, target_tool_name, target_arguments}
+    - Multi-turn: each sample has {messages} with multiple assistant/function turn pairs.
+      Multi-turn traces are decomposed into per-turn samples, each with GT context prefix.
+    """
     logger.info("Loading local dataset from %s", data_path)
 
     if data_path.endswith(".jsonl"):
-        samples = []
+        raw_samples = []
         with open(data_path) as f:
             for line in f:
                 if line.strip():
-                    samples.append(json.loads(line))
+                    raw_samples.append(json.loads(line))
     else:
         with open(data_path) as f:
-            samples = json.load(f)
+            raw_samples = json.load(f)
 
-    required_fields = {"question", "tools", "target_tool_name", "target_arguments"}
-    valid_samples = [s for s in samples if required_fields.issubset(s.keys())]
+    # Auto-detect format from first sample
+    if not raw_samples:
+        return [], []
 
-    if len(valid_samples) < len(samples):
-        logger.warning(
-            "Filtered %d samples missing required fields (%s)",
-            len(samples) - len(valid_samples),
-            required_fields,
+    first = raw_samples[0]
+    single_turn_fields = {"question", "tools", "target_tool_name", "target_arguments"}
+
+    if single_turn_fields.issubset(first.keys()):
+        # Single-turn format
+        valid = [s for s in raw_samples if single_turn_fields.issubset(s.keys())]
+        if len(valid) < len(raw_samples):
+            logger.warning(
+                "Filtered %d samples missing required fields",
+                len(raw_samples) - len(valid),
+            )
+        train = valid[:n_train]
+        val = valid[n_train:n_train + n_val]
+        return train, val
+
+    if "messages" in first:
+        # Multi-turn format — decompose into per-turn samples
+        all_samples = _decompose_multiturn_traces(raw_samples)
+        logger.info(
+            "Decomposed %d multi-turn traces into %d per-turn samples",
+            len(raw_samples), len(all_samples),
         )
+        train = all_samples[:n_train]
+        val = all_samples[n_train:n_train + n_val]
+        return train, val
 
-    train = valid_samples[:n_train]
-    val = valid_samples[n_train:n_train + n_val]
-    return train, val
+    logger.warning("Unrecognized dataset format — no valid samples loaded")
+    return [], []
+
+
+def _decompose_multiturn_traces(traces: list[dict]) -> list[dict]:
+    """Decompose multi-turn traces into per-turn single-call samples.
+
+    Each multi-turn trace with N tool calls becomes N samples. Sample k
+    contains the full GT context up to turn k as the prompt prefix, and
+    the expected tool call at turn k as the target.
+
+    Input format (per trace):
+        messages: [system, user, assistant+function_call, function_result,
+                   assistant+function_call, function_result, ..., assistant_final]
+        (messages can be a JSON string or list)
+
+    Output format (per sample):
+        system_prompt: system message content
+        question: user message content
+        context_messages: list of GT messages between user and this turn
+        tools: extracted from system prompt or empty (tools passed via system prompt)
+        target_tool_name: expected tool name at this turn
+        target_arguments: expected tool arguments at this turn
+    """
+    samples = []
+
+    for trace_idx, trace in enumerate(traces):
+        messages = trace.get("messages", [])
+        if isinstance(messages, str):
+            try:
+                messages = json.loads(messages)
+            except json.JSONDecodeError:
+                continue
+
+        if len(messages) < 3:
+            continue
+
+        # Extract system and user messages
+        system_msg = messages[0] if messages[0].get("role") == "system" else {"role": "system", "content": ""}
+        user_msg = None
+        user_idx = None
+        for i, m in enumerate(messages):
+            if m.get("role") == "user":
+                user_msg = m
+                user_idx = i
+                break
+
+        if user_msg is None:
+            continue
+
+        # Walk through the conversation and find each assistant tool-call turn
+        # Everything between user and current turn is GT context
+        context_prefix = []  # GT messages between user and current turn
+        turn_messages = messages[user_idx + 1:]  # everything after user
+
+        i = 0
+        while i < len(turn_messages):
+            msg = turn_messages[i]
+
+            if msg.get("role") != "assistant":
+                # Non-assistant message (shouldn't happen at turn boundary, skip)
+                context_prefix.append(msg)
+                i += 1
+                continue
+
+            # Check if this assistant message has a tool call
+            fc = msg.get("function_call")
+            tcs = msg.get("tool_calls")
+
+            if fc:
+                target_name = fc.get("name", "")
+                target_args_str = fc.get("arguments", "{}")
+                if isinstance(target_args_str, str):
+                    try:
+                        target_args = json.loads(target_args_str)
+                    except json.JSONDecodeError:
+                        target_args = {}
+                else:
+                    target_args = target_args_str
+            elif tcs and len(tcs) > 0:
+                tc = tcs[0]
+                target_name = tc.get("function", {}).get("name", "")
+                target_args_str = tc.get("function", {}).get("arguments", "{}")
+                if isinstance(target_args_str, str):
+                    try:
+                        target_args = json.loads(target_args_str)
+                    except json.JSONDecodeError:
+                        target_args = {}
+                else:
+                    target_args = target_args_str
+            else:
+                # Final assistant message (no tool call) — skip, not a training turn
+                break
+
+            # Create a sample for this turn
+            sample = {
+                "id": f"{trace.get('id', trace_idx)}_turn{len(samples)}",
+                "question": user_msg.get("content", ""),
+                "system_prompt": system_msg.get("content", ""),
+                "tools": [],  # tools are embedded in system prompt for this format
+                "context_messages": list(context_prefix),  # GT context up to this turn
+                "target_tool_name": target_name,
+                "target_arguments": target_args,
+            }
+            samples.append(sample)
+
+            # Add this assistant message + its tool result to context for next turn
+            context_prefix.append(msg)
+            i += 1
+
+            # Consume the following function/tool result message
+            if i < len(turn_messages) and turn_messages[i].get("role") in ("function", "tool"):
+                context_prefix.append(turn_messages[i])
+                i += 1
+
+    return samples
 
 
 def _process_hf_row(row: dict) -> Optional[dict]:
@@ -534,24 +673,37 @@ class ARTLoRAGRPOBackend(Backend):
         max_tokens: int = 512,
         reward_fn: Callable = tool_call_reward,
     ):
-        """Built-in single-turn rollout for tool-call verification."""
+        """Built-in rollout for tool-call verification (single-turn and multi-turn).
+
+        For single-turn samples: messages = [system, user] → model generates tool call.
+        For multi-turn samples: messages = [system, user, ...gt_context] → model generates
+        the next tool call given ground-truth prefix context.
+        """
         async with sem:
             client = model.openai_client()
             model_name = model.get_inference_name()
 
+            # Build message list: system + user + optional GT context prefix
             messages = [
                 {"role": "system", "content": sample.get("system_prompt", "")},
                 {"role": "user", "content": sample["question"]},
             ]
+            context_messages = sample.get("context_messages", [])
+            messages.extend(context_messages)
+
+            # Tools may be a list (single-turn) or empty (multi-turn, embedded in system prompt)
+            tools = sample.get("tools") or None
+            create_kwargs = {
+                "model": model_name,
+                "messages": messages,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+            if tools:
+                create_kwargs["tools"] = tools
 
             try:
-                response = await client.chat.completions.create(
-                    model=model_name,
-                    messages=messages,
-                    tools=sample["tools"],
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                )
+                response = await client.chat.completions.create(**create_kwargs)
 
                 choice = response.choices[0]
 
@@ -561,13 +713,15 @@ class ARTLoRAGRPOBackend(Backend):
                     expected_args=sample["target_arguments"],
                 )
 
-                trajectory = art.Trajectory(
-                    messages_and_choices=[
-                        messages[0],  # system (context, not trainable)
-                        messages[1],  # user (context, not trainable)
-                        choice,       # model output (trainable, carries logprobs)
-                    ]
-                )
+                # Trajectory: all context messages as dicts (not trainable),
+                # then the model's Choice (trainable, carries logprobs)
+                messages_and_choices = []
+                messages_and_choices.append(messages[0])  # system
+                messages_and_choices.append(messages[1])  # user
+                messages_and_choices.extend(context_messages)  # GT context (dicts, not trainable)
+                messages_and_choices.append(choice)  # model output (trainable)
+
+                trajectory = art.Trajectory(messages_and_choices=messages_and_choices)
                 trajectory.reward = reward
                 return trajectory
 

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -57,23 +57,55 @@ from .rewards import tool_call_reward
 logger = logging.getLogger(__name__)
 
 
-def _force_cleanup():
-    """Kill all child processes (vLLM engine, etc.) and force-exit.
+async def _shutdown_art_backend(backend) -> None:
+    """Shut down the ART LocalBackend and its vLLM engine cleanly.
 
-    ART/vLLM spawns subprocesses and threads that don't shut down cleanly
-    via backend.close(). This kills child processes and calls os._exit()
-    to avoid hanging on orphaned threads.
+    ART's backend.close() is a no-op in shared/in-process mode because it only
+    handles the dedicated vLLM subprocess. In shared mode, vLLM runs as an
+    AsyncLLM engine with a spawned EngineCore process. We need to explicitly
+    call engine.shutdown() to terminate it.
     """
-    import psutil
-    current = psutil.Process()
-    children = current.children(recursive=True)
-    for child in children:
-        try:
-            child.kill()
-        except psutil.NoSuchProcess:
-            pass
-    psutil.wait_procs(children, timeout=5)
-    os._exit(0)
+    for _, service in backend._services.items():
+        # Shut down the vLLM engine if it exists (shared/in-process mode)
+        llm_task = getattr(service, "__dict__", {}).get("llm")
+        if llm_task is not None and hasattr(llm_task, "result"):
+            try:
+                engine = llm_task.result() if llm_task.done() else None
+                if engine is not None and hasattr(engine, "shutdown"):
+                    engine.shutdown()
+            except Exception as e:
+                logger.warning("Error shutting down vLLM engine: %s", e)
+
+        # Also call the service's own close (handles dedicated mode subprocess)
+        close_fn = getattr(service, "close", None)
+        if close_fn is not None:
+            try:
+                close_fn()
+            except Exception as e:
+                logger.warning("Error closing service: %s", e)
+
+    # Release GPU memory and clean up remaining threads.
+    # asyncio.run() can hang on non-daemon threads left by torch/vLLM.
+    # Since results are already saved to disk by the training loop,
+    # force exit to avoid blocking indefinitely.
+    try:
+        import torch
+        import gc
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:
+        pass
+
+    import threading
+    non_daemon = [t for t in threading.enumerate()
+                  if t.is_alive() and not t.daemon and t != threading.main_thread()]
+    if non_daemon:
+        logger.info(
+            "Force-exiting to clean up %d non-daemon threads (torch/vLLM)",
+            len(non_daemon),
+        )
+        os._exit(0)
 
 
 # ---------------------------------------------------------------------------
@@ -490,9 +522,10 @@ class ARTLoRAGRPOBackend(Backend):
     def execute_training(self, algorithm_params: Dict[str, Any]) -> Any:
         """Execute LoRA GRPO training using ART.
 
-        Runs training in a forked subprocess to ensure clean GPU/thread cleanup.
-        ART/vLLM spawns threads and processes that don't shut down cleanly,
-        so subprocess isolation prevents resource leaks in the caller.
+        Runs in a subprocess to isolate the caller from ART/vLLM's non-daemon
+        threads that prevent clean Python exit. The subprocess performs proper
+        engine shutdown (freeing GPU), saves results to disk, then force-exits.
+        The parent reads results from disk.
         """
         import multiprocessing as mp
 
@@ -501,7 +534,6 @@ class ARTLoRAGRPOBackend(Backend):
         results_path = os.path.join(ckpt_output_dir, "training_results.json")
         error_path = os.path.join(ckpt_output_dir, ".training_error")
 
-        # Remove stale error file
         if os.path.exists(error_path):
             os.remove(error_path)
 
@@ -513,48 +545,35 @@ class ARTLoRAGRPOBackend(Backend):
         proc.start()
         proc.join()
 
-        # Check for errors
         if os.path.exists(error_path):
             with open(error_path) as f:
                 error_msg = f.read()
             os.remove(error_path)
             raise RuntimeError(f"GRPO training failed: {error_msg}")
 
-        if proc.exitcode != 0 and not os.path.exists(results_path):
+        if not os.path.exists(results_path):
             raise RuntimeError(f"GRPO training subprocess exited with code {proc.exitcode}")
 
-        # Read results
         with open(results_path) as f:
             return json.load(f)
 
     @staticmethod
     def _subprocess_entry(algorithm_params, results_path, error_path):
-        """Entry point for the training subprocess."""
+        """Subprocess entry point for training."""
         os.environ["VLLM_USE_V1"] = "0"
-
         try:
             import art
             from art.local.backend import LocalBackend
-        except ImportError:
+            result = asyncio.run(
+                ARTLoRAGRPOBackend()._run_training(algorithm_params, art, LocalBackend)
+            )
+            with open(results_path, "w") as f:
+                json.dump(result, f, indent=2)
+        except SystemExit:
+            pass  # os._exit from shutdown — results already on disk
+        except Exception as e:
             with open(error_path, "w") as f:
-                f.write("openpipe-art is not installed. Install with: pip install openpipe-art")
-            os._exit(1)
-
-        async def _run_and_cleanup():
-            try:
-                result = await ARTLoRAGRPOBackend()._run_training(
-                    algorithm_params, art, LocalBackend
-                )
-                with open(results_path, "w") as f:
-                    json.dump(result, f, indent=2)
-            except Exception as e:
-                with open(error_path, "w") as f:
-                    f.write(str(e))
-            # Force cleanup before asyncio.run() tries to shut down the event loop
-            # (which hangs on vLLM's dangling threads)
-            _force_cleanup()
-
-        asyncio.run(_run_and_cleanup())
+                f.write(str(e))
 
     async def _run_training(self, params: Dict[str, Any], art, LocalBackend) -> Dict[str, Any]:
         """Async training loop."""
@@ -663,6 +682,40 @@ class ARTLoRAGRPOBackend(Backend):
         await model.register(backend)
         logger.info("Model registered with ART backend at %s", art_path)
 
+        try:
+            return await self._run_training_loop(
+                model, backend, art, train_data,
+                mode=mode,
+                rollout_fn=rollout_fn,
+                reward_fn=reward_fn,
+                num_iterations=num_iterations,
+                group_size=group_size,
+                tasks_per_iteration=tasks_per_iteration,
+                learning_rate=learning_rate,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                concurrency=concurrency,
+                ckpt_output_dir=ckpt_output_dir,
+                art_path=art_path,
+                model_path=model_path,
+                lora_r=lora_r,
+                lora_alpha=lora_alpha,
+                iteration_callback=iteration_callback,
+            )
+        finally:
+            logger.info("Shutting down ART backend...")
+            await _shutdown_art_backend(backend)
+            logger.info("ART backend shut down")
+
+    async def _run_training_loop(
+        self, model, backend, art, train_data, *,
+        mode, rollout_fn, reward_fn,
+        num_iterations, group_size, tasks_per_iteration,
+        learning_rate, temperature, max_tokens, concurrency,
+        ckpt_output_dir, art_path, model_path, lora_r, lora_alpha,
+        iteration_callback,
+    ) -> Dict[str, Any]:
+        """Inner training loop."""
         # Build the rollout function for built-in tool-call mode
         sem = asyncio.Semaphore(concurrency)
         actual_reward_fn = reward_fn or tool_call_reward

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -978,6 +978,9 @@ class LoRAGRPOAlgorithm(Algorithm):
         gpu_memory_utilization: Optional[float] = None,
         max_lora_rank: Optional[int] = None,
         vllm_base_url: Optional[str] = None,
+        # Multi-GPU configuration (verl backend)
+        n_gpus: Optional[int] = None,
+        tensor_parallel_size: Optional[int] = None,
         # ART configuration
         art_model_name: Optional[str] = None,
         art_project: Optional[str] = None,
@@ -1083,6 +1086,8 @@ class LoRAGRPOAlgorithm(Algorithm):
             "gpu_memory_utilization": gpu_memory_utilization,
             "max_lora_rank": max_lora_rank,
             "vllm_base_url": vllm_base_url,
+            "n_gpus": n_gpus,
+            "tensor_parallel_size": tensor_parallel_size,
             "art_model_name": art_model_name,
             "art_project": art_project,
             "art_path": art_path,
@@ -1137,6 +1142,8 @@ class LoRAGRPOAlgorithm(Algorithm):
             "gpu_memory_utilization": float,
             "max_lora_rank": int,
             "vllm_base_url": str,
+            "n_gpus": int,
+            "tensor_parallel_size": int,
             # ART
             "art_model_name": str,
             "art_project": str,
@@ -1191,6 +1198,9 @@ def lora_grpo(
     gpu_memory_utilization: float = 0.45,
     max_lora_rank: Optional[int] = None,
     vllm_base_url: Optional[str] = None,
+    # Multi-GPU configuration (verl backend)
+    n_gpus: int = 1,
+    tensor_parallel_size: int = 1,
     # ART configuration
     art_model_name: Optional[str] = None,
     art_project: Optional[str] = None,
@@ -1351,6 +1361,8 @@ def lora_grpo(
         gpu_memory_utilization=gpu_memory_utilization,
         max_lora_rank=max_lora_rank,
         vllm_base_url=vllm_base_url,
+        n_gpus=n_gpus,
+        tensor_parallel_size=tensor_parallel_size,
         art_model_name=art_model_name,
         art_project=art_project,
         art_path=art_path,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1086,8 +1086,9 @@ class LoRAGRPOAlgorithm(Algorithm):
         # vLLM configuration
         gpu_memory_utilization: Optional[float] = None,
         max_lora_rank: Optional[int] = None,
-        # Multi-GPU configuration (verl backend)
+        # Multi-GPU/multi-node configuration (verl backend)
         n_gpus: Optional[int] = None,
+        nnodes: Optional[int] = None,
         tensor_parallel_size: Optional[int] = None,
         # ART configuration
         art_model_name: Optional[str] = None,
@@ -1314,8 +1315,9 @@ def lora_grpo(
     # vLLM configuration
     gpu_memory_utilization: float = 0.45,
     max_lora_rank: Optional[int] = None,
-    # Multi-GPU configuration (verl backend)
+    # Multi-GPU/multi-node configuration (verl backend)
     n_gpus: int = 1,
+    nnodes: int = 1,
     tensor_parallel_size: int = 1,
     # ART configuration
     art_model_name: Optional[str] = None,
@@ -1484,6 +1486,7 @@ def lora_grpo(
         gpu_memory_utilization=gpu_memory_utilization,
         max_lora_rank=max_lora_rank,
         n_gpus=n_gpus,
+        nnodes=nnodes,
         tensor_parallel_size=tensor_parallel_size,
         use_dr_grpo=use_dr_grpo,
         art_model_name=art_model_name,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1324,7 +1324,7 @@ def lora_grpo(
     # Algorithm variant
     use_dr_grpo: bool = True,
     # Backend selection
-    backend: str = "art",
+    backend: str = "verl",
     # Callbacks
     iteration_callback: Optional[Callable] = None,
     # Logging / experiment tracking
@@ -1388,7 +1388,8 @@ def lora_grpo(
             model, uses token-level loss normalization instead of KL regularization.
             Saves GPU memory and generally improves training efficiency.
             Only supported with verl backend. Falls back to standard GRPO on ART.
-        backend: Backend to use (default: 'art').
+        backend: Backend to use (default: 'verl'). Options: 'verl' (multi-GPU,
+            FSDP, Dr. GRPO support) or 'art' (single-GPU, Unsloth).
         iteration_callback: Callback after each iteration: (iteration_num, results_dict).
 
         wandb_project: Weights & Biases project name.

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1321,6 +1321,8 @@ def lora_grpo(
     art_model_name: Optional[str] = None,
     art_project: Optional[str] = None,
     art_path: Optional[str] = None,
+    # Algorithm variant
+    use_dr_grpo: bool = True,
     # Backend selection
     backend: str = "art",
     # Callbacks
@@ -1382,6 +1384,10 @@ def lora_grpo(
         art_project: ART project name (default: 'training-hub-grpo').
         art_path: Path for ART backend storage.
 
+        use_dr_grpo: Use Dr. GRPO variant (default: True). Removes the reference
+            model, uses token-level loss normalization instead of KL regularization.
+            Saves GPU memory and has shown stronger results in ALFWorld benchmarks.
+            Only supported with verl backend. Falls back to standard GRPO on ART.
         backend: Backend to use (default: 'art').
         iteration_callback: Callback after each iteration: (iteration_num, results_dict).
 
@@ -1478,6 +1484,7 @@ def lora_grpo(
         max_lora_rank=max_lora_rank,
         n_gpus=n_gpus,
         tensor_parallel_size=tensor_parallel_size,
+        use_dr_grpo=use_dr_grpo,
         art_model_name=art_model_name,
         art_project=art_project,
         art_path=art_path,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1386,7 +1386,7 @@ def lora_grpo(
 
         use_dr_grpo: Use Dr. GRPO variant (default: True). Removes the reference
             model, uses token-level loss normalization instead of KL regularization.
-            Saves GPU memory and has shown stronger results in ALFWorld benchmarks.
+            Saves GPU memory and generally improves training efficiency.
             Only supported with verl backend. Falls back to standard GRPO on ART.
         backend: Backend to use (default: 'art').
         iteration_callback: Callback after each iteration: (iteration_num, results_dict).

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -27,7 +27,6 @@ import logging
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -409,17 +408,37 @@ class VeRLLoRAGRPOBackend(Backend):
             "trainer.save_freq=5",
             "trainer.test_freq=-1",
             "trainer.val_before_train=False",
-            'trainer.logger=["console"]',
             "trainer.project_name=training-hub-grpo",
-            f"trainer.experiment_name=lora_grpo",
+            "trainer.experiment_name=lora_grpo",
             f"trainer.default_local_dir={ckpt_output_dir}/checkpoints",
             "trainer.resume_mode=auto",
         ]
 
-        # Add wandb/mlflow logging if configured
-        if algorithm_params.get("wandb_project"):
-            cmd.append(f'trainer.logger=["console","wandb"]')
-            cmd.append(f"trainer.project_name={algorithm_params['wandb_project']}")
+        # Experiment tracking (with env var fallbacks, matching other algorithms)
+        loggers = ["console"]
+        wandb_project = algorithm_params.get("wandb_project") or os.environ.get("WANDB_PROJECT")
+        mlflow_tracking_uri = algorithm_params.get("mlflow_tracking_uri") or os.environ.get("MLFLOW_TRACKING_URI")
+
+        if wandb_project:
+            loggers.append("wandb")
+            cmd.append(f"trainer.project_name={wandb_project}")
+        if mlflow_tracking_uri:
+            loggers.append("mlflow")
+            mlflow_experiment_name = (
+                algorithm_params.get("mlflow_experiment_name")
+                or os.environ.get("MLFLOW_EXPERIMENT_NAME")
+            )
+            if mlflow_experiment_name and not wandb_project:
+                # verl maps project_name → MLflow experiment
+                cmd.append(f"trainer.project_name={mlflow_experiment_name}")
+
+        wandb_run_name = algorithm_params.get("wandb_run_name") or os.environ.get("WANDB_RUN_NAME")
+        mlflow_run_name = algorithm_params.get("mlflow_run_name") or os.environ.get("MLFLOW_RUN_NAME")
+        if wandb_run_name or mlflow_run_name:
+            experiment_name = wandb_run_name or mlflow_run_name
+            cmd.append(f"trainer.experiment_name={experiment_name}")
+
+        cmd.append(f'trainer.logger={json.dumps(loggers)}')
 
         logger.info(
             "Starting verl GRPO training: model=%s, n_gpus=%d, "
@@ -434,6 +453,13 @@ class VeRLLoRAGRPOBackend(Backend):
         env["NCCL_DEBUG"] = "WARN"
         env["VLLM_LOGGING_LEVEL"] = "WARN"
         env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "true"
+
+        # Pass tracking env vars to subprocess
+        wandb_entity = algorithm_params.get("wandb_entity") or os.environ.get("WANDB_ENTITY")
+        if wandb_entity:
+            env["WANDB_ENTITY"] = wandb_entity
+        if mlflow_tracking_uri:
+            env["MLFLOW_TRACKING_URI"] = mlflow_tracking_uri
         # Add output dir to PYTHONPATH so verl can import the custom agent loop
         env["PYTHONPATH"] = ckpt_output_dir + ":" + env.get("PYTHONPATH", "")
 

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -357,8 +357,10 @@ class VeRLLoRAGRPOBackend(Backend):
         n_gpus = algorithm_params.get("n_gpus", 1)
         tp_size = algorithm_params.get("tensor_parallel_size", 1)
 
-        # Effective batch size: tasks_per_iteration * group_size
-        train_batch_size = tasks_per_iteration * group_size
+        # train_batch_size = number of prompts per batch. verl's rollout.n
+        # (set from group_size) controls how many rollouts per prompt, so
+        # batch size should NOT be multiplied by group_size.
+        train_batch_size = tasks_per_iteration
 
         # Build verl command
         cmd = [

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -79,6 +79,7 @@ def _prepare_verl_data(
             for ctx_msg in s.get("context_messages", []):
                 prompt.append(ctx_msg)
 
+            tools = s.get("tools", [])
             row = {
                 "prompt": prompt,
                 "reward_model": {
@@ -87,7 +88,11 @@ def _prepare_verl_data(
                         "tool_args": s["target_arguments"],
                     }),
                 },
-                "tools": json.dumps(s.get("tools", [])),
+                "extra_info": {
+                    "index": len(rows),
+                    "tools_kwargs": {"tools": tools} if tools else {},
+                    "need_tools_kwargs": bool(tools),
+                },
                 "data_source": "tool_call",
             }
             rows.append(row)
@@ -161,42 +166,45 @@ def tool_call_compute_score(data_source, solution_str, ground_truth, **kwargs):
 def _extract_tool_call_from_text(text):
     """Extract tool call from model-generated text.
 
-    Handles multiple formats:
-    - JSON function call: {"name": "...", "arguments": {...}}
-    - Tool call tags: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
+    Handles Qwen3 format: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
+    Also handles thinking blocks and various JSON formats.
     """
     if not text:
         return None, {}
 
     import re
 
-    # Try to find JSON with name/arguments pattern
-    patterns = [
-        r'<tool_call>\\s*(\\{.*?\\})\\s*</tool_call>',
-        r'\\{"name":\\s*"([^"]+)".*?"arguments":\\s*(\\{.*?\\})\\s*\\}',
-    ]
+    # Strip thinking blocks first
+    text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
 
-    for pattern in patterns:
-        match = re.search(pattern, text, re.DOTALL)
-        if match:
-            try:
-                if match.lastindex == 1:
-                    obj = json.loads(match.group(1))
-                    return obj.get("name"), obj.get("arguments", {})
-                else:
-                    name = match.group(1)
-                    args = json.loads(match.group(2))
-                    return name, args
-            except json.JSONDecodeError:
-                continue
+    # Try <tool_call> tags (Qwen3 format) - use greedy match for nested braces
+    tc_match = re.search(r'<tool_call>\\s*(.+?)\\s*</tool_call>', text, re.DOTALL)
+    if tc_match:
+        try:
+            obj = json.loads(tc_match.group(1))
+            if isinstance(obj, dict):
+                return obj.get("name"), obj.get("arguments", {})
+        except json.JSONDecodeError:
+            pass
 
-    # Try parsing the entire text as JSON
-    try:
-        obj = json.loads(text.strip())
-        if isinstance(obj, dict) and "name" in obj:
-            return obj["name"], obj.get("arguments", {})
-    except json.JSONDecodeError:
-        pass
+    # Try to find any JSON object with name+arguments
+    # Find all { } balanced blocks
+    for match in re.finditer(r'\\{', text):
+        start = match.start()
+        depth = 0
+        for i in range(start, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    try:
+                        obj = json.loads(text[start:i+1])
+                        if isinstance(obj, dict) and "name" in obj:
+                            return obj["name"], obj.get("arguments", {})
+                    except json.JSONDecodeError:
+                        pass
+                    break
 
     return None, {}
 
@@ -312,6 +320,7 @@ class VeRLLoRAGRPOBackend(Backend):
             f"data.max_response_length={max_tokens}",
             "data.filter_overlong_prompts=True",
             "data.truncation=error",
+            "data.need_tools_kwargs=True",
             # Model + LoRA
             f"actor_rollout_ref.model.path={model_path}",
             f"actor_rollout_ref.model.lora_rank={lora_r}",

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -1,0 +1,403 @@
+"""verl backend for LoRA + GRPO training.
+
+Provides multi-GPU distributed GRPO training using the verl framework
+(Volcano Engine Reinforcement Learning for LLMs). Uses FSDP for distributed
+LoRA training and vLLM for parallel rollout generation.
+
+This backend supports scaling to large models (70B+) across multiple GPUs,
+unlike the ART backend which is limited to single-GPU time-sharing.
+
+Usage:
+    from training_hub import lora_grpo
+
+    # Single-turn tool-call training on 8 GPUs
+    result = lora_grpo(
+        model_path="Qwen/Qwen3-4B",
+        data_path="Agent-Ark/Toucan-1.5M",
+        ckpt_output_dir="./grpo_output",
+        backend="verl",
+        num_iterations=15,
+        group_size=8,
+        n_gpus=8,
+    )
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from . import Backend, AlgorithmRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _prepare_verl_data(
+    data_path: str,
+    output_dir: str,
+    n_train: int = 5000,
+    n_val: int = 500,
+    data_config: str = "Qwen3",
+) -> tuple[str, str]:
+    """Convert training data to verl's expected Parquet format.
+
+    verl expects a Parquet file with at minimum a 'prompt' column containing
+    chat messages (list of dicts with role/content). Additional columns like
+    'ground_truth' are passed through to the reward function.
+
+    For tool-call data, each sample becomes a row with:
+    - prompt: [system_msg, user_msg, ...context_msgs] (messages up to the turn)
+    - ground_truth: {"tool_name": ..., "tool_args": ...} (expected tool call)
+    - tools: list of tool definitions (for the tools= API parameter)
+
+    Returns:
+        (train_parquet_path, val_parquet_path)
+    """
+    import pandas as pd
+
+    # Use our existing data loading + decomposition
+    from .lora_grpo import _load_local_dataset, _load_tool_call_dataset
+
+    if data_path.endswith((".json", ".jsonl")):
+        train_data, val_data = _load_local_dataset(data_path, n_train, n_val)
+    else:
+        train_data, val_data = _load_tool_call_dataset(
+            data_path, n_train=n_train, n_val=n_val, data_config=data_config,
+        )
+
+    def samples_to_parquet(samples, path):
+        rows = []
+        for s in samples:
+            # Build the prompt messages (everything the model sees before generating)
+            prompt = [{"role": "system", "content": s.get("system_prompt", "")}]
+            prompt.append({"role": "user", "content": s["question"]})
+            # Add GT context for multi-turn samples
+            for ctx_msg in s.get("context_messages", []):
+                prompt.append(ctx_msg)
+
+            row = {
+                "prompt": prompt,
+                "reward_model": {
+                    "ground_truth": json.dumps({
+                        "tool_name": s["target_tool_name"],
+                        "tool_args": s["target_arguments"],
+                    }),
+                },
+                "tools": json.dumps(s.get("tools", [])),
+                "data_source": "tool_call",
+            }
+            rows.append(row)
+
+        df = pd.DataFrame(rows)
+        df.to_parquet(path, index=False)
+        logger.info("Saved %d samples to %s", len(rows), path)
+        return path
+
+    os.makedirs(output_dir, exist_ok=True)
+    train_path = os.path.join(output_dir, "train.parquet")
+    val_path = os.path.join(output_dir, "val.parquet")
+
+    samples_to_parquet(train_data, train_path)
+    if val_data:
+        samples_to_parquet(val_data, val_path)
+    else:
+        # verl requires a val file, create a small one from train
+        samples_to_parquet(train_data[:min(50, len(train_data))], val_path)
+
+    return train_path, val_path
+
+
+def _write_reward_function(output_dir: str) -> str:
+    """Write the tool-call reward function for verl to load.
+
+    verl loads custom reward functions from a file path + function name.
+    This writes a standalone reward module that verl can import.
+
+    Returns:
+        Path to the reward function file.
+    """
+    reward_code = '''
+"""Tool-call reward function for verl GRPO training."""
+import json
+
+
+def tool_call_compute_score(data_source, solution_str, ground_truth, **kwargs):
+    """Compute reward for tool-call verification.
+
+    Called by verl's reward manager for each generated response.
+
+    Args:
+        data_source: Dataset identifier (unused, always "tool_call")
+        solution_str: The model's generated response text
+        ground_truth: JSON string with {"tool_name": ..., "tool_args": ...}
+
+    Returns:
+        float: 1.0 (correct name + args), 0.5 (correct name), 0.0 (wrong/missing)
+    """
+    gt = json.loads(ground_truth) if isinstance(ground_truth, str) else ground_truth
+    expected_name = gt["tool_name"]
+    expected_args = gt.get("tool_args", {})
+
+    # Extract tool call from the model's response
+    # verl passes the raw generated text — we need to parse tool calls from it
+    predicted_name, predicted_args = _extract_tool_call_from_text(solution_str)
+
+    if predicted_name is None:
+        return 0.0
+
+    if not _names_match(predicted_name, expected_name):
+        return 0.0
+
+    if _args_match(predicted_args, expected_args):
+        return 1.0
+
+    return 0.5
+
+
+def _extract_tool_call_from_text(text):
+    """Extract tool call from model-generated text.
+
+    Handles multiple formats:
+    - JSON function call: {"name": "...", "arguments": {...}}
+    - Tool call tags: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
+    """
+    if not text:
+        return None, {}
+
+    import re
+
+    # Try to find JSON with name/arguments pattern
+    patterns = [
+        r'<tool_call>\\s*(\\{.*?\\})\\s*</tool_call>',
+        r'\\{"name":\\s*"([^"]+)".*?"arguments":\\s*(\\{.*?\\})\\s*\\}',
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, text, re.DOTALL)
+        if match:
+            try:
+                if match.lastindex == 1:
+                    obj = json.loads(match.group(1))
+                    return obj.get("name"), obj.get("arguments", {})
+                else:
+                    name = match.group(1)
+                    args = json.loads(match.group(2))
+                    return name, args
+            except json.JSONDecodeError:
+                continue
+
+    # Try parsing the entire text as JSON
+    try:
+        obj = json.loads(text.strip())
+        if isinstance(obj, dict) and "name" in obj:
+            return obj["name"], obj.get("arguments", {})
+    except json.JSONDecodeError:
+        pass
+
+    return None, {}
+
+
+def _names_match(predicted, expected):
+    if predicted == expected:
+        return True
+    if predicted.endswith(expected) or expected.endswith(predicted):
+        return True
+    p = predicted.lower().replace("-", "_").replace(".", "_")
+    e = expected.lower().replace("-", "_").replace(".", "_")
+    return p == e or p.endswith(e) or e.endswith(p)
+
+
+def _args_match(predicted, expected):
+    if isinstance(predicted, str):
+        try:
+            predicted = json.loads(predicted)
+        except json.JSONDecodeError:
+            return False
+    if isinstance(expected, str):
+        try:
+            expected = json.loads(expected)
+        except json.JSONDecodeError:
+            return False
+    if not predicted and not expected:
+        return True
+    if not predicted or not expected:
+        return False
+    try:
+        return json.dumps(_normalize(predicted), sort_keys=True) == json.dumps(_normalize(expected), sort_keys=True)
+    except (TypeError, ValueError):
+        return False
+
+
+def _normalize(args):
+    normalized = {}
+    for k, v in args.items():
+        if isinstance(v, str):
+            try:
+                v = int(v)
+            except ValueError:
+                try:
+                    v = float(v)
+                except ValueError:
+                    v = v.strip()
+        normalized[k] = v
+    return normalized
+'''
+    reward_path = os.path.join(output_dir, "verl_reward.py")
+    with open(reward_path, "w") as f:
+        f.write(reward_code)
+    return reward_path
+
+
+class VeRLLoRAGRPOBackend(Backend):
+    """verl backend for distributed multi-GPU LoRA + GRPO training.
+
+    Uses verl's FSDP for distributed LoRA training and vLLM for parallel
+    rollout generation. Supports scaling to 70B+ models across multiple GPUs.
+    """
+
+    def execute_training(self, algorithm_params: Dict[str, Any]) -> Any:
+        """Execute LoRA GRPO training using verl."""
+        ckpt_output_dir = algorithm_params["ckpt_output_dir"]
+        os.makedirs(ckpt_output_dir, exist_ok=True)
+
+        # Prepare data in verl's Parquet format
+        data_path = algorithm_params.get("data_path")
+        if data_path is None:
+            raise ValueError("data_path is required for verl backend")
+
+        data_dir = os.path.join(ckpt_output_dir, "verl_data")
+        train_path, val_path = _prepare_verl_data(
+            data_path=data_path,
+            output_dir=data_dir,
+            n_train=algorithm_params.get("n_train", 5000),
+            n_val=algorithm_params.get("n_val", 500),
+            data_config=algorithm_params.get("data_config", "Qwen3"),
+        )
+
+        # Write reward function
+        reward_path = _write_reward_function(ckpt_output_dir)
+
+        # Extract parameters
+        model_path = algorithm_params["model_path"]
+        num_iterations = algorithm_params.get("num_iterations", 15)
+        group_size = algorithm_params.get("group_size", 8)
+        tasks_per_iteration = algorithm_params.get("tasks_per_iteration", 100)
+        learning_rate = algorithm_params.get("learning_rate", 1e-5)
+        lora_r = algorithm_params.get("lora_r", 16)
+        lora_alpha = algorithm_params.get("lora_alpha", 8)
+        max_tokens = algorithm_params.get("max_tokens", 512)
+        temperature = algorithm_params.get("temperature", 0.7)
+        gpu_memory_utilization = algorithm_params.get("gpu_memory_utilization", 0.35)
+        n_gpus = algorithm_params.get("n_gpus", 1)
+        tp_size = algorithm_params.get("tensor_parallel_size", 1)
+
+        # Effective batch size: tasks_per_iteration * group_size
+        train_batch_size = tasks_per_iteration * group_size
+
+        # Build verl command
+        cmd = [
+            sys.executable, "-m", "verl.trainer.main_ppo",
+            # Algorithm
+            "algorithm.adv_estimator=grpo",
+            "algorithm.use_kl_in_reward=False",
+            # Data
+            f"data.train_files={train_path}",
+            f"data.val_files={val_path}",
+            f"data.train_batch_size={train_batch_size}",
+            f"data.max_prompt_length=4096",
+            f"data.max_response_length={max_tokens}",
+            "data.filter_overlong_prompts=True",
+            "data.truncation=error",
+            # Model + LoRA
+            f"actor_rollout_ref.model.path={model_path}",
+            f"actor_rollout_ref.model.lora_rank={lora_r}",
+            f"actor_rollout_ref.model.lora_alpha={lora_alpha}",
+            "actor_rollout_ref.model.enable_gradient_checkpointing=True",
+            "actor_rollout_ref.model.use_remove_padding=True",
+            # Actor (training)
+            f"actor_rollout_ref.actor.optim.lr={learning_rate}",
+            f"actor_rollout_ref.actor.ppo_mini_batch_size={min(train_batch_size, 256)}",
+            f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 4)}",
+            "actor_rollout_ref.actor.use_kl_loss=False",
+            "actor_rollout_ref.actor.entropy_coeff=0",
+            "actor_rollout_ref.actor.fsdp_config.param_offload=False",
+            "actor_rollout_ref.actor.fsdp_config.optimizer_offload=False",
+            # Rollout (vLLM)
+            "actor_rollout_ref.rollout.name=vllm",
+            f"actor_rollout_ref.rollout.tensor_model_parallel_size={tp_size}",
+            f"actor_rollout_ref.rollout.n={group_size}",
+            f"actor_rollout_ref.rollout.gpu_memory_utilization={gpu_memory_utilization}",
+            "actor_rollout_ref.rollout.load_format=safetensors",
+            f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 4)}",
+            # Reference model
+            "actor_rollout_ref.ref.fsdp_config.param_offload=True",
+            f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 4)}",
+            # Reward
+            f"reward.custom_reward_function.path={reward_path}",
+            "reward.custom_reward_function.name=tool_call_compute_score",
+            # Trainer
+            "trainer.critic_warmup=0",
+            f"trainer.n_gpus_per_node={n_gpus}",
+            "trainer.nnodes=1",
+            f"trainer.total_epochs={num_iterations}",
+            "trainer.save_freq=5",
+            "trainer.test_freq=-1",
+            "trainer.val_before_train=False",
+            'trainer.logger=["console"]',
+            "trainer.project_name=training-hub-grpo",
+            f"trainer.experiment_name=lora_grpo",
+            f"trainer.default_local_dir={ckpt_output_dir}/checkpoints",
+            "trainer.resume_mode=auto",
+        ]
+
+        # Add wandb/mlflow logging if configured
+        if algorithm_params.get("wandb_project"):
+            cmd.append(f'trainer.logger=["console","wandb"]')
+            cmd.append(f"trainer.project_name={algorithm_params['wandb_project']}")
+
+        logger.info(
+            "Starting verl GRPO training: model=%s, n_gpus=%d, "
+            "lora_r=%d, lr=%s, epochs=%d, batch=%d, group=%d",
+            model_path, n_gpus, lora_r, learning_rate,
+            num_iterations, train_batch_size, group_size,
+        )
+
+        # Run verl as a subprocess
+        env = os.environ.copy()
+        env["TOKENIZERS_PARALLELISM"] = "true"
+        env["NCCL_DEBUG"] = "WARN"
+        env["VLLM_LOGGING_LEVEL"] = "WARN"
+        env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "true"
+
+        result = subprocess.run(
+            cmd,
+            env=env,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"verl training failed with exit code {result.returncode}"
+            )
+
+        # Collect results
+        return {
+            "status": "success",
+            "checkpoint_path": os.path.join(ckpt_output_dir, "checkpoints"),
+            "backend": "verl",
+            "model_path": model_path,
+            "n_gpus": n_gpus,
+            "lora_r": lora_r,
+            "num_iterations": num_iterations,
+        }
+
+
+# Register the verl backend for the lora_grpo algorithm
+# (algorithm is already registered by lora_grpo.py, we just add a new backend)
+try:
+    AlgorithmRegistry.register_backend("lora_grpo", "verl", VeRLLoRAGRPOBackend)
+except ValueError:
+    pass  # Algorithm not registered yet (import order), will be registered on first use

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -312,6 +312,50 @@ def _write_agent_loop(output_dir: str) -> tuple[str, str]:
     return dst, installed_path
 
 
+def _normalize_verl_checkpoints(checkpoint_dir: str) -> list[str]:
+    """Merge tokenizer files into verl's lora_adapter dirs for direct vLLM use.
+
+    verl saves adapter weights and tokenizer files in separate subdirs:
+        global_step_N/actor/lora_adapter/{adapter_config.json, adapter_model.safetensors}
+        global_step_N/actor/huggingface/{tokenizer files, config.json}
+
+    This copies the huggingface files into lora_adapter/ so that directory
+    is self-contained and directly loadable by vLLM as a LoRA adapter path.
+    The full checkpoint (FSDP state, optimizer, etc.) is preserved for resume.
+
+    Returns:
+        List of paths to the usable lora_adapter checkpoint directories.
+    """
+    import shutil
+
+    adapter_paths = []
+    if not os.path.exists(checkpoint_dir):
+        return adapter_paths
+
+    for entry in sorted(os.listdir(checkpoint_dir)):
+        if not entry.startswith("global_step_"):
+            continue
+
+        raw_dir = os.path.join(checkpoint_dir, entry)
+        lora_dir = os.path.join(raw_dir, "actor", "lora_adapter")
+        hf_dir = os.path.join(raw_dir, "actor", "huggingface")
+
+        if not os.path.isdir(lora_dir):
+            continue
+
+        # Copy tokenizer/config files into lora_adapter dir
+        if os.path.isdir(hf_dir):
+            for f in os.listdir(hf_dir):
+                dst = os.path.join(lora_dir, f)
+                if not os.path.exists(dst):  # don't overwrite adapter files
+                    shutil.copy2(os.path.join(hf_dir, f), dst)
+
+        adapter_paths.append(lora_dir)
+        logger.info("Normalized checkpoint: %s/actor/lora_adapter/", entry)
+
+    return adapter_paths
+
+
 class VeRLLoRAGRPOBackend(Backend):
     """verl backend for distributed multi-GPU LoRA + GRPO training.
 
@@ -362,6 +406,13 @@ class VeRLLoRAGRPOBackend(Backend):
         # batch size should NOT be multiplied by group_size.
         train_batch_size = tasks_per_iteration
 
+        # Calculate steps per epoch for checkpoint frequency.
+        # Save once per epoch by default so each epoch has a usable checkpoint.
+        import pandas as pd
+        train_dataset_size = len(pd.read_parquet(train_path))
+        steps_per_epoch = max(1, (train_dataset_size + train_batch_size - 1) // train_batch_size)
+        save_freq = steps_per_epoch
+
         # Build verl command
         cmd = [
             sys.executable, "-m", "verl.trainer.main_ppo",
@@ -408,7 +459,7 @@ class VeRLLoRAGRPOBackend(Backend):
             f"trainer.n_gpus_per_node={n_gpus}",
             "trainer.nnodes=1",
             f"trainer.total_epochs={num_iterations}",
-            "trainer.save_freq=5",
+            f"trainer.save_freq={save_freq}",
             "trainer.test_freq=-1",
             "trainer.val_before_train=False",
             "trainer.project_name=training-hub-grpo",
@@ -466,20 +517,82 @@ class VeRLLoRAGRPOBackend(Backend):
         # Add output dir to PYTHONPATH so verl can import the custom agent loop
         env["PYTHONPATH"] = ckpt_output_dir + ":" + env.get("PYTHONPATH", "")
 
-        result = subprocess.run(
-            cmd,
-            env=env,
-        )
+        # Stream output to stdout, log file, and parse metrics live
+        import re
+        log_path = os.path.join(ckpt_output_dir, "verl_training.log")
+        metrics_path = os.path.join(ckpt_output_dir, "training_metrics.jsonl")
+        reward_history = []
+        step_pattern = re.compile(r'step:(\d+)\s*-\s*(.*)')
 
-        if result.returncode != 0:
+        with open(log_path, "w") as log_file:
+            proc = subprocess.Popen(
+                cmd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            for line in proc.stdout:
+                # Stream to stdout live
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                # Save to log file
+                log_file.write(line)
+                log_file.flush()
+
+                # Parse step metrics and write training_metrics.jsonl live
+                match = step_pattern.search(line)
+                if match:
+                    step = int(match.group(1))
+                    metrics_str = match.group(2)
+                    raw = {}
+                    for kv in metrics_str.split(" - "):
+                        kv = kv.strip()
+                        if ":" not in kv:
+                            continue
+                        key, val = kv.split(":", 1)
+                        try:
+                            raw[key.strip()] = float(val.strip())
+                        except ValueError:
+                            pass
+
+                    entry = {
+                        "step": step,
+                        "epoch": raw.get("training/epoch", 0),
+                        "mean_reward": raw.get("critic/score/mean", 0),
+                        "loss": raw.get("actor/pg_loss"),
+                        "grad_norm": raw.get("actor/grad_norm"),
+                        "learning_rate": raw.get("actor/lr"),
+                        "entropy": raw.get("actor/entropy"),
+                        "response_length_mean": raw.get("response_length/mean"),
+                        "prompt_length_mean": raw.get("prompt_length/mean"),
+                        "wall_time_s": raw.get("timing_s/step"),
+                    }
+                    entry = {k: v for k, v in entry.items() if v is not None}
+                    reward_history.append(entry.get("mean_reward", 0))
+
+                    with open(metrics_path, "a") as mf:
+                        mf.write(json.dumps(entry) + "\n")
+                        mf.flush()
+
+            proc.wait()
+
+        if proc.returncode != 0:
             raise RuntimeError(
-                f"verl training failed with exit code {result.returncode}"
+                f"verl training failed with exit code {proc.returncode}"
             )
 
-        # Collect results
+        # Post-training: normalize checkpoints into flat adapter dirs
+        # (matching ART's format for uniform vLLM loading)
+        checkpoint_dir = os.path.join(ckpt_output_dir, "checkpoints")
+        adapter_checkpoints = _normalize_verl_checkpoints(checkpoint_dir)
+
         return {
             "status": "success",
-            "checkpoint_path": os.path.join(ckpt_output_dir, "checkpoints"),
+            "checkpoint_path": checkpoint_dir,
+            "adapter_checkpoints": adapter_checkpoints,
+            "reward_history": reward_history,
             "backend": "verl",
             "model_path": model_path,
             "n_gpus": n_gpus,

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -260,6 +260,41 @@ def _normalize(args):
     return reward_path
 
 
+def _write_agent_loop(output_dir: str) -> tuple[str, str]:
+    """Write a single-turn tool-calling agent loop for verl.
+
+    verl's default SingleTurnAgentLoop doesn't pass tools to the chat template.
+    This custom agent loop passes tools from the dataset's tools_kwargs field,
+    enabling models like Qwen3 to generate structured tool calls.
+
+    Returns:
+        (agent_module_path, agent_config_path)
+    """
+    import shutil
+
+    # Copy the agent loop module to the output dir
+    src = os.path.join(os.path.dirname(__file__), "verl_tool_agent.py")
+    dst = os.path.join(output_dir, "verl_tool_agent.py")
+    shutil.copy2(src, dst)
+
+    # Also install it into verl's agent_loop directory so Ray workers can import it
+    import verl.experimental.agent_loop as agent_loop_pkg
+    agent_loop_dir = os.path.dirname(agent_loop_pkg.__file__)
+    installed_path = os.path.join(agent_loop_dir, "verl_tool_agent.py")
+    shutil.copy2(src, installed_path)
+
+    # Patch the __init__.py to import it
+    init_path = os.path.join(agent_loop_dir, "__init__.py")
+    with open(init_path, "r") as f:
+        init_content = f.read()
+    if "verl_tool_agent" not in init_content:
+        with open(init_path, "a") as f:
+            f.write("\nfrom .verl_tool_agent import SingleTurnToolAgentLoop\n")
+            f.write("_ = [*_, SingleTurnToolAgentLoop]\n")
+
+    return dst, installed_path
+
+
 class VeRLLoRAGRPOBackend(Backend):
     """verl backend for distributed multi-GPU LoRA + GRPO training.
 
@@ -286,8 +321,9 @@ class VeRLLoRAGRPOBackend(Backend):
             data_config=algorithm_params.get("data_config", "Qwen3"),
         )
 
-        # Write reward function
+        # Write reward function and install custom agent loop
         reward_path = _write_reward_function(ckpt_output_dir)
+        _write_agent_loop(ckpt_output_dir)
 
         # Extract parameters
         model_path = algorithm_params["model_path"]
@@ -320,7 +356,6 @@ class VeRLLoRAGRPOBackend(Backend):
             f"data.max_response_length={max_tokens}",
             "data.filter_overlong_prompts=True",
             "data.truncation=error",
-            "data.need_tools_kwargs=True",
             # Model + LoRA
             f"actor_rollout_ref.model.path={model_path}",
             f"actor_rollout_ref.model.lora_rank={lora_r}",
@@ -381,6 +416,8 @@ class VeRLLoRAGRPOBackend(Backend):
         env["NCCL_DEBUG"] = "WARN"
         env["VLLM_LOGGING_LEVEL"] = "WARN"
         env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "true"
+        # Add output dir to PYTHONPATH so verl can import the custom agent loop
+        env["PYTHONPATH"] = ckpt_output_dir + ":" + env.get("PYTHONPATH", "")
 
         result = subprocess.run(
             cmd,

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -351,6 +351,7 @@ class VeRLLoRAGRPOBackend(Backend):
         lora_r = algorithm_params.get("lora_r", 16)
         lora_alpha = algorithm_params.get("lora_alpha", 8)
         max_tokens = algorithm_params.get("max_tokens", 512)
+        max_prompt_length = algorithm_params.get("max_prompt_length", 16384)
         temperature = algorithm_params.get("temperature", 0.7)
         gpu_memory_utilization = algorithm_params.get("gpu_memory_utilization", 0.35)
         n_gpus = algorithm_params.get("n_gpus", 1)
@@ -369,7 +370,7 @@ class VeRLLoRAGRPOBackend(Backend):
             f"data.train_files={train_path}",
             f"data.val_files={val_path}",
             f"data.train_batch_size={train_batch_size}",
-            f"data.max_prompt_length=8192",
+            f"data.max_prompt_length={max_prompt_length}",
             f"data.max_response_length={max_tokens}",
             "data.filter_overlong_prompts=True",
             "data.truncation=error",

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -80,6 +80,26 @@ def _prepare_verl_data(
                 prompt.append(ctx_msg)
 
             tools = s.get("tools", [])
+
+            # Embed tools in the system prompt so the model sees tool definitions
+            # during generation. This is simpler than configuring verl's tool agent
+            # loop and works with the default SingleTurnAgentLoop.
+            if tools:
+                tools_text = json.dumps(tools, indent=2)
+                tools_instruction = (
+                    "\n\nYou have access to the following tools. To call a tool, "
+                    "respond with a JSON object in this format: "
+                    '{"name": "tool_name", "arguments": {"arg1": "value1"}}\n\n'
+                    f"Tools:\n{tools_text}"
+                )
+                if prompt and prompt[0]["role"] == "system":
+                    prompt[0] = {
+                        "role": "system",
+                        "content": prompt[0]["content"] + tools_instruction,
+                    }
+                else:
+                    prompt.insert(0, {"role": "system", "content": tools_instruction})
+
             row = {
                 "prompt": prompt,
                 "reward_model": {
@@ -90,8 +110,6 @@ def _prepare_verl_data(
                 },
                 "extra_info": {
                     "index": len(rows),
-                    "tools_kwargs": {"tools": tools} if tools else {},
-                    "need_tools_kwargs": bool(tools),
                 },
                 "data_source": "tool_call",
             }
@@ -352,7 +370,7 @@ class VeRLLoRAGRPOBackend(Backend):
             f"data.train_files={train_path}",
             f"data.val_files={val_path}",
             f"data.train_batch_size={train_batch_size}",
-            f"data.max_prompt_length=4096",
+            f"data.max_prompt_length=8192",
             f"data.max_response_length={max_tokens}",
             "data.filter_overlong_prompts=True",
             "data.truncation=error",
@@ -365,7 +383,7 @@ class VeRLLoRAGRPOBackend(Backend):
             # Actor (training)
             f"actor_rollout_ref.actor.optim.lr={learning_rate}",
             f"actor_rollout_ref.actor.ppo_mini_batch_size={min(train_batch_size, 256)}",
-            f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 4)}",
+            f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 2)}",
             "actor_rollout_ref.actor.use_kl_loss=False",
             "actor_rollout_ref.actor.entropy_coeff=0",
             "actor_rollout_ref.actor.fsdp_config.param_offload=False",
@@ -376,10 +394,10 @@ class VeRLLoRAGRPOBackend(Backend):
             f"actor_rollout_ref.rollout.n={group_size}",
             f"actor_rollout_ref.rollout.gpu_memory_utilization={gpu_memory_utilization}",
             "actor_rollout_ref.rollout.load_format=safetensors",
-            f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 4)}",
+            f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 2)}",
             # Reference model
             "actor_rollout_ref.ref.fsdp_config.param_offload=True",
-            f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 4)}",
+            f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 2)}",
             # Reward
             f"reward.custom_reward_function.path={reward_path}",
             "reward.custom_reward_function.name=tool_call_compute_score",

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -508,7 +508,6 @@ class VeRLLoRAGRPOBackend(Backend):
         env["NCCL_DEBUG"] = "WARN"
         env["VLLM_LOGGING_LEVEL"] = "WARN"
         env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "true"
-        env["HF_HUB_OFFLINE"] = "1"  # use cached model, avoid HF timeouts during training
 
         # Pass tracking env vars to subprocess
         wandb_entity = algorithm_params.get("wandb_entity") or os.environ.get("WANDB_ENTITY")

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -72,6 +72,13 @@ def _prepare_verl_data(
             system_prompt=system_prompt, data_source=data_source,
         )
 
+    if reward_type == "custom":
+        return _prepare_generic_data(
+            data_path, train_path, val_path,
+            n_train=n_train, n_val=n_val,
+            system_prompt=system_prompt, data_source=data_source or "custom",
+        )
+
     # Tool-call data loading + decomposition
     from .lora_grpo import _load_local_dataset, _load_tool_call_dataset
 
@@ -140,6 +147,73 @@ def _prepare_verl_data(
         # verl requires a val file, create a small one from train
         samples_to_parquet(train_data[:min(50, len(train_data))], val_path)
 
+    return train_path, val_path
+
+
+def _prepare_generic_data(
+    data_path: str,
+    train_path: str,
+    val_path: str,
+    n_train: int = 5000,
+    n_val: int = 500,
+    system_prompt: str = None,
+    data_source: str = "custom",
+) -> tuple[str, str]:
+    """Prepare generic data for verl GRPO with custom reward functions.
+
+    Expects JSONL with 'question' and 'ground_truth' fields.
+    Optionally, samples can include 'messages' (list of chat messages)
+    instead of 'question'.
+
+    The ground_truth is passed to the reward function via
+    reward_model.ground_truth in the parquet schema.
+    """
+    import pandas as pd
+
+    with open(data_path) as f:
+        raw = [json.loads(line) for line in f if line.strip()]
+
+    samples = raw[:n_train]
+    val_samples = raw[n_train:n_train + n_val] if n_val > 0 else []
+
+    default_sys = system_prompt or ""
+
+    def build_rows(data):
+        rows = []
+        for i, s in enumerate(data):
+            # Build prompt from 'messages' or 'question'
+            if "messages" in s:
+                prompt = s["messages"]
+            elif "question" in s:
+                prompt = []
+                if default_sys:
+                    prompt.append({"role": "system", "content": default_sys})
+                prompt.append({"role": "user", "content": s["question"]})
+            else:
+                logger.warning("Sample %d has no 'question' or 'messages', skipping", i)
+                continue
+
+            gt = s.get("ground_truth", s.get("answer", ""))
+
+            rows.append({
+                "data_source": data_source,
+                "prompt": prompt,
+                "reward_model": {"style": "rule", "ground_truth": str(gt)},
+                "extra_info": {"index": i},
+            })
+        return rows
+
+    train_rows = build_rows(samples)
+    pd.DataFrame(train_rows).to_parquet(train_path, index=False)
+
+    if val_samples:
+        val_rows = build_rows(val_samples)
+        pd.DataFrame(val_rows).to_parquet(val_path, index=False)
+    else:
+        pd.DataFrame(train_rows[:min(5, len(train_rows))]).to_parquet(val_path, index=False)
+
+    logger.info("Prepared generic data: %d train, %d val", len(train_rows),
+                len(val_samples) if val_samples else min(5, len(train_rows)))
     return train_path, val_path
 
 
@@ -411,20 +485,6 @@ def _write_custom_reward_function(reward_fn, output_dir: str) -> str:
     source = textwrap.dedent(source)
     fn_name = reward_fn.__name__
 
-    # Get the module-level imports the function might need
-    fn_module = inspect.getmodule(reward_fn)
-    module_source = ""
-    if fn_module is not None:
-        try:
-            full_source = inspect.getsource(fn_module)
-            # Extract import lines from the module
-            imports = [line for line in full_source.split("\n")
-                       if line.strip().startswith(("import ", "from "))]
-            if imports:
-                module_source = "\n".join(imports) + "\n\n"
-        except (TypeError, OSError):
-            pass
-
     # If the function isn't named compute_score, add an alias
     alias = ""
     if fn_name != "compute_score":
@@ -432,7 +492,7 @@ def _write_custom_reward_function(reward_fn, output_dir: str) -> str:
 
     reward_path = os.path.join(output_dir, "verl_custom_reward.py")
     with open(reward_path, "w") as f:
-        f.write(module_source + source + alias)
+        f.write(source + alias)
 
     logger.info("Wrote custom reward function to %s (fn=%s)", reward_path, fn_name)
     return reward_path
@@ -678,7 +738,10 @@ class VeRLLoRAGRPOBackend(Backend):
         if data_path is None:
             raise ValueError("data_path is required for verl backend")
 
+        reward_fn = algorithm_params.get("reward_fn")
         reward_type = algorithm_params.get("reward_type", "tool_call")
+        if reward_fn is not None and reward_type == "tool_call":
+            reward_type = "custom"
 
         data_dir = os.path.join(ckpt_output_dir, "verl_data")
         train_path, val_path = _prepare_verl_data(

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -41,6 +41,9 @@ def _prepare_verl_data(
     n_train: int = 5000,
     n_val: int = 500,
     data_config: str = "Qwen3",
+    reward_type: str = "tool_call",
+    system_prompt: str = None,
+    data_source: str = None,
 ) -> tuple[str, str]:
     """Convert training data to verl's expected Parquet format.
 
@@ -48,17 +51,28 @@ def _prepare_verl_data(
     chat messages (list of dicts with role/content). Additional columns like
     'ground_truth' are passed through to the reward function.
 
-    For tool-call data, each sample becomes a row with:
-    - prompt: [system_msg, user_msg, ...context_msgs] (messages up to the turn)
-    - ground_truth: {"tool_name": ..., "tool_args": ...} (expected tool call)
-    - tools: list of tool definitions (for the tools= API parameter)
+    Supports two reward types:
+    - "tool_call": Tool-call verification (decomposed multi-turn traces)
+    - "math": Math answer verification via verl's built-in verifiers
+      (data should have 'problem' and 'answer' fields)
 
     Returns:
         (train_parquet_path, val_parquet_path)
     """
     import pandas as pd
 
-    # Use our existing data loading + decomposition
+    os.makedirs(output_dir, exist_ok=True)
+    train_path = os.path.join(output_dir, "train.parquet")
+    val_path = os.path.join(output_dir, "val.parquet")
+
+    if reward_type == "math":
+        return _prepare_math_data(
+            data_path, train_path, val_path,
+            n_train=n_train, n_val=n_val,
+            system_prompt=system_prompt, data_source=data_source,
+        )
+
+    # Tool-call data loading + decomposition
     from .lora_grpo import _load_local_dataset, _load_tool_call_dataset
 
     if data_path.endswith((".json", ".jsonl")):
@@ -119,10 +133,6 @@ def _prepare_verl_data(
         logger.info("Saved %d samples to %s", len(rows), path)
         return path
 
-    os.makedirs(output_dir, exist_ok=True)
-    train_path = os.path.join(output_dir, "train.parquet")
-    val_path = os.path.join(output_dir, "val.parquet")
-
     samples_to_parquet(train_data, train_path)
     if val_data:
         samples_to_parquet(val_data, val_path)
@@ -131,6 +141,247 @@ def _prepare_verl_data(
         samples_to_parquet(train_data[:min(50, len(train_data))], val_path)
 
     return train_path, val_path
+
+
+def _prepare_math_data(
+    data_path: str,
+    train_path: str,
+    val_path: str,
+    n_train: int = 5000,
+    n_val: int = 500,
+    system_prompt: str = None,
+    data_source: str = None,
+) -> tuple[str, str]:
+    """Prepare math problem data for verl GRPO training.
+
+    Expects JSONL with 'problem' and 'answer' fields. Uses verl's built-in
+    math reward verifiers (routes via data_source field).
+
+    Returns:
+        (train_parquet_path, val_parquet_path)
+    """
+    import pandas as pd
+
+    if system_prompt is None:
+        system_prompt = (
+            "Please reason step by step, and put your final answer "
+            "within \\boxed{}."
+        )
+
+    with open(data_path) as f:
+        raw = [json.loads(line) for line in f if line.strip()]
+
+    # Auto-detect data_source from filename if not specified
+    if data_source is None:
+        basename = os.path.basename(data_path).lower()
+        if "aime" in basename:
+            # Extract year if present
+            import re
+            year_match = re.search(r'(\d{4})', basename)
+            data_source = f"aime{year_match.group(1)}" if year_match else "aime"
+        elif "gsm8k" in basename:
+            data_source = "openai/gsm8k"
+        elif "math" in basename:
+            data_source = "lighteval/MATH"
+        else:
+            data_source = "math"
+
+    rows = []
+    for i, p in enumerate(raw):
+        # Support both 'problem' and 'question' field names
+        problem_text = p.get("problem") or p.get("question", "")
+        answer = str(p.get("answer", ""))
+
+        row = {
+            "prompt": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": problem_text},
+            ],
+            "reward_model": {
+                "ground_truth": answer,
+            },
+            "extra_info": {
+                "index": i,
+            },
+            "data_source": data_source,
+        }
+        rows.append(row)
+
+    train_rows = rows[:n_train]
+    val_rows = rows[n_train:n_train + n_val] if n_val > 0 else rows[:min(50, len(rows))]
+
+    pd.DataFrame(train_rows).to_parquet(train_path, index=False)
+    pd.DataFrame(val_rows).to_parquet(val_path, index=False)
+    logger.info("Saved %d math problems to %s (data_source=%s)", len(train_rows), train_path, data_source)
+
+    return train_path, val_path
+
+
+def _write_math_reward_function(output_dir: str) -> str:
+    """Write a math answer verification reward function for verl.
+
+    Uses math_verify for robust semantic comparison (handles LaTeX
+    equivalence like \\frac{1}{2} == 0.5). Falls back to string
+    matching if math_verify is not installed.
+
+    Returns:
+        Path to the reward function file.
+    """
+    reward_code = '''
+"""Math answer verification reward function for verl GRPO training.
+
+Extracts answers from \\boxed{} or <answer> tags and compares to ground truth
+using math_verify for semantic equivalence. Returns 1.0 for correct, 0.0 for wrong.
+
+Requires: pip install math-verify
+"""
+import re
+import logging
+
+logging.getLogger("math_verify").setLevel(logging.ERROR)
+
+
+def math_compute_score(data_source, solution_str, ground_truth, **kwargs):
+    """Compute reward for math answer verification.
+
+    Extracts the last \\boxed{} from the response, then uses math_verify
+    for semantic comparison with ground truth. Falls back to normalized
+    string matching if math_verify fails.
+
+    Args:
+        data_source: Dataset identifier (e.g., "aime2024", "math")
+        solution_str: The model's generated solution text
+        ground_truth: The correct answer as a string
+
+    Returns:
+        float: 1.0 if correct, 0.0 if wrong
+    """
+    if isinstance(ground_truth, dict):
+        ground_truth = ground_truth.get("ground_truth", ground_truth)
+    ground_truth = str(ground_truth).strip()
+
+    try:
+        predicted = _extract_answer(solution_str)
+        if predicted is None:
+            return 0.0
+        return 1.0 if _verify(predicted, ground_truth) else 0.0
+    except Exception:
+        return 0.0
+
+
+def _extract_answer(text):
+    """Extract answer from model output.
+
+    Priority:
+    1. Last \\boxed{...}
+    2. <answer>...</answer> or <answer>... (stop consumed closing tag)
+    3. Full text (let math_verify handle extraction)
+    """
+    if not text:
+        return None
+
+    # Try last \\boxed{...}
+    boxed = _last_boxed(text)
+    if boxed is not None:
+        return _remove_boxed(boxed)
+
+    # Try <answer>...</answer>
+    m = re.search(r"<answer>\\s*(.+?)\\s*</answer>", text, re.DOTALL)
+    if m:
+        ans = m.group(1).strip()
+        # Remove boxed wrapper if present inside
+        inner_boxed = _last_boxed(ans)
+        if inner_boxed:
+            return _remove_boxed(inner_boxed)
+        return ans
+
+    # Try <answer>... at end (stop sequence consumed </answer>)
+    m = re.search(r"<answer>\\s*(.+?)\\s*$", text, re.DOTALL)
+    if m:
+        ans = m.group(1).strip()
+        inner_boxed = _last_boxed(ans)
+        if inner_boxed:
+            return _remove_boxed(inner_boxed)
+        return ans
+
+    # Fall back to full text (math_verify can often extract from it)
+    return text.strip()
+
+
+def _last_boxed(string):
+    """Find the last \\boxed{...} expression using brace counting."""
+    idx = string.rfind("\\\\boxed{")
+    if idx < 0:
+        idx = string.rfind("\\\\fbox{")
+        if idx < 0:
+            return None
+
+    i = idx
+    depth = 0
+    while i < len(string):
+        if string[i] == "{":
+            depth += 1
+        elif string[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return string[idx:i + 1]
+        i += 1
+    return None
+
+
+def _remove_boxed(s):
+    """Remove \\boxed{} or \\fbox{} wrapper."""
+    for prefix in ["\\\\boxed{", "\\\\fbox{"]:
+        if s.startswith(prefix) and s.endswith("}"):
+            return s[len(prefix):-1]
+    if "\\\\boxed " in s:
+        return s.split("\\\\boxed ")[-1].split("$")[0]
+    return s
+
+
+def _normalize_latex(text):
+    """Normalize LaTeX variants for comparison."""
+    text = re.sub(r"\\\\[dt]frac", r"\\\\frac", text)
+    text = re.sub(r"\\\\frac\\s*([^{\\s])\\s*([^{\\s])", r"\\\\frac{\\1}{\\2}", text)
+    return text
+
+
+def _verify(predicted, ground_truth):
+    """Verify answer using math_verify, with string fallback."""
+    predicted = predicted.strip()
+    ground_truth = ground_truth.strip()
+
+    # Quick exact match
+    if predicted == ground_truth:
+        return True
+
+    # Normalize and try again
+    pred_norm = _normalize_latex(predicted)
+    truth_norm = _normalize_latex(ground_truth)
+    if pred_norm == truth_norm:
+        return True
+
+    # Use math_verify for semantic comparison
+    try:
+        import math_verify
+        pred_parsed = math_verify.parse(pred_norm, parsing_timeout=5)
+        truth_parsed = math_verify.parse(truth_norm, parsing_timeout=5)
+        if not pred_parsed or not truth_parsed:
+            return False
+        return math_verify.verify(truth_parsed, pred_parsed)
+    except ImportError:
+        # Fallback: simple numeric comparison
+        try:
+            return abs(float(predicted) - float(ground_truth)) < 1e-6
+        except (ValueError, TypeError):
+            return False
+    except Exception:
+        return False
+'''
+    reward_path = os.path.join(output_dir, "verl_math_reward.py")
+    with open(reward_path, "w") as f:
+        f.write(reward_code)
+    return reward_path
 
 
 def _write_reward_function(output_dir: str) -> str:
@@ -373,6 +624,8 @@ class VeRLLoRAGRPOBackend(Backend):
         if data_path is None:
             raise ValueError("data_path is required for verl backend")
 
+        reward_type = algorithm_params.get("reward_type", "tool_call")
+
         data_dir = os.path.join(ckpt_output_dir, "verl_data")
         train_path, val_path = _prepare_verl_data(
             data_path=data_path,
@@ -380,11 +633,19 @@ class VeRLLoRAGRPOBackend(Backend):
             n_train=algorithm_params.get("n_train", 5000),
             n_val=algorithm_params.get("n_val", 500),
             data_config=algorithm_params.get("data_config", "Qwen3"),
+            reward_type=reward_type,
+            system_prompt=algorithm_params.get("system_prompt"),
+            data_source=algorithm_params.get("data_source"),
         )
 
-        # Write reward function and install custom agent loop
-        reward_path = _write_reward_function(ckpt_output_dir)
-        _write_agent_loop(ckpt_output_dir)
+        # Write reward function (and agent loop for tool_call mode)
+        if reward_type == "tool_call":
+            reward_path = _write_reward_function(ckpt_output_dir)
+            _write_agent_loop(ckpt_output_dir)
+        elif reward_type == "math":
+            reward_path = _write_math_reward_function(ckpt_output_dir)
+        else:
+            reward_path = None
 
         # Extract parameters
         model_path = algorithm_params["model_path"]
@@ -400,6 +661,7 @@ class VeRLLoRAGRPOBackend(Backend):
         gpu_memory_utilization = algorithm_params.get("gpu_memory_utilization", 0.35)
         n_gpus = algorithm_params.get("n_gpus", 1)
         tp_size = algorithm_params.get("tensor_parallel_size", 1)
+        use_dr_grpo = algorithm_params.get("use_dr_grpo", True)
 
         # train_batch_size = number of prompts per batch. verl's rollout.n
         # (set from group_size) controls how many rollouts per prompt, so
@@ -420,6 +682,14 @@ class VeRLLoRAGRPOBackend(Backend):
             # Algorithm
             "algorithm.adv_estimator=grpo",
             "algorithm.use_kl_in_reward=False",
+        ]
+
+        # Dr. GRPO: no reference model, token-level normalization
+        if use_dr_grpo:
+            cmd.append("algorithm.norm_adv_by_std_in_grpo=False")
+            logger.info("Using Dr. GRPO: no ref model, token-level loss normalization")
+
+        cmd.extend([
             # Data
             f"data.train_files={train_path}",
             f"data.val_files={val_path}",
@@ -438,23 +708,36 @@ class VeRLLoRAGRPOBackend(Backend):
             f"actor_rollout_ref.actor.optim.lr={learning_rate}",
             f"actor_rollout_ref.actor.ppo_mini_batch_size={min(train_batch_size, 256)}",
             f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1",
-            "actor_rollout_ref.actor.use_kl_loss=False",
             "actor_rollout_ref.actor.entropy_coeff=0",
             "actor_rollout_ref.actor.fsdp_config.param_offload=False",
             "actor_rollout_ref.actor.fsdp_config.optimizer_offload=False",
+        ])
+
+        # Actor KL and loss settings depend on Dr. GRPO vs standard
+        if use_dr_grpo:
+            cmd.extend([
+                "actor_rollout_ref.actor.use_kl_loss=False",
+                "actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-sum-norm",
+            ])
+        else:
+            cmd.extend([
+                "actor_rollout_ref.actor.use_kl_loss=True",
+                "actor_rollout_ref.actor.kl_loss_coef=0.01",
+                "actor_rollout_ref.actor.kl_loss_type=low_var_kl",
+            ])
+
+        cmd.extend([
             # Rollout (vLLM)
             "actor_rollout_ref.rollout.name=vllm",
             f"actor_rollout_ref.rollout.tensor_model_parallel_size={tp_size}",
             f"actor_rollout_ref.rollout.n={group_size}",
             f"actor_rollout_ref.rollout.gpu_memory_utilization={gpu_memory_utilization}",
+            f"actor_rollout_ref.rollout.max_model_len={max_prompt_length + max_tokens}",
             "actor_rollout_ref.rollout.load_format=safetensors",
             f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 2)}",
-            # Reference model
+            # Reference model (only used when not Dr. GRPO)
             "actor_rollout_ref.ref.fsdp_config.param_offload=True",
             f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 2)}",
-            # Reward
-            f"reward.custom_reward_function.path={reward_path}",
-            "reward.custom_reward_function.name=tool_call_compute_score",
             # Trainer
             "trainer.critic_warmup=0",
             f"trainer.n_gpus_per_node={n_gpus}",
@@ -467,7 +750,19 @@ class VeRLLoRAGRPOBackend(Backend):
             "trainer.experiment_name=lora_grpo",
             f"trainer.default_local_dir={ckpt_output_dir}/checkpoints",
             "trainer.resume_mode=auto",
-        ]
+        ])
+
+        # Reward configuration
+        if reward_type == "tool_call":
+            cmd.extend([
+                f"reward.custom_reward_function.path={reward_path}",
+                "reward.custom_reward_function.name=tool_call_compute_score",
+            ])
+        elif reward_type == "math":
+            cmd.extend([
+                f"reward.custom_reward_function.path={reward_path}",
+                "reward.custom_reward_function.name=math_compute_score",
+            ])
 
         # Experiment tracking (with env var fallbacks, matching other algorithms)
         loggers = ["console"]

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -642,7 +642,7 @@ def _normalize(args):
     return reward_path
 
 
-def _write_agent_loop(output_dir: str) -> tuple[str, str]:
+def _write_agent_loop(output_dir: str) -> str:
     """Write a single-turn tool-calling agent loop for verl.
 
     verl's default SingleTurnAgentLoop doesn't pass tools to the chat template.
@@ -650,7 +650,7 @@ def _write_agent_loop(output_dir: str) -> tuple[str, str]:
     enabling models like Qwen3 to generate structured tool calls.
 
     Returns:
-        (agent_module_path, agent_config_path)
+        Path to the agent loop module in output_dir.
     """
     import shutil
 
@@ -659,22 +659,27 @@ def _write_agent_loop(output_dir: str) -> tuple[str, str]:
     dst = os.path.join(output_dir, "verl_tool_agent.py")
     shutil.copy2(src, dst)
 
-    # Also install it into verl's agent_loop directory so Ray workers can import it
-    import verl.experimental.agent_loop as agent_loop_pkg
-    agent_loop_dir = os.path.dirname(agent_loop_pkg.__file__)
-    installed_path = os.path.join(agent_loop_dir, "verl_tool_agent.py")
-    shutil.copy2(src, installed_path)
+    # Try to install it into verl's agent_loop directory so Ray workers can
+    # import it. This may fail on read-only container filesystems (e.g., KubeRay
+    # custom images), which is fine — the module is still available via PYTHONPATH.
+    try:
+        import verl.experimental.agent_loop as agent_loop_pkg
+        agent_loop_dir = os.path.dirname(agent_loop_pkg.__file__)
+        installed_path = os.path.join(agent_loop_dir, "verl_tool_agent.py")
+        shutil.copy2(src, installed_path)
 
-    # Patch the __init__.py to import it
-    init_path = os.path.join(agent_loop_dir, "__init__.py")
-    with open(init_path, "r") as f:
-        init_content = f.read()
-    if "verl_tool_agent" not in init_content:
-        with open(init_path, "a") as f:
-            f.write("\nfrom .verl_tool_agent import SingleTurnToolAgentLoop\n")
-            f.write("_ = [*_, SingleTurnToolAgentLoop]\n")
+        # Patch the __init__.py to import it
+        init_path = os.path.join(agent_loop_dir, "__init__.py")
+        with open(init_path, "r") as f:
+            init_content = f.read()
+        if "verl_tool_agent" not in init_content:
+            with open(init_path, "a") as f:
+                f.write("\nfrom .verl_tool_agent import SingleTurnToolAgentLoop\n")
+                f.write("_ = [*_, SingleTurnToolAgentLoop]\n")
+    except (PermissionError, OSError) as e:
+        logger.warning("Could not install agent loop into verl package dir: %s", e)
 
-    return dst, installed_path
+    return dst
 
 
 def _normalize_verl_checkpoints(checkpoint_dir: str) -> list[str]:
@@ -780,6 +785,7 @@ class VeRLLoRAGRPOBackend(Backend):
         temperature = algorithm_params.get("temperature", 0.7)
         gpu_memory_utilization = algorithm_params.get("gpu_memory_utilization", 0.35)
         n_gpus = algorithm_params.get("n_gpus", 1)
+        nnodes = algorithm_params.get("nnodes", 1)
         tp_size = algorithm_params.get("tensor_parallel_size", 1)
         use_dr_grpo = algorithm_params.get("use_dr_grpo", True)
 
@@ -861,7 +867,7 @@ class VeRLLoRAGRPOBackend(Backend):
             # Trainer
             "trainer.critic_warmup=0",
             f"trainer.n_gpus_per_node={n_gpus}",
-            "trainer.nnodes=1",
+            f"trainer.nnodes={nnodes}",
             f"trainer.total_epochs={num_iterations}",
             f"trainer.save_freq={save_freq}",
             "trainer.test_freq=-1",

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -168,7 +168,7 @@ def tool_call_compute_score(data_source, solution_str, ground_truth, **kwargs):
     # verl passes the raw generated text — we need to parse tool calls from it
     predicted_name, predicted_args = _extract_tool_call_from_text(solution_str)
 
-    if predicted_name is None:
+    if predicted_name is None or not isinstance(predicted_name, str):
         return 0.0
 
     if not _names_match(predicted_name, expected_name):
@@ -407,11 +407,12 @@ class VeRLLoRAGRPOBackend(Backend):
         train_batch_size = tasks_per_iteration
 
         # Calculate steps per epoch for checkpoint frequency.
-        # Save once per epoch by default so each epoch has a usable checkpoint.
+        # Default: save once per epoch. Can be overridden via saves_per_epoch.
         import pandas as pd
         train_dataset_size = len(pd.read_parquet(train_path))
         steps_per_epoch = max(1, (train_dataset_size + train_batch_size - 1) // train_batch_size)
-        save_freq = steps_per_epoch
+        saves_per_epoch = algorithm_params.get("saves_per_epoch", 1)
+        save_freq = max(1, steps_per_epoch // saves_per_epoch)
 
         # Build verl command
         cmd = [
@@ -436,7 +437,7 @@ class VeRLLoRAGRPOBackend(Backend):
             # Actor (training)
             f"actor_rollout_ref.actor.optim.lr={learning_rate}",
             f"actor_rollout_ref.actor.ppo_mini_batch_size={min(train_batch_size, 256)}",
-            f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu={min(train_batch_size // max(n_gpus, 1), 2)}",
+            f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1",
             "actor_rollout_ref.actor.use_kl_loss=False",
             "actor_rollout_ref.actor.entropy_coeff=0",
             "actor_rollout_ref.actor.fsdp_config.param_offload=False",
@@ -507,6 +508,7 @@ class VeRLLoRAGRPOBackend(Backend):
         env["NCCL_DEBUG"] = "WARN"
         env["VLLM_LOGGING_LEVEL"] = "WARN"
         env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "true"
+        env["HF_HUB_OFFLINE"] = "1"  # use cached model, avoid HF timeouts during training
 
         # Pass tracking env vars to subprocess
         wandb_entity = algorithm_params.get("wandb_entity") or os.environ.get("WANDB_ENTITY")
@@ -582,6 +584,47 @@ class VeRLLoRAGRPOBackend(Backend):
             raise RuntimeError(
                 f"verl training failed with exit code {proc.returncode}"
             )
+
+        # Re-parse log file to fill in any gaps in training_metrics.jsonl
+        # (covers steps that were missed due to stdout buffering)
+        logged_steps = set()
+        if os.path.exists(metrics_path):
+            with open(metrics_path) as mf:
+                for line in mf:
+                    if line.strip():
+                        logged_steps.add(json.loads(line).get("step"))
+
+        with open(log_path) as lf:
+            for line in lf:
+                match = step_pattern.search(line)
+                if match and int(match.group(1)) not in logged_steps:
+                    step = int(match.group(1))
+                    raw = {}
+                    for kv in match.group(2).split(" - "):
+                        kv = kv.strip()
+                        if ":" not in kv:
+                            continue
+                        key, val = kv.split(":", 1)
+                        try:
+                            raw[key.strip()] = float(val.strip())
+                        except ValueError:
+                            pass
+                    entry = {
+                        "step": step,
+                        "epoch": raw.get("training/epoch", 0),
+                        "mean_reward": raw.get("critic/score/mean", 0),
+                        "loss": raw.get("actor/pg_loss"),
+                        "grad_norm": raw.get("actor/grad_norm"),
+                        "learning_rate": raw.get("actor/lr"),
+                        "entropy": raw.get("actor/entropy"),
+                        "response_length_mean": raw.get("response_length/mean"),
+                        "prompt_length_mean": raw.get("prompt_length/mean"),
+                        "wall_time_s": raw.get("timing_s/step"),
+                    }
+                    entry = {k: v for k, v in entry.items() if v is not None}
+                    reward_history.append(entry.get("mean_reward", 0))
+                    with open(metrics_path, "a") as mf:
+                        mf.write(json.dumps(entry) + "\n")
 
         # Post-training: normalize checkpoints into flat adapter dirs
         # (matching ART's format for uniform vLLM loading)

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -384,6 +384,60 @@ def _verify(predicted, ground_truth):
     return reward_path
 
 
+def _write_custom_reward_function(reward_fn, output_dir: str) -> str:
+    """Write a user-provided reward function to a file for verl to load.
+
+    The function is serialized via inspect.getsource. It must be a standalone
+    function (no closures over local variables) with the verl reward signature:
+        compute_score(data_source, solution_str, ground_truth, extra_info=None, **kwargs) -> float
+
+    If the function has a different name, a wrapper is generated that calls it
+    as `compute_score`.
+
+    Returns:
+        Path to the reward function file.
+    """
+    import inspect
+    import textwrap
+
+    # If reward_fn is a string, treat it as a path to a reward file
+    if isinstance(reward_fn, str):
+        if os.path.isfile(reward_fn):
+            logger.info("Using reward function file directly: %s", reward_fn)
+            return reward_fn
+        raise FileNotFoundError(f"Reward function file not found: {reward_fn}")
+
+    source = inspect.getsource(reward_fn)
+    source = textwrap.dedent(source)
+    fn_name = reward_fn.__name__
+
+    # Get the module-level imports the function might need
+    fn_module = inspect.getmodule(reward_fn)
+    module_source = ""
+    if fn_module is not None:
+        try:
+            full_source = inspect.getsource(fn_module)
+            # Extract import lines from the module
+            imports = [line for line in full_source.split("\n")
+                       if line.strip().startswith(("import ", "from "))]
+            if imports:
+                module_source = "\n".join(imports) + "\n\n"
+        except (TypeError, OSError):
+            pass
+
+    # If the function isn't named compute_score, add an alias
+    alias = ""
+    if fn_name != "compute_score":
+        alias = f"\ncompute_score = {fn_name}\n"
+
+    reward_path = os.path.join(output_dir, "verl_custom_reward.py")
+    with open(reward_path, "w") as f:
+        f.write(module_source + source + alias)
+
+    logger.info("Wrote custom reward function to %s (fn=%s)", reward_path, fn_name)
+    return reward_path
+
+
 def _write_reward_function(output_dir: str) -> str:
     """Write the tool-call reward function for verl to load.
 
@@ -639,7 +693,10 @@ class VeRLLoRAGRPOBackend(Backend):
         )
 
         # Write reward function (and agent loop for tool_call mode)
-        if reward_type == "tool_call":
+        reward_fn = algorithm_params.get("reward_fn")
+        if reward_fn is not None:
+            reward_path = _write_custom_reward_function(reward_fn, ckpt_output_dir)
+        elif reward_type == "tool_call":
             reward_path = _write_reward_function(ckpt_output_dir)
             _write_agent_loop(ckpt_output_dir)
         elif reward_type == "math":
@@ -753,7 +810,12 @@ class VeRLLoRAGRPOBackend(Backend):
         ])
 
         # Reward configuration
-        if reward_type == "tool_call":
+        if reward_fn is not None:
+            cmd.extend([
+                f"reward.custom_reward_function.path={reward_path}",
+                "reward.custom_reward_function.name=compute_score",
+            ])
+        elif reward_type == "tool_call":
             cmd.extend([
                 f"reward.custom_reward_function.path={reward_path}",
                 "reward.custom_reward_function.name=tool_call_compute_score",

--- a/src/training_hub/algorithms/rewards.py
+++ b/src/training_hub/algorithms/rewards.py
@@ -1,0 +1,178 @@
+"""Built-in reward functions for GRPO training.
+
+Provides reusable reward functions for common RL verification scenarios.
+Users can also define custom reward functions with the signature:
+    (model_response, expected, **kwargs) -> float
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def tool_call_reward(
+    model_response: Any,
+    expected_name: str,
+    expected_args: dict,
+) -> float:
+    """Compute reward based on tool call correctness.
+
+    Compares the model's tool call output against expected name and arguments.
+    Handles both OpenAI Choice objects and dict-format messages.
+
+    Args:
+        model_response: The OpenAI ChatCompletion Choice or message object.
+        expected_name: The expected tool/function name.
+        expected_args: The expected arguments dict.
+
+    Returns:
+        1.0 — correct tool name AND correct arguments
+        0.5 — correct tool name, wrong/partial arguments
+        0.0 — wrong tool name or no tool call
+    """
+    predicted_name, predicted_args = _extract_tool_call(model_response)
+
+    if predicted_name is None:
+        return 0.0
+
+    if not _names_match(predicted_name, expected_name):
+        return 0.0
+
+    if _args_match(predicted_args, expected_args):
+        return 1.0
+
+    return 0.5
+
+
+def binary_reward(reward_value: float, threshold: float = 1.0) -> float:
+    """Convert a continuous reward to binary pass/fail.
+
+    Args:
+        reward_value: The continuous reward value.
+        threshold: The threshold for pass (default: 1.0).
+
+    Returns:
+        1.0 if reward_value >= threshold (within epsilon), else 0.0.
+    """
+    if reward_value >= threshold - 1e-6:
+        return 1.0
+    return 0.0
+
+
+def _extract_tool_call(message: Any) -> tuple[str | None, dict]:
+    """Extract tool call name and arguments from an OpenAI message."""
+    # Handle Choice object
+    if hasattr(message, "message"):
+        message = message.message
+
+    # Check tool_calls (modern format)
+    if hasattr(message, "tool_calls") and message.tool_calls:
+        tc = message.tool_calls[0]
+        name = tc.function.name
+        args_str = tc.function.arguments
+        if isinstance(args_str, str):
+            try:
+                args = json.loads(args_str)
+            except json.JSONDecodeError:
+                args = {}
+        else:
+            args = args_str or {}
+        return name, args
+
+    # Check function_call (legacy format)
+    if hasattr(message, "function_call") and message.function_call:
+        name = message.function_call.name
+        args_str = message.function_call.arguments
+        if isinstance(args_str, str):
+            try:
+                args = json.loads(args_str)
+            except json.JSONDecodeError:
+                args = {}
+        else:
+            args = args_str or {}
+        return name, args
+
+    # Dict format
+    if isinstance(message, dict):
+        if "tool_calls" in message and message["tool_calls"]:
+            tc = message["tool_calls"][0]
+            name = tc.get("function", {}).get("name")
+            args = tc.get("function", {}).get("arguments", {})
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {}
+            return name, args
+        if "function_call" in message and message["function_call"]:
+            name = message["function_call"].get("name")
+            args = message["function_call"].get("arguments", {})
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {}
+            return name, args
+
+    return None, {}
+
+
+def _names_match(predicted: str, expected: str) -> bool:
+    """Check if tool names match, handling common variations."""
+    if predicted == expected:
+        return True
+    if predicted.endswith(expected) or expected.endswith(predicted):
+        return True
+    p = predicted.lower().replace("-", "_").replace(".", "_")
+    e = expected.lower().replace("-", "_").replace(".", "_")
+    if p == e:
+        return True
+    if p.endswith(e) or e.endswith(p):
+        return True
+    return False
+
+
+def _args_match(predicted: dict, expected: dict) -> bool:
+    """Check if arguments match, with type coercion and normalization."""
+    if isinstance(predicted, str):
+        try:
+            predicted = json.loads(predicted)
+        except json.JSONDecodeError:
+            return False
+    if isinstance(expected, str):
+        try:
+            expected = json.loads(expected)
+        except json.JSONDecodeError:
+            return False
+
+    if not predicted and not expected:
+        return True
+    if not predicted or not expected:
+        return False
+
+    try:
+        pred_normalized = json.dumps(_normalize_args(predicted), sort_keys=True)
+        exp_normalized = json.dumps(_normalize_args(expected), sort_keys=True)
+        return pred_normalized == exp_normalized
+    except (TypeError, ValueError, AttributeError):
+        return False
+
+
+def _normalize_args(args: dict) -> dict:
+    """Normalize argument values for comparison."""
+    normalized = {}
+    for k, v in args.items():
+        if isinstance(v, str):
+            try:
+                v = int(v)
+            except ValueError:
+                try:
+                    v = float(v)
+                except ValueError:
+                    v = v.strip()
+        normalized[k] = v
+    return normalized

--- a/src/training_hub/algorithms/verl_tool_agent.py
+++ b/src/training_hub/algorithms/verl_tool_agent.py
@@ -1,0 +1,88 @@
+"""Single-turn tool-calling agent loop for verl.
+
+A minimal agent loop that passes tools to the chat template so the model
+generates structured tool calls. Used by the verl backend for tool-call
+GRPO training.
+
+This is a drop-in replacement for verl's SingleTurnAgentLoop that adds
+tool support via tools_kwargs from the dataset.
+"""
+import logging
+import os
+from typing import Any
+from uuid import uuid4
+
+from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput, register
+from verl.utils.profiler import simple_timer
+from verl.workers.rollout.replica import TokenOutput
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+@register("single_turn_tool_agent")
+class SingleTurnToolAgentLoop(AgentLoopBase):
+    """Single-turn agent loop that passes tools to the chat template.
+
+    Unlike the default SingleTurnAgentLoop, this passes tool definitions
+    from the dataset's tools_kwargs to apply_chat_template, enabling
+    models like Qwen3 to generate structured tool calls.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prompt_length = self.rollout_config.prompt_length
+        self.response_length = self.rollout_config.response_length
+
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        messages = list(kwargs["raw_prompt"])
+
+        # Extract tools from dataset's tools_kwargs
+        tools_kwargs = kwargs.get("tools_kwargs", {})
+        tools = tools_kwargs.get("tools", None)
+
+        # Extract images and videos from messages
+        multi_modal_data = await self.process_vision_info(messages)
+        images = multi_modal_data.get("images")
+        videos = multi_modal_data.get("videos")
+
+        # Apply chat template WITH tools
+        prompt_ids = await self.apply_chat_template(
+            messages,
+            tools=tools,
+            images=images,
+            videos=videos,
+        )
+
+        # Generate sequences
+        metrics = {}
+        with simple_timer("generate_sequences", metrics):
+            output: TokenOutput = await self.server_manager.generate(
+                request_id=uuid4().hex,
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=images,
+                video_data=videos,
+            )
+        if metrics.get("num_preempted") is None:
+            metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
+        response_mask = [1] * len(output.token_ids)
+
+        output: AgentLoopOutput = AgentLoopOutput(
+            prompt_ids=prompt_ids,
+            response_ids=output.token_ids[: self.response_length],
+            response_mask=response_mask[: self.response_length],
+            response_logprobs=output.log_probs[: self.response_length] if output.log_probs else None,
+            routed_experts=(
+                output.routed_experts[: len(prompt_ids) + self.response_length]
+                if output.routed_experts is not None
+                else None
+            ),
+            multi_modal_data=multi_modal_data,
+            num_turns=2,
+            metrics=metrics,
+            extra_fields=output.extra_fields,
+        )
+
+        output.extra_fields.update({"turn_scores": [], "tool_rewards": []})
+        return output


### PR DESCRIPTION
## Summary

Moves `instructlab-training`, `rhai-innovation-mini-trainer`, `numba`, and `llvmlite` from base `[project].dependencies` into a new `[lab]` optional extra, and guards the corresponding imports in `__init__.py` with `try/except`.

This resolves a `numba` version conflict when installing `training-hub` alongside `vllm` (which pins `numba==0.61.2`, conflicting with `numba>=0.62.0` required by `instructlab-training`). The GRPO/verl code paths don't use those packages, so making them optional is safe.

## Changes

- **`pyproject.toml`**: New `[lab]` extra containing `instructlab-training`, `rhai-innovation-mini-trainer`, `numba>=0.62.0`, `llvmlite>=0.42`. The `[cuda]` and `[lora]` extras now include `training-hub[lab]` so existing installs are unaffected.
- **`src/training_hub/__init__.py`**: Imports from `.algorithms.sft`, `.algorithms.osft`, `.algorithms.lora`, and `.profiling` are now guarded with `try/except ImportError` — they load when the backing packages are present and are silently skipped otherwise.
- **`docs/README.md`**: Updated install instructions to reflect the new `[lab]` extra for SFT/OSFT support.

## Motivation

Building a Ray GRPO runtime image ([distributed-workloads PR](https://github.com/opendatahub-io/distributed-workloads/pull/795)) requires `vllm 0.12.0` which pins `numba==0.61.2`. Currently this forces installing `training-hub` with `--no-deps` and patching `__init__.py` at image build time. This PR eliminates both workarounds.

## Naming

The extra is called `[lab]` since the dependencies (`instructlab-training`, `rhai-innovation-mini-trainer`) come from the InstructLab / Red Hat AI Innovation ecosystem and power the SFT and OSFT backends. Open to suggestions on naming.

## Test Plan
- [ ] `pip install training-hub` — base install loads, GRPO imports work, SFT/LoRA imports are skipped cleanly
- [ ] `pip install training-hub[lab]` — all SFT/OSFT imports work as before
- [ ] `pip install training-hub[cuda]` — pulls in lab deps + CUDA extras
- [ ] `pip install training-hub[lora]` — pulls in lab deps + LoRA extras
- [ ] `pip install training-hub[grpo]` — GRPO works without numba conflict