### PR TITLE
Ignore async cleanup errors when ART training has completed

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -719,9 +719,17 @@ class ARTLoRAGRPOBackend(Backend):
         except SystemExit:
             pass  # os._exit from shutdown — results saved in _run_training
         except Exception as e:
-            with open(error_path, "w") as f:
+            if not os.path.exists(results_path):
+                with open(error_path, "w") as f:
+                    import traceback
+                    f.write(traceback.format_exc())
+            else:
                 import traceback
-                f.write(traceback.format_exc())
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Post-training cleanup error (training completed successfully):\n%s",
+                    traceback.format_exc(),
+                )
 
     async def _run_training(self, params: Dict[str, Any], art, LocalBackend) -> Dict[str, Any]:
         """Async training loop."""


### PR DESCRIPTION
ART's background health-check task throws ConnectionRefusedError after vLLM shuts down at the end of training. This caused the subprocess to write to error_path even though training completed successfully, making Kubeflow restart the pod.

Now we check if results_path exists before treating an exception as a failure. If training completed, the error is logged as a warning instead of written to error_path.

Note: results_path is written before model.train() as a pre-save, so this check is not a guarantee that the final checkpoint was persisted. However, the alternative (failing the pod) is worse since the adapter and metrics are typically already on disk by the time the cleanup error occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in training workflows to preserve partial results instead of overwriting them when failures occur. Error information is now logged as warnings to provide clearer visibility into training cleanup processes while maintaining successful outputs from prior execution stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/training_hub/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->