### PR TITLE
Add AI Research Skills plugins to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -87,8 +87,32 @@ jobs:
             feature-dev@claude-plugins-official
             huggingface-skills@claude-plugins-official
             frontend-design@claude-plugins-official
+            model-architecture@ai-research-skills
+            tokenization@ai-research-skills
+            fine-tuning@ai-research-skills
+            mechanistic-interpretability@ai-research-skills
+            data-processing@ai-research-skills
+            post-training@ai-research-skills
+            safety-alignment@ai-research-skills
+            distributed-training@ai-research-skills
+            infrastructure@ai-research-skills
+            optimization@ai-research-skills
+            evaluation@ai-research-skills
+            inference-serving@ai-research-skills
+            mlops@ai-research-skills
+            agents@ai-research-skills
+            rag@ai-research-skills
+            prompt-engineering@ai-research-skills
+            observability@ai-research-skills
+            multimodal@ai-research-skills
+            emerging-techniques@ai-research-skills
+            autoresearch@ai-research-skills
+            ml-paper-writing@ai-research-skills
+            ideation@ai-research-skills
+            agent-native-research-artifact@ai-research-skills
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
+            https://github.com/Orchestra-Research/AI-research-SKILLs.git
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
## Summary

This PR adds 23 AI Research Skills plugin categories (containing 98 individual skills) from [Orchestra Research](https://github.com/Orchestra-Research/AI-research-SKILLs) to the Claude Code GitHub Action workflow.

### Changes

- Added 23 `ai-research-skills` plugins covering: model architecture, tokenization, fine-tuning, mechanistic interpretability, data processing, post-training, safety/alignment, distributed training, infrastructure, optimization, evaluation, inference serving, MLOps, agents, RAG, prompt engineering, observability, multimodal, emerging techniques, autoresearch, ML paper writing, ideation, and agent-native research artifacts
- Added the Orchestra Research marketplace (`https://github.com/Orchestra-Research/AI-research-SKILLs.git`) to `plugin_marketplaces`

### Why

These plugins provide Claude Code with specialized knowledge and skills for AI/ML research workflows, enabling better assistance with training, evaluation, deployment, and research tasks across the full ML lifecycle.