### PR TITLE
Add max_steps to GRPO metrics for progress percentage calculation

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1041,6 +1041,7 @@ class ARTLoRAGRPOBackend(Backend):
             rollout_entry = {
                 "step": iteration + 1,
                 "epoch": (iteration + 1) / num_iterations,
+                "max_steps": num_iterations,
                 "phase": "rollout",
                 "mean_reward": mean_reward,
                 "full_match_rate": full_match,
@@ -1108,6 +1109,7 @@ class ARTLoRAGRPOBackend(Backend):
             train_entry = {
                 "step": iteration + 1,
                 "epoch": (iteration + 1) / num_iterations,
+                "max_steps": num_iterations,
                 "phase": "train",
                 "wall_time_s": iter_time,
             }


### PR DESCRIPTION
Add max_steps (set to num_iterations) to both rollout and train phase entries in training_metrics.jsonl.

This enables the Kubeflow SDK metrics handler to calculate progressPercentage for GRPO training jobs, matching the pattern established for LoRA SFT in [#55](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/pull/55).

Without this, the SDK reports progress as "unknown" (None) for GRPO jobs because num_iterations was only implicitly encoded in the epoch field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training metrics now include a `max_steps` field, providing enhanced visibility into training iteration configuration during GRPO training.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/training_hub/pull/73)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->