### PR TITLE
Support larger models, full fine-tuning, and Qwen3.5 in verl backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,10 @@ src/training_hub/
 │   ├── sft.py               # Supervised Fine-Tuning
 │   ├── osft.py              # Orthogonal Subspace Fine-Tuning
 │   ├── lora.py              # LoRA + SFT
+│   ├── lora_grpo.py         # LoRA + GRPO and GRPO (ART backend, algorithm, convenience fns)
+│   ├── lora_grpo_verl.py    # verl backend for LoRA + GRPO and GRPO
+│   ├── rewards.py           # Reward functions (tool_call_reward, binary_reward)
+│   ├── verl_tool_agent.py   # Custom verl agent loop for tool-call training
 │   └── peft_extender.py     # PEFT parameter handling for LoRA
 └── profiling/
     └── memory_estimator.py  # GPU memory estimation for training
@@ -101,10 +105,10 @@ Training Hub is designed to support multiple backends per algorithm:
 
 - **Files**: `snake_case.py`
 - **Classes**: `PascalCase` (e.g., `SFTAlgorithm`, `MiniTrainerOSFTBackend`)
-- **Functions**: `snake_case` (e.g., `sft()`, `osft()`, `lora_sft()`)
+- **Functions**: `snake_case` (e.g., `sft()`, `osft()`, `lora_sft()`, `lora_grpo()`, `grpo()`)
 - **Constants**: `UPPER_SNAKE_CASE` (e.g., `FLOAT32_BYTES_N`)
-- **Backend names**: kebab-case strings (e.g., `"instructlab-training"`, `"mini-trainer"`)
-- **Algorithm names**: lowercase (e.g., `"sft"`, `"osft"`, `"lora_sft"`)
+- **Backend names**: kebab-case strings (e.g., `"instructlab-training"`, `"mini-trainer"`, `"verl"`, `"art"`)
+- **Algorithm names**: lowercase (e.g., `"sft"`, `"osft"`, `"lora_sft"`, `"lora_grpo"`, `"grpo"`)
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,45 @@ There are no automated tests checked into the repo yet. When testing ART GRPO lo
 - **Install vllm separately after `[grpo]`.** `openpipe-art` declares vllm as a dependency but the prebuilt wheel may need manual installation to match CUDA/torch versions. After install, verify: `python -c "from vllm import _C; print('OK')"`. If `_C` import fails, the wheel was built for a different torch version.
 - **Verify flashinfer versions match:** `uv pip list | grep flashinfer` — `flashinfer-python` and `flashinfer-cubin` must be the same version. Mismatches crash the vLLM engine core subprocess silently.
 
+### Disk and Cache Management
+
+- **Set `TMPDIR` to a large filesystem** (e.g., NVMe) before launching training. Flash-attn and flashinfer JIT compilation write hundreds of MB of temp files to `/tmp`. If `/tmp` is on a small root partition, the build fills the disk silently and the compilation fails with no useful error. Also set `RAY_TMPDIR` for Ray socket paths (AF_UNIX paths have a 107-byte limit — deep NVMe paths can exceed this, use a short path like `/mnt/nvme0n1/tmp`).
+- **Clear flashinfer JIT cache when changing CUDA toolkit versions.** The cache at `~/.cache/flashinfer/` contains compiled kernels for a specific CUDA version. After upgrading nvcc, delete the cache: `rm -rf ~/.cache/flashinfer/`.
+- **Clear uv and pip caches periodically.** They can grow to 60-100GB on root. `uv cache clean` and `rm -rf ~/.cache/pip/`.
+- **vLLM compile cache** at `~/.cache/vllm/torch_compile_cache/` can also grow large. Safe to delete between runs.
+
+### Training Larger Models with verl (8B+)
+
+These lessons apply to models larger than Qwen3-4B on 80GB H100s with co-located FSDP+vLLM.
+
+- **Use `load_format=dummy` instead of `safetensors`** for the verl rollout config. With `safetensors`, vLLM loads the full model from disk during init on top of FSDP's copy, doubling GPU memory. With `dummy`, vLLM allocates empty tensors for profiling and gets real weights via the checkpoint engine's weight sync. This is verl's own default — we were overriding it unnecessarily.
+- **Increase `update_weights_bucket_megabytes` to 3072.** The default 2048MB bucket can't fit the embedding weight for models with large vocabularies (e.g., Qwen3's 152K vocab × 4096 hidden × 4 bytes = 2.36GB in float32). Without this, the FSDP→vLLM weight sync fails.
+- **`load_format=safetensors` is needed for LoRA on very large models (9B+).** With `dummy` format, the first weight sync calls `FSDP.summon_full_params` which reconstructs the full unsharded model on each GPU — OOM for 9B+. With `safetensors`, vLLM preloads base weights from disk, so subsequent syncs only transfer LoRA params (`base_sync_done=True`). Use with `layered_summon=True` for efficient LoRA-only syncs.
+- **Full fine-tuning works by setting `lora_r=0`.** verl treats `lora_rank=0` as "no LoRA, train all parameters." No other changes needed — the same FSDP+vLLM pipeline handles full fine-tuning. Full FT is faster per step (no LoRA adapter management overhead) but uses more memory and may overfit earlier.
+- **verl's FSDP→vLLM weight sync is the memory bottleneck.** During `update_weights`, FSDP gathers the full model in float32 onto each GPU to sync to vLLM. For 9B models in float32 this is ~36GB per GPU on top of FSDP's shards. This is why Qwen3-8B (8.2B params, 152K vocab) barely fits but Qwen3.5-9B (9.5B params, 248K vocab) doesn't without `safetensors` + `layered_summon`.
+
+### Qwen3.5 (GatedDeltaNet) Specific
+
+Qwen3.5 uses a hybrid architecture: 75% GatedDeltaNet linear attention layers + 25% full attention. This requires specific setup:
+
+- **CUDA toolkit >= 12.5 required.** flashinfer's GDN kernels use PTX intrinsics (`tensormap_replace_global_dim`) added in CUDA 12.5. CUDA 12.4 fails at JIT compile time. Install the toolkit only — no driver upgrade needed: `sudo dnf install -y cuda-toolkit-12-8`.
+- **Install `flash-linear-attention` and `tilelang`.** Without FLA's fused Triton kernels, GDN layers decompose into 15-20 separate GPU ops per step — 10-50x slower. `tilelang` is required on Hopper GPUs with Triton >= 3.4.0 to avoid incorrect gradients. Set `use_fused_kernels=True` in the verl model config.
+- **vLLM >= 0.19.0 required.** Older versions don't support `Qwen3_5ForConditionalGeneration`.
+- **Pass `language_model_only=True`.** Qwen3.5-9B is text-only but registers as a multimodal architecture. Without this flag, vLLM loads the full VL model with vision encoder. Install `qwen-vl-utils` as well (imported during model init even in text-only mode).
+- **Do NOT use `tensor_parallel_size > 1`.** Qwen3.5 has known TP issues with vLLM 0.19 (NCCL hangs during inference).
+- **Set `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1200`.** Default is 300s. GDN inference on long prompts (20K+ tokens) with TP=1 can exceed 5 minutes, causing `TimeoutError: RPC call to sample_tokens timed out`.
+- **Qwen3.5 chat template requires dict arguments in tool_calls.** Unlike Qwen3, the Qwen3.5 Jinja template calls `.items()` on tool call arguments. If `arguments` is a JSON string instead of a dict, tokenization fails with `"Can only get item pairs from a mapping"`. The data prep code must `json.loads()` string arguments before passing them to the tokenizer.
+- **transformers >= 4.58 required** for the `qwen3_5` model type. Also upgrade `huggingface_hub >= 1.0`.
+- **Force-reinstall `nvidia-nccl-cu12` after installing vLLM 0.19.** vLLM may leave a stale cu13 NCCL `.so` file even though pip shows cu12. Verify with `python -c "import ctypes; lib=ctypes.CDLL('path/to/libnccl.so.2'); v=ctypes.c_int(); lib.ncclGetVersion(ctypes.byref(v)); print(v.value)"`.
+
+### Past Incidents (continued)
+
+- **Root filesystem filled by flash-attn JIT compilation.** CUDA compilation of flash-attn wrote hundreds of 125-140MB temp files to `/tmp` on a 100GB root partition. The build failed silently with "Error compiling objects for extension" and no disk space error. Fix: set `TMPDIR=/mnt/nvme0n1/tmp` before building. Lesson: always set TMPDIR to a large filesystem for CUDA compilation.
+- **Stale `libnccl.so` version after package reinstall.** `pip list` showed `nvidia-nccl-cu12==2.27.5` but the actual `.so` file was version 2.28.9 (from a prior cu13 install). Caused NCCL errors at runtime. Fix: `pip install nvidia-nccl-cu12==2.27.5 --force-reinstall`. Lesson: pip metadata and actual library files can diverge — verify with ctypes or ldd when debugging NCCL issues.
+- **vLLM `sample_tokens` timeout on GDN models.** Qwen3.5-9B with 29K+ token prompts exceeded the 300s default `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS`. The vLLM worker appeared to hang and the engine reported `EngineDeadError`. Fix: increase timeout to 1200s. Lesson: GDN linear attention is slower per token than standard attention — timeout values calibrated for transformer models may be too low.
+- **FLA fused kernels crash without `tilelang` on Hopper.** `RuntimeError: Triton >= 3.4.0 on Hopper GPUs produces incorrect results for gated chunk_bwd_dqkwg (see #640). Please install tilelang`. The error message is clear and actionable — just `pip install tilelang`.
+- **21 min/step without FLA vs 3.3 min/step with FLA.** The `[transformers] The fast path is not available because one of the required library is not installed` warning is easy to miss. Without FLA, GDN layers use a decomposed fallback that is 10-50x slower. Always install `flash-linear-attention` when training GDN/Qwen3.5 models.
+
 ### verl Backend Reference Configuration
 
 These are known-good configuration values from validated training runs. Use as a starting point when debugging or configuring new runs.
@@ -343,4 +382,25 @@ gpu_memory_utilization=0.3
 num_iterations=2, group_size=8, prompt_batch_size=50
 learning_rate=1e-5
 Result: successful completion, both iterations
+
+# Validated on 8x H100, Qwen3-8B, OpenShift v4 data (LoRA)
+lora_r=128, lora_alpha=256
+gpu_memory_utilization=0.5, load_format=dummy
+update_weights_bucket_megabytes=3072
+prompt_batch_size=48, group_size=8
+learning_rate=5e-6, max_prompt_length=32768
+Final reward: 0.80 avg, 0.89 peak (8 epochs, 41 hours)
+
+# Validated on 8x H100, Qwen3-8B, OpenShift v4 data (full fine-tuning)
+lora_r=0 (full fine-tuning)
+gpu_memory_utilization=0.5, load_format=dummy
+Peak reward: 0.804 at epoch 5, then overfitting (8 epochs, 26.5 hours)
+
+# Validated on 8x H100, Qwen3.5-9B, OpenShift v4 data (LoRA)
+lora_r=128, lora_alpha=256
+gpu_memory_utilization=0.3, load_format=safetensors, layered_summon=True
+language_model_only=True, use_fused_kernels=True
+VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1200
+Requires: vllm==0.19.0, flash-linear-attention, tilelang, CUDA toolkit 12.5+
+Step time: ~3.3 min/step, reward 0.85+ by epoch 2
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 | Continual Learning (OSFT) | 🔄 | ✅ | 🔄 | - | - | Implemented |
 | **Low-Rank Adaptation (LoRA) + SFT** | - | - | - | ✅ | - | Implemented |
 | **LoRA + GRPO (Adapter-Based RLVR)** | - | - | - | ✅ | ✅ | Implemented |
+| **GRPO (Full Fine-Tuning RLVR)** | - | - | - | - | ✅ | Implemented |
 | Direct Preference Optimization (DPO) | - | - | - | - | 🔄 | Planned |
 
 **Legend:**
@@ -135,6 +136,22 @@ result = lora_grpo(
     ckpt_output_dir="./grpo_output",
     backend="verl",
     n_gpus=4,
+)
+```
+
+### [GRPO (Full Fine-Tuning RLVR)](./algorithms/grpo)
+
+Full-parameter GRPO training via the verl backend. Trains all model weights instead of LoRA adapters. Same data formats and reward functions as LoRA + GRPO.
+
+```python
+from training_hub import grpo
+
+result = grpo(
+    model_path="Qwen/Qwen3-8B",
+    data_path="./tool_call_traces.jsonl",
+    ckpt_output_dir="./grpo_full_output",
+    n_gpus=8,
+    num_iterations=8,
 )
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,7 @@ result = lora_grpo(
 )
 ```
 
-### [GRPO (Full Fine-Tuning RLVR)](./algorithms/grpo)
+### [GRPO (Full Fine-Tuning RLVR)](/algorithms/grpo)
 
 Full-parameter GRPO training via the verl backend. Trains all model weights instead of LoRA adapters. Same data formats and reward functions as LoRA + GRPO.
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
   * [OSFT - Orthogonal Subspace Fine-Tuning](/algorithms/osft)
   * [LoRA - Low-Rank Adaptation](/algorithms/lora)
   * [LoRA + GRPO - Adapter RLVR](/algorithms/lora_grpo)
+  * [GRPO - Full Fine-Tuning RLVR](/algorithms/grpo)
 
 * API Reference
   * [API Overview](/api/)
@@ -21,6 +22,7 @@
     * [osft()](/api/functions/osft)
     * [lora_sft()](/api/functions/lora_sft)
     * [lora_grpo()](/api/functions/lora_grpo)
+    * [grpo()](/api/functions/grpo)
     * [create_algorithm()](/api/functions/create-algorithm)
   * Classes
     * [Algorithm](/api/classes/Algorithm)

--- a/docs/algorithms/grpo.md
+++ b/docs/algorithms/grpo.md
@@ -37,11 +37,10 @@ Only the **verl** backend is supported. Full fine-tuning requires FSDP for multi
 | Trainable params | ~1-2% (adapter only) | 100% (all weights) |
 | Checkpoint size | ~1-2 GB | ~16 GB (8B model) |
 | Serving | Base model + adapter | Standalone model |
-| Training speed | Slower (adapter overhead) | Faster per step |
 | Overfitting risk | Lower | Higher (may peak early) |
 | Memory | Lower | Higher |
 
-In practice, both achieve similar peak reward. Full FT tends to peak earlier but may overfit in later epochs, while LoRA training is more stable across epochs.
+Despite a significant drop in trainable parameters, we find that in most cases the adapter-based approach sees similar or stronger quality, while providing more flexibility in deployment and agentic systems. Depending on the use-case, either method will carry different benefits (capacity vs flexibility).
 
 ## Data Format
 

--- a/docs/algorithms/grpo.md
+++ b/docs/algorithms/grpo.md
@@ -1,0 +1,64 @@
+# GRPO — Full Fine-Tuning with Reinforcement Learning from Verifiable Rewards
+
+Full-parameter GRPO training via the verl backend. Trains all model weights using Group Relative Policy Optimization, without LoRA adapters.
+
+> For LoRA-based GRPO (parameter-efficient), see [LoRA + GRPO](/algorithms/lora_grpo).
+
+## When to Use
+
+- You want maximum model capacity and are willing to train all parameters
+- You have enough GPUs to fit the full model in FSDP (8B models need 8x H100 80GB)
+- You want a standalone fine-tuned model (no base model + adapter at inference)
+
+## Quick Start
+
+```python
+from training_hub import grpo
+
+result = grpo(
+    model_path="Qwen/Qwen3-8B",
+    data_path="training_data.jsonl",
+    ckpt_output_dir="./grpo_output",
+    n_gpus=8,
+    num_iterations=8,
+    group_size=8,
+    prompt_batch_size=48,
+)
+```
+
+## Backend
+
+Only the **verl** backend is supported. Full fine-tuning requires FSDP for multi-GPU parameter sharding, which the ART backend does not support.
+
+## Comparison with LoRA + GRPO
+
+| | LoRA + GRPO | GRPO (Full FT) |
+|--|-------------|----------------|
+| Trainable params | ~1-2% (adapter only) | 100% (all weights) |
+| Checkpoint size | ~1-2 GB | ~16 GB (8B model) |
+| Serving | Base model + adapter | Standalone model |
+| Training speed | Slower (adapter overhead) | Faster per step |
+| Overfitting risk | Lower | Higher (may peak early) |
+| Memory | Lower | Higher |
+
+In practice, both achieve similar peak reward. Full FT tends to peak earlier but may overfit in later epochs, while LoRA training is more stable across epochs.
+
+## Data Format
+
+Uses the same data formats as [LoRA + GRPO](/algorithms/lora_grpo) — tool-call traces or generic question/ground_truth JSONL.
+
+## Checkpoints
+
+Full fine-tuning produces FSDP sharded checkpoints. Use verl's model merger to consolidate into HuggingFace format:
+
+```bash
+python -m verl.model_merger merge \
+  --backend fsdp \
+  --local_dir ./checkpoints/global_step_76/actor \
+  --target_dir ./merged_checkpoint \
+  --trust-remote-code
+```
+
+## API Reference
+
+See [`grpo()`](/api/functions/grpo) for the full parameter reference.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -14,6 +14,7 @@ Training Hub provides convenient top-level functions for common training tasks:
 | [`osft()`](/api/functions/osft) | Orthogonal subspace fine-tuning for continual learning | [Details](/api/functions/osft) |
 | [`lora_sft()`](/api/functions/lora_sft) | Parameter-efficient fine-tuning with LoRA | [Details](/api/functions/lora_sft) |
 | [`lora_grpo()`](/api/functions/lora_grpo) | LoRA + GRPO for tool-calling agents (RLVR) | [Details](/api/functions/lora_grpo) |
+| [`grpo()`](/api/functions/grpo) | Full-parameter GRPO training (verl backend) | [Details](/api/functions/grpo) |
 | [`create_algorithm()`](/api/functions/create-algorithm) | Factory function to create algorithm instances | [Details](/api/functions/create-algorithm) |
 
 ### Classes

--- a/docs/api/functions/grpo.md
+++ b/docs/api/functions/grpo.md
@@ -1,0 +1,107 @@
+# `grpo()`
+
+Full-parameter GRPO training via the verl backend. Equivalent to `lora_grpo(..., lora_r=0, backend="verl")`.
+
+## Signature
+
+```python
+from training_hub import grpo
+
+result = grpo(
+    model_path: str,
+    ckpt_output_dir: str,
+    # Data
+    data_path: str = None,
+    data_config: str = "Qwen3",
+    n_train: int = 5000,
+    n_val: int = 500,
+    reward_fn: Callable = None,
+    # GRPO
+    num_iterations: int = 15,
+    group_size: int = 8,
+    prompt_batch_size: int = 100,
+    learning_rate: float = 1e-5,
+    temperature: float = 0.7,
+    max_tokens: int = 512,
+    max_prompt_length: int = 16384,
+    # GPU
+    gpu_memory_utilization: float = 0.45,
+    n_gpus: int = 1,
+    nnodes: int = 1,
+    tensor_parallel_size: int = 1,
+    # Algorithm
+    use_dr_grpo: bool = True,
+    # Tracking
+    wandb_project: str = None,
+    mlflow_tracking_uri: str = None,
+    **kwargs,
+)
+```
+
+## Quick Example
+
+```python
+from training_hub import grpo
+
+result = grpo(
+    model_path="Qwen/Qwen3-8B",
+    data_path="./training_data.jsonl",
+    ckpt_output_dir="./grpo_output",
+    n_gpus=8,
+    num_iterations=8,
+)
+```
+
+## Parameters
+
+### Required
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model_path` | `str` | HuggingFace model ID or local path |
+| `ckpt_output_dir` | `str` | Directory for checkpoints and results |
+
+### Data
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `data_path` | `None` | Dataset path (HuggingFace ID or local JSONL) |
+| `data_config` | `"Qwen3"` | HuggingFace dataset config |
+| `n_train` | `5000` | Training samples to load |
+| `n_val` | `500` | Validation samples to load |
+| `reward_fn` | `None` | Custom reward function for generic data |
+
+### GRPO Hyperparameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_iterations` | `15` | Training epochs |
+| `group_size` | `8` | Rollouts per prompt for advantage estimation |
+| `prompt_batch_size` | `100` | Unique prompts per step |
+| `learning_rate` | `1e-5` | Learning rate |
+| `temperature` | `0.7` | Sampling temperature |
+| `max_tokens` | `512` | Max response tokens |
+| `max_prompt_length` | `16384` | Max prompt tokens (filtered) |
+
+### GPU Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `n_gpus` | `1` | Number of GPUs |
+| `nnodes` | `1` | Number of nodes |
+| `gpu_memory_utilization` | `0.45` | vLLM GPU memory fraction |
+| `tensor_parallel_size` | `1` | vLLM tensor parallelism |
+
+## Differences from `lora_grpo()`
+
+- No `lora_r`, `lora_alpha`, `target_modules`, `max_lora_rank` parameters
+- No `backend` parameter (always `"verl"`)
+- No `rollout_fn`, `tasks`, `concurrency` (custom rollout is ART-only)
+- Produces full model checkpoints (~16GB for 8B) instead of LoRA adapters (~1-2GB)
+- Requires `python -m verl.model_merger merge` to consolidate FSDP checkpoints
+
+## Related
+
+- [`lora_grpo()`](/api/functions/lora_grpo) — LoRA-based GRPO (parameter-efficient, supports ART and verl)
+- [GRPO Algorithm Guide](/algorithms/grpo)
+- [verl Backend](/api/backends/verl)

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -2,7 +2,7 @@ from .algorithms import Algorithm, Backend, AlgorithmRegistry, create_algorithm
 from .algorithms.sft import sft, SFTAlgorithm, InstructLabTrainingSFTBackend
 from .algorithms.osft import OSFTAlgorithm, MiniTrainerOSFTBackend, osft
 from .algorithms.lora import lora_sft, LoRASFTAlgorithm, UnslothLoRABackend
-from .algorithms.lora_grpo import lora_grpo, LoRAGRPOAlgorithm, ARTLoRAGRPOBackend
+from .algorithms.lora_grpo import lora_grpo, grpo, LoRAGRPOAlgorithm, ARTLoRAGRPOBackend
 from .algorithms.lora_grpo_verl import VeRLLoRAGRPOBackend
 from .algorithms.rewards import tool_call_reward, binary_reward
 from .hub_core import welcome
@@ -18,6 +18,7 @@ __all__ = [
     'osft',
     'lora_sft',
     'lora_grpo',
+    'grpo',
     'SFTAlgorithm',
     'InstructLabTrainingSFTBackend',
     'OSFTAlgorithm',

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1795,6 +1795,17 @@ def grpo(
             n_gpus=4,
         )
     """
+    _unsupported = {
+        "backend", "rollout_fn", "tasks", "concurrency",
+        "lora_r", "lora_alpha", "target_modules", "max_lora_rank", "max_grad_norm",
+    } & kwargs.keys()
+    if _unsupported:
+        raise ValueError(
+            "grpo() only supports verl full fine-tuning. "
+            f"Unsupported arguments: {', '.join(sorted(_unsupported))}. "
+            "Use lora_grpo() for LoRA training or ART backend."
+        )
+
     return lora_grpo(
         model_path=model_path,
         ckpt_output_dir=ckpt_output_dir,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1475,9 +1475,12 @@ class LoRAGRPOAlgorithm(Algorithm):
         }
 
 
-# Register algorithm and backend
+# Register algorithm and backends
 AlgorithmRegistry.register_algorithm("lora_grpo", LoRAGRPOAlgorithm)
 AlgorithmRegistry.register_backend("lora_grpo", "art", ARTLoRAGRPOBackend)
+
+# GRPO (full fine-tuning) reuses the same algorithm class — verl backend only
+AlgorithmRegistry.register_algorithm("grpo", LoRAGRPOAlgorithm)
 
 
 # ---------------------------------------------------------------------------
@@ -1686,5 +1689,141 @@ def lora_grpo(
         mlflow_tracking_uri=mlflow_tracking_uri,
         mlflow_experiment_name=mlflow_experiment_name,
         mlflow_run_name=mlflow_run_name,
+        **kwargs,
+    )
+
+
+def grpo(
+    model_path: str,
+    ckpt_output_dir: str,
+    # Data source (built-in tool-call mode)
+    data_path: Optional[str] = None,
+    data_config: str = "Qwen3",
+    n_train: int = 5000,
+    n_val: int = 500,
+    # Custom rollout mode
+    reward_fn: Optional[Callable] = None,
+    # GRPO hyperparameters
+    num_iterations: int = 15,
+    group_size: int = 8,
+    prompt_batch_size: int = 100,
+    learning_rate: float = 1e-5,
+    temperature: float = 0.7,
+    max_tokens: int = 512,
+    max_prompt_length: int = 16384,
+    # vLLM configuration
+    gpu_memory_utilization: float = 0.45,
+    # Multi-GPU/multi-node configuration
+    n_gpus: int = 1,
+    nnodes: int = 1,
+    tensor_parallel_size: int = 1,
+    # Algorithm variant
+    use_dr_grpo: bool = True,
+    # Callbacks
+    iteration_callback: Optional[Callable] = None,
+    # Logging / experiment tracking
+    wandb_project: Optional[str] = None,
+    wandb_entity: Optional[str] = None,
+    wandb_run_name: Optional[str] = None,
+    mlflow_tracking_uri: Optional[str] = None,
+    mlflow_experiment_name: Optional[str] = None,
+    mlflow_run_name: Optional[str] = None,
+    **kwargs,
+) -> Any:
+    """Run full-parameter GRPO training (no LoRA) via the verl backend.
+
+    Trains all model parameters using Group Relative Policy Optimization.
+    This is equivalent to ``lora_grpo(..., lora_r=0, backend="verl")`` but
+    provides a cleaner interface for full fine-tuning without LoRA-specific
+    parameters. Only the verl backend is supported (multi-GPU FSDP).
+
+    Args:
+        model_path: HuggingFace model ID or local path (e.g., 'Qwen/Qwen3-8B').
+        ckpt_output_dir: Directory to save checkpoints and training results.
+
+        data_path: Dataset path. HuggingFace ID or local JSON/JSONL path.
+        data_config: HuggingFace dataset config name (default: 'Qwen3').
+        n_train: Number of training samples to load (default: 5000).
+        n_val: Number of validation samples to load (default: 500).
+
+        reward_fn: Custom reward function. For generic data, signature:
+            (data_source, solution_str, ground_truth) -> float.
+
+        num_iterations: GRPO training epochs (default: 15).
+        group_size: Rollouts per prompt for advantage estimation (default: 8).
+        prompt_batch_size: Unique prompts per training step (default: 100).
+        learning_rate: Learning rate (default: 1e-5).
+        temperature: Sampling temperature (default: 0.7).
+        max_tokens: Max response tokens per rollout (default: 512).
+        max_prompt_length: Max prompt length in tokens (default: 16384).
+
+        gpu_memory_utilization: vLLM GPU memory fraction (default: 0.45).
+        n_gpus: Number of GPUs (default: 1).
+        nnodes: Number of nodes (default: 1).
+        tensor_parallel_size: vLLM tensor parallelism (default: 1).
+        use_dr_grpo: Use Dr. GRPO variant (default: True).
+        iteration_callback: Callback after each iteration.
+
+        wandb_project: Weights & Biases project name.
+        wandb_entity: Weights & Biases team/entity name.
+        wandb_run_name: Weights & Biases run name.
+        mlflow_tracking_uri: MLflow tracking server URI.
+        mlflow_experiment_name: MLflow experiment name.
+        mlflow_run_name: MLflow run name.
+
+    Returns:
+        Dict with training results including reward_history and checkpoint_path.
+
+    Examples:
+        # Full fine-tuning on OpenShift tool-call data
+        result = grpo(
+            model_path="Qwen/Qwen3-8B",
+            data_path="training_data_v4.jsonl",
+            ckpt_output_dir="./grpo_full_output",
+            n_gpus=8,
+            num_iterations=8,
+            group_size=8,
+            prompt_batch_size=48,
+        )
+
+        # Full fine-tuning with custom reward
+        result = grpo(
+            model_path="Qwen/Qwen3-8B",
+            data_path="./my_data.jsonl",
+            reward_fn=my_reward,
+            ckpt_output_dir="./grpo_output",
+            n_gpus=4,
+        )
+    """
+    return lora_grpo(
+        model_path=model_path,
+        ckpt_output_dir=ckpt_output_dir,
+        data_path=data_path,
+        data_config=data_config,
+        n_train=n_train,
+        n_val=n_val,
+        reward_fn=reward_fn,
+        num_iterations=num_iterations,
+        group_size=group_size,
+        prompt_batch_size=prompt_batch_size,
+        learning_rate=learning_rate,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        max_prompt_length=max_prompt_length,
+        gpu_memory_utilization=gpu_memory_utilization,
+        n_gpus=n_gpus,
+        nnodes=nnodes,
+        tensor_parallel_size=tensor_parallel_size,
+        use_dr_grpo=use_dr_grpo,
+        iteration_callback=iteration_callback,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
+        wandb_run_name=wandb_run_name,
+        mlflow_tracking_uri=mlflow_tracking_uri,
+        mlflow_experiment_name=mlflow_experiment_name,
+        mlflow_run_name=mlflow_run_name,
+        # Full fine-tuning: no LoRA, verl only
+        lora_r=0,
+        backend="verl",
         **kwargs,
     )

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -1130,8 +1130,9 @@ class VeRLLoRAGRPOBackend(Backend):
 
 
 # Register the verl backend for the lora_grpo algorithm
-# (algorithm is already registered by lora_grpo.py, we just add a new backend)
+# (algorithms are already registered by lora_grpo.py, we just add verl backends)
 try:
     AlgorithmRegistry.register_backend("lora_grpo", "verl", VeRLLoRAGRPOBackend)
+    AlgorithmRegistry.register_backend("grpo", "verl", VeRLLoRAGRPOBackend)
 except ValueError:
     pass  # Algorithm not registered yet (import order), will be registered on first use

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -97,7 +97,24 @@ def _prepare_verl_data(
             prompt.append({"role": "user", "content": s["question"]})
             # Add GT context for multi-turn samples
             for ctx_msg in s.get("context_messages", []):
-                prompt.append(ctx_msg)
+                msg = dict(ctx_msg)
+                # Ensure tool_calls arguments are dicts, not JSON strings
+                # (required by Qwen3.5 chat template which calls .items() on them)
+                if "tool_calls" in msg and msg["tool_calls"]:
+                    fixed_calls = []
+                    for tc in msg["tool_calls"]:
+                        tc = dict(tc)
+                        if "function" in tc:
+                            fn = dict(tc["function"])
+                            if isinstance(fn.get("arguments"), str):
+                                try:
+                                    fn["arguments"] = json.loads(fn["arguments"])
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+                            tc["function"] = fn
+                        fixed_calls.append(tc)
+                    msg["tool_calls"] = fixed_calls
+                prompt.append(msg)
 
             tools = s.get("tools", [])
 
@@ -845,19 +862,26 @@ class VeRLLoRAGRPOBackend(Backend):
             f"data.max_response_length={max_tokens}",
             "data.filter_overlong_prompts=True",
             "data.truncation=error",
-            # Model + LoRA
+            # Model
             f"actor_rollout_ref.model.path={model_path}",
-            f"actor_rollout_ref.model.lora_rank={lora_r}",
-            f"actor_rollout_ref.model.lora_alpha={lora_alpha}",
+        ])
+        # LoRA (skip for full fine-tuning when lora_r=0 or None)
+        if lora_r:
+            cmd.extend([
+                f"actor_rollout_ref.model.lora_rank={lora_r}",
+                f"actor_rollout_ref.model.lora_alpha={lora_alpha}",
+            ])
+        cmd.extend([
             "actor_rollout_ref.model.enable_gradient_checkpointing=True",
             "actor_rollout_ref.model.use_remove_padding=True",
+            "actor_rollout_ref.model.use_fused_kernels=True",
             # Actor (training)
             f"actor_rollout_ref.actor.optim.lr={learning_rate}",
             f"actor_rollout_ref.actor.ppo_mini_batch_size={ppo_mini_batch_size}",
             "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1",
             "actor_rollout_ref.actor.entropy_coeff=0",
-            "actor_rollout_ref.actor.fsdp_config.param_offload=False",
-            "actor_rollout_ref.actor.fsdp_config.optimizer_offload=False",
+            f"actor_rollout_ref.actor.fsdp_config.param_offload={algorithm_params.get('param_offload', False)}",
+            f"actor_rollout_ref.actor.fsdp_config.optimizer_offload={algorithm_params.get('optimizer_offload', False)}",
         ])
 
         # Actor KL and loss settings depend on Dr. GRPO vs standard
@@ -880,8 +904,16 @@ class VeRLLoRAGRPOBackend(Backend):
             f"actor_rollout_ref.rollout.n={group_size}",
             f"actor_rollout_ref.rollout.gpu_memory_utilization={gpu_memory_utilization}",
             f"actor_rollout_ref.rollout.max_model_len={max_prompt_length + max_tokens}",
-            "actor_rollout_ref.rollout.load_format=safetensors",
+            f"actor_rollout_ref.rollout.load_format={algorithm_params.get('load_format', 'dummy')}",
+            "actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=3072",
             f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={max(1, min(train_batch_size // max(n_gpus, 1), 2))}",
+        ])
+        if algorithm_params.get("layered_summon", False):
+            cmd.append("actor_rollout_ref.rollout.layered_summon=True")
+        # language_model_only for multimodal architectures used as text-only (e.g. Qwen3.5)
+        if algorithm_params.get("language_model_only", False):
+            cmd.append("+actor_rollout_ref.rollout.engine_kwargs.vllm.language_model_only=True")
+        cmd.extend([
             # Reference model (only used when not Dr. GRPO)
             "actor_rollout_ref.ref.fsdp_config.param_offload=True",
             f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={max(1, min(train_batch_size // max(n_gpus, 1), 2))}",

--- a/src/training_hub/algorithms/lora_grpo_verl.py
+++ b/src/training_hub/algorithms/lora_grpo_verl.py
@@ -108,9 +108,10 @@ def _prepare_verl_data(
                             fn = dict(tc["function"])
                             if isinstance(fn.get("arguments"), str):
                                 try:
-                                    fn["arguments"] = json.loads(fn["arguments"])
+                                    parsed = json.loads(fn["arguments"])
+                                    fn["arguments"] = parsed if isinstance(parsed, dict) else {}
                                 except (json.JSONDecodeError, TypeError):
-                                    pass
+                                    fn["arguments"] = {}
                             tc["function"] = fn
                         fixed_calls.append(tc)
                     msg["tool_calls"] = fixed_calls


### PR DESCRIPTION
## Summary

- **Full fine-tuning GRPO support**: New `grpo()` convenience function for full-parameter training (verl backend only)
- **LoRA improvements for larger models (8B+)**: `load_format=dummy` default, configurable offload, larger weight sync buckets
- **Qwen3.5 (GatedDeltaNet) support**: `language_model_only`, `use_fused_kernels`, tool_calls argument parsing fix
- **AGENTS.md**: Comprehensive operational guide for disk management, larger models, Qwen3.5, and new incident reports

## New: `grpo()` function

Equivalent to `lora_grpo(..., lora_r=0, backend="verl")` with a cleaner API — no LoRA-specific parameters. Verl backend only, since full fine-tuning requires FSDP.

```python
from training_hub import grpo

result = grpo(
    model_path="Qwen/Qwen3-8B",
    data_path="./training_data.jsonl",
    ckpt_output_dir="./grpo_output",
    n_gpus=8,
)
```

## Code changes

**verl backend (`lora_grpo_verl.py`):**
- `load_format` default changed from `safetensors` to `dummy` (verl's own default — avoids double model load OOM)
- `update_weights_bucket_megabytes=3072` (embedding weight for 152K+ vocab exceeds default 2048MB bucket)
- `use_fused_kernels=True` (enables FLA fused Triton kernels for GDN models — 10-50x speedup)
- `language_model_only` passthrough for vLLM via Hydra `+` override
- `load_format`, `param_offload`, `optimizer_offload`, `layered_summon` configurable via kwargs
- LoRA conditionally applied only when `lora_r > 0`
- tool_calls `arguments` parsed from JSON strings to dicts (Qwen3.5 template compatibility)

**New files:**
- `docs/algorithms/grpo.md` — Algorithm guide with comparison to LoRA + GRPO
- `docs/api/functions/grpo.md` — API reference

**Updated files:**
- `__init__.py` — exports `grpo`
- `lora_grpo.py` — `grpo()` function, algorithm registration
- `docs/_sidebar.md`, `docs/api/README.md`, `docs/README.md` — navigation and support matrix

## Validated configurations

| Model | Method | GPUs | Step time | Final reward |
|-------|--------|------|-----------|-------------|
| Qwen3-8B | LoRA r=128 | 8x H100 | 4.1 min | 0.80 avg |
| Qwen3-8B | Full FT (`grpo()`) | 8x H100 | 2.7 min | 0.80 peak (epoch 5) |
| Qwen3.5-9B | LoRA r=128 | 8x H100 | 3.3 min | 0.85+ (in progress) |

## Test plan

- [x] Qwen3-8B LoRA: 8 epochs completed, avg reward 0.80
- [x] Qwen3-8B full fine-tuning: 8 epochs completed, peak 0.804
- [x] Qwen3.5-9B LoRA: running, 170+ steps, reward 0.85+
- [x] Qwen3-4B (original config): no regression — `lora_r=128` still applies LoRA as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `grpo()` convenience function for full-parameter fine-tuning with GRPO
  * Enhanced tool-call argument handling in GRPO data processing
  * Expanded verl backend configuration options (load format, bucket sizing, language model settings)

* **Documentation**
  * Added comprehensive GRPO algorithm documentation and API reference
  * Updated navigation with new GRPO entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->