### PR TITLE
Relax litellm floor from >=1.82.0 to >=1.71.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ lora = [
 grpo = [
     "openpipe-art",
     "verl>=0.7",  # no [vllm] extra — verl works with ART's vllm 0.15+ despite its conservative cap
-    "litellm>=1.82.0,<1.82.7",  # 1.82.7-1.82.8 compromised (TeamPCP supply chain attack, 2026-03-24)
+    "litellm>=1.71.1,<1.82.7",  # 1.82.7+ potentially compromised (TeamPCP supply chain attack, 2026-03-24)
     "transformers>=4.51.3,<5.0",  # trl<=0.24 (capped by unsloth) breaks with transformers 5.x
 ]
 


### PR DESCRIPTION
## Summary

Lowers the litellm minimum version from `>=1.82.0` to `>=1.71.1` to unblock RHOAI 3.5 AIPCC indexes which ship litellm 1.74.15 and 1.75.8.

## Rationale

- `openpipe-art` itself only requires `litellm>=1.71.1`
- training_hub does not import litellm directly — it's a transitive dependency
- Upper cap `<1.82.7` retained (TeamPCP supply chain attack in 1.82.7-1.82.8)

## Validation

ART backend `lora_grpo` functionally tested with `litellm==1.75.8` (one of the AIPCC versions):
- Model: Qwen/Qwen3-4B, vLLM 0.17.0
- Generic data with custom reward function
- 1 iteration, 8 rollouts, reward 0.75
- Training completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the `litellm` optional dependency version constraint to support a broader range of compatible versions, improving flexibility for the `grpo` module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/training_hub/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->