### PR TITLE
Add ITS Hub rollout adapter for GRPO training

### DIFF
--- a/examples/scripts/its_rollout_example.py
+++ b/examples/scripts/its_rollout_example.py
@@ -60,7 +60,7 @@ ALGORITHM_FACTORIES = {
 
 def contains_answer_reward(response_text, task):
     """Simple reward: 1.0 if ground truth appears in response, else 0.0."""
-    ground_truth = task.get("answer", task.get("ground_truth", ""))
+    ground_truth = str(task.get("answer", task.get("ground_truth", "")))
     if not ground_truth:
         return 0.0
     return 1.0 if ground_truth.lower() in response_text.lower() else 0.0
@@ -129,7 +129,7 @@ def load_tasks(data_path):
     """Load tasks from JSONL file."""
     import json
     tasks = []
-    with open(data_path) as f:
+    with open(data_path, encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:

--- a/examples/scripts/its_rollout_example.py
+++ b/examples/scripts/its_rollout_example.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+ITS Hub + GRPO Training Example
+
+Uses ITS Hub inference-time scaling algorithms (SelfConsistency, BestOfN)
+as the rollout mechanism for GRPO training. The ITS Hub algorithm generates
+multiple candidate responses per prompt, selects the best one, and builds
+a training trajectory from it.
+
+Requires: its_hub[lm], openpipe-art
+
+Example usage:
+    # SelfConsistency rollout (default)
+    python its_rollout_example.py \\
+        --ckpt-output-dir ./its_grpo_output \\
+        --data-path ./my_data.jsonl
+
+    # BestOfN rollout (uses training model as judge)
+    python its_rollout_example.py \\
+        --ckpt-output-dir ./its_grpo_output \\
+        --data-path ./my_data.jsonl \\
+        --algorithm best_of_n
+
+    # Quick test
+    python its_rollout_example.py \\
+        --ckpt-output-dir ./its_grpo_output \\
+        --data-path ./my_data.jsonl \\
+        --num-iterations 1 --prompt-batch-size 5 --budget 3
+"""
+
+import argparse
+import sys
+import time
+from datetime import datetime
+
+from training_hub import lora_grpo
+from training_hub.algorithms.its_rollout import ITSRollout
+
+
+# --- Algorithm factories (module-level for picklability) ---
+
+def make_self_consistency(lm):
+    from its_hub import SelfConsistency
+    return SelfConsistency()
+
+
+def make_best_of_n(lm):
+    from its_hub import BestOfN, LLMJudge
+    judge = LLMJudge(lm=lm, judge_prompt="Rate the accuracy of this response from 1 to 10. Reply with just the number.")
+    return BestOfN(orm=judge)
+
+
+ALGORITHM_FACTORIES = {
+    "self_consistency": make_self_consistency,
+    "best_of_n": make_best_of_n,
+}
+
+
+# --- Reward function (module-level for picklability) ---
+
+def contains_answer_reward(response_text, task):
+    """Simple reward: 1.0 if ground truth appears in response, else 0.0."""
+    ground_truth = task.get("answer", task.get("ground_truth", ""))
+    if not ground_truth:
+        return 0.0
+    return 1.0 if ground_truth.lower() in response_text.lower() else 0.0
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="ITS Hub + GRPO Training",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Data format (JSONL, one object per line):
+  {"messages": [{"role": "user", "content": "..."}], "answer": "expected answer"}
+
+The 'messages' field is sent to the model. The 'answer' field is used by
+the reward function to score responses.
+        """
+    )
+
+    parser.add_argument('--ckpt-output-dir', required=True,
+                        help='Directory to save checkpoints')
+    parser.add_argument('--data-path', required=True,
+                        help='JSONL file with messages + answer fields')
+
+    # ITS Hub configuration
+    parser.add_argument('--algorithm', default='self_consistency',
+                        choices=list(ALGORITHM_FACTORIES.keys()),
+                        help='ITS Hub algorithm (default: self_consistency)')
+    parser.add_argument('--budget', type=int, default=8,
+                        help='Candidates per rollout (default: 8)')
+    parser.add_argument('--max-concurrency', type=int, default=32,
+                        help='Max concurrent LM calls within each ITS rollout (default: 32)')
+
+    # Model
+    parser.add_argument('--model-path', default='Qwen/Qwen3-4B',
+                        help='HuggingFace model ID (default: Qwen/Qwen3-4B)')
+
+    # GRPO hyperparameters
+    parser.add_argument('--num-iterations', type=int, default=10,
+                        help='Training iterations (default: 10)')
+    parser.add_argument('--group-size', type=int, default=8,
+                        help='Rollouts per prompt (default: 8)')
+    parser.add_argument('--prompt-batch-size', type=int, default=50,
+                        help='Prompts per iteration (default: 50)')
+    parser.add_argument('--learning-rate', type=float, default=1e-5,
+                        help='Learning rate (default: 1e-5)')
+    parser.add_argument('--concurrency', type=int, default=16,
+                        help='Max concurrent rollouts (default: 16)')
+
+    # LoRA
+    parser.add_argument('--lora-r', type=int, default=16,
+                        help='LoRA rank (default: 16)')
+    parser.add_argument('--lora-alpha', type=int, default=8,
+                        help='LoRA alpha (default: 8)')
+
+    # vLLM
+    parser.add_argument('--gpu-memory-utilization', type=float, default=0.3,
+                        help='vLLM GPU memory fraction (default: 0.3)')
+
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print configuration and exit')
+
+    return parser.parse_args()
+
+
+def load_tasks(data_path):
+    """Load tasks from JSONL file."""
+    import json
+    tasks = []
+    with open(data_path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                tasks.append(json.loads(line))
+    return tasks
+
+
+def main():
+    args = parse_arguments()
+
+    tasks = load_tasks(args.data_path)
+    factory = ALGORITHM_FACTORIES[args.algorithm]
+
+    rollout = ITSRollout(
+        algorithm_factory=factory,
+        budget=args.budget,
+        reward_fn=contains_answer_reward,
+        max_concurrency=args.max_concurrency,
+    )
+
+    rollouts_per_iter = args.prompt_batch_size * args.group_size
+    candidates_per_iter = rollouts_per_iter * args.budget
+
+    print("ITS Hub + GRPO Training")
+    print("=" * 60)
+    print(f"Model:              {args.model_path}")
+    print(f"Data:               {args.data_path} ({len(tasks)} tasks)")
+    print(f"Algorithm:          {args.algorithm} (budget={args.budget})")
+    print(f"Backend:            art (single GPU)")
+    print()
+    print("GRPO Configuration:")
+    print(f"  Iterations:       {args.num_iterations}")
+    print(f"  Prompts/batch:    {args.prompt_batch_size}")
+    print(f"  Group size:       {args.group_size}")
+    print(f"  Rollouts/iter:    {rollouts_per_iter}")
+    print(f"  LM calls/iter:    {candidates_per_iter} ({rollouts_per_iter} x {args.budget})")
+    print(f"  Outer concurrency:{args.concurrency}")
+    print(f"  Inner concurrency:{args.max_concurrency}")
+    print(f"  Learning rate:    {args.learning_rate}")
+    print()
+    print("LoRA Configuration:")
+    print(f"  Rank (r):         {args.lora_r}")
+    print(f"  Alpha:            {args.lora_alpha}")
+    print(f"  GPU mem util:     {args.gpu_memory_utilization}")
+    print("=" * 60)
+
+    if args.dry_run:
+        print("\nDry run — exiting without training")
+        return
+
+    print(f"\nStarting training at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    start_time = time.time()
+
+    try:
+        result = lora_grpo(
+            model_path=args.model_path,
+            ckpt_output_dir=args.ckpt_output_dir,
+            rollout_fn=rollout,
+            tasks=tasks,
+            backend="art",
+            num_iterations=args.num_iterations,
+            group_size=args.group_size,
+            prompt_batch_size=args.prompt_batch_size,
+            learning_rate=args.learning_rate,
+            concurrency=args.concurrency,
+            lora_r=args.lora_r,
+            lora_alpha=args.lora_alpha,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+        )
+
+        elapsed = time.time() - start_time
+        print()
+        print("=" * 60)
+        print("Training completed!")
+        print(f"Time:              {elapsed:.0f}s ({elapsed/3600:.1f}h)")
+        print(f"Total rollouts:    {result.get('total_rollouts', '?')}")
+        print(f"Final reward:      {result.get('final_mean_reward', '?')}")
+        if 'reward_history' in result:
+            print(f"Reward history:    {[f'{r:.3f}' for r in result['reward_history']]}")
+        print("=" * 60)
+
+    except Exception as e:
+        elapsed = time.time() - start_time
+        print()
+        print("=" * 60)
+        print(f"Training failed after {elapsed:.1f}s")
+        print(f"Error: {e}")
+        print()
+        print("Troubleshooting:")
+        print("  - Ensure its_hub is installed: pip install its_hub[lm]")
+        print("  - Ensure openpipe-art is installed")
+        print("  - Reduce budget: --budget 3")
+        print("  - Reduce concurrency: --concurrency 8 --max-concurrency 8")
+        print("  - Reduce GPU memory: --gpu-memory-utilization 0.2")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -8,6 +8,7 @@ from .algorithms.gepa import gepa, GEPAAlgorithm, GEPABackend, MLflowGEPABackend
 from .algorithms.rewards import tool_call_reward, binary_reward
 from .hub_core import welcome
 from .profiling.memory_estimator import BasicEstimator, OSFTEstimatorExperimental, estimate, OSFTEstimator, LoRAEstimator, QLoRAEstimator
+from .algorithms.its_rollout import ITSRollout
 from .visualization import plot_loss
 
 __all__ = [
@@ -42,5 +43,6 @@ __all__ = [
     'LoRAEstimator',
     'QLoRAEstimator',
     'estimate',
+    'ITSRollout',
     'plot_loss',
 ]

--- a/src/training_hub/algorithms/its_rollout.py
+++ b/src/training_hub/algorithms/its_rollout.py
@@ -1,0 +1,181 @@
+"""ITS Hub integration for GRPO rollouts.
+
+Provides ITSRollout, a picklable adapter that uses ITS Hub generation
+algorithms (BestOfN, SelfConsistency, etc.) as rollout functions for
+lora_grpo() with the ART backend.
+
+Requires: its_hub (optional dependency, imported lazily)
+"""
+
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _dict_to_choice(response: dict):
+    """Convert an ITS Hub response dict (with _raw_choice) to an OpenAI SDK Choice."""
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+    raw = response.get("_raw_choice", {})
+    msg_kwargs: dict[str, Any] = {
+        "role": response.get("role", "assistant"),
+        "content": response.get("content"),
+    }
+    if "tool_calls" in response:
+        msg_kwargs["tool_calls"] = response["tool_calls"]
+    return Choice(
+        index=raw.get("index", 0),
+        finish_reason=raw.get("finish_reason", "stop"),
+        message=ChatCompletionMessage(**msg_kwargs),
+    )
+
+
+class ITSRollout:
+    """Picklable rollout adapter that uses ITS Hub algorithms for GRPO training.
+
+    Uses ITS Hub's generation strategies (BestOfN, SelfConsistency, BeamSearch,
+    ParticleFiltering) as the rollout mechanism for ``lora_grpo()`` with the
+    ART backend.
+
+    The ``algorithm_factory`` and ``reward_fn`` must be defined at module level
+    (not lambdas or closures) because ART runs in a spawned subprocess.
+
+    Concurrency note: each rollout generates ``budget`` LM calls internally
+    via ITS Hub's orchestrator. With ``group_size=8``, ``prompt_batch_size=50``,
+    and ``budget=8``, that's 50*8*8=3200 concurrent LM calls. Use
+    ``max_concurrency`` to limit the inner ITS Hub calls, and
+    ``lora_grpo(concurrency=...)`` to limit the outer rollout calls.
+
+    Args:
+        algorithm_factory: Module-level function ``(lm) -> AbstractScalingAlgorithm``.
+            Receives an ITS Hub LM pointed at the training model's vLLM server
+            and returns a configured algorithm instance. If the algorithm needs
+            a reward model (e.g., BestOfN with LLMJudge), construct it here
+            using the provided ``lm`` — note that judge calls add to the total
+            LM call count beyond ``budget``.
+        budget: Number of candidates to generate per rollout.
+        reward_fn: Module-level function ``(response_text, task) -> float``.
+            Scores the selected response. This is separate from
+            ``lora_grpo(reward_fn=...)`` — do not pass both.
+        message_key: Key in the task dict containing the prompt messages.
+        temperature: Sampling temperature for generation.
+        max_tokens: Maximum response tokens.
+        max_concurrency: Max concurrent LM calls within each ITS Hub rollout.
+            Controls the ITS Hub orchestrator's concurrency limit. Default 32.
+
+    Example::
+
+        from its_hub import SelfConsistency
+        from training_hub.algorithms.its_rollout import ITSRollout
+
+        def make_sc(lm):
+            return SelfConsistency()
+
+        def my_reward(response_text, task):
+            return 1.0 if task["answer"] in response_text else 0.0
+
+        rollout = ITSRollout(
+            algorithm_factory=make_sc,
+            budget=8,
+            reward_fn=my_reward,
+        )
+
+        lora_grpo(
+            model_path="Qwen/Qwen3-4B",
+            rollout_fn=rollout,
+            tasks=my_tasks,
+            backend="art",
+        )
+    """
+
+    def __init__(
+        self,
+        algorithm_factory: Callable,
+        budget: int,
+        reward_fn: Callable[[str, dict], float],
+        message_key: str = "messages",
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        max_concurrency: int = 32,
+    ):
+        self.algorithm_factory = algorithm_factory
+        self.budget = budget
+        self.reward_fn = reward_fn
+        self.message_key = message_key
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.max_concurrency = max_concurrency
+
+        # Lazy-initialized after unpickling in ART's subprocess
+        self._lm = None
+        self._algorithm = None
+
+    async def __call__(self, model, task) -> Any:
+        """Run an ITS Hub algorithm and return an ART Trajectory.
+
+        Args:
+            model: ART TrainableModel with ``.openai_client()`` and
+                ``.get_inference_name()`` methods.
+            task: Task dict; must contain a key matching ``self.message_key``.
+
+        Returns:
+            ``art.Trajectory`` with ``.reward`` set.
+        """
+        import art
+
+        if self._lm is None:
+            self._init_its_hub(model)
+
+        messages = task[self.message_key]
+
+        try:
+            result = await self._algorithm.ainfer(
+                self._lm,
+                messages,
+                budget=self.budget,
+                return_response_only=False,
+            )
+
+            selected = result.the_one
+            choice = _dict_to_choice(selected)
+            response_text = selected.get("content") or ""
+
+            trajectory = art.Trajectory(
+                messages_and_choices=list(messages) + [choice],
+            )
+            trajectory.reward = float(self.reward_fn(response_text, task))
+            return trajectory
+
+        except Exception as e:
+            logger.warning("ITS Hub rollout failed: %s", e)
+            trajectory = art.Trajectory(
+                messages_and_choices=[
+                    {"role": "system", "content": "failed"},
+                    {"role": "user", "content": "failed"},
+                ],
+            )
+            trajectory.reward = 0.0
+            return trajectory
+
+    def _init_its_hub(self, model) -> None:
+        """Create ITS Hub LM and algorithm on first call."""
+        from its_hub import OpenAICompatibleLanguageModel
+
+        client = model.openai_client()
+
+        lm_kwargs: dict[str, Any] = {
+            "endpoint": str(client.base_url),
+            "api_key": client.api_key or "EMPTY",
+            "model_name": model.get_inference_name(),
+            "include_raw_choices": True,
+            "max_concurrency": self.max_concurrency,
+        }
+        if self.temperature is not None:
+            lm_kwargs["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            lm_kwargs["max_tokens"] = self.max_tokens
+
+        self._lm = OpenAICompatibleLanguageModel(**lm_kwargs)
+        self._algorithm = self.algorithm_factory(self._lm)

--- a/src/training_hub/algorithms/its_rollout.py
+++ b/src/training_hub/algorithms/its_rollout.py
@@ -7,6 +7,7 @@ lora_grpo() with the ART backend.
 Requires: its_hub (optional dependency, imported lazily)
 """
 
+import asyncio
 import logging
 from typing import Any, Callable, Optional
 
@@ -111,6 +112,17 @@ class ITSRollout:
         # Lazy-initialized after unpickling in ART's subprocess
         self._lm = None
         self._algorithm = None
+        self._init_lock = None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_lm"] = None
+        state["_algorithm"] = None
+        state["_init_lock"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
     async def __call__(self, model, task) -> Any:
         """Run an ITS Hub algorithm and return an ART Trajectory.
@@ -124,10 +136,21 @@ class ITSRollout:
             ``art.Trajectory`` with ``.reward`` set.
         """
         import art
+        from openai.types.chat.chat_completion import Choice
+        from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
         if self._lm is None:
-            self._init_its_hub(model)
+            if self._init_lock is None:
+                self._init_lock = asyncio.Lock()
+            async with self._init_lock:
+                if self._lm is None:
+                    self._init_its_hub(model)
 
+        if self.message_key not in task:
+            raise KeyError(
+                f"Task is missing key '{self.message_key}'. "
+                f"Available keys: {list(task.keys())}"
+            )
         messages = task[self.message_key]
 
         try:
@@ -139,6 +162,11 @@ class ITSRollout:
             )
 
             selected = result.the_one
+            if selected is None:
+                raise ValueError(
+                    "ITS Hub algorithm returned no selected candidate "
+                    "(result.the_one is None)"
+                )
             choice = _dict_to_choice(selected)
             response_text = selected.get("content") or ""
 
@@ -148,13 +176,17 @@ class ITSRollout:
             trajectory.reward = float(self.reward_fn(response_text, task))
             return trajectory
 
-        except Exception as e:
-            logger.warning("ITS Hub rollout failed: %s", e)
+        except (ConnectionError, TimeoutError) as e:
+            logger.warning("ITS Hub rollout failed (retriable): %s", e)
+            fallback_choice = Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(
+                    role="assistant", content="[rollout failed]"
+                ),
+            )
             trajectory = art.Trajectory(
-                messages_and_choices=[
-                    {"role": "system", "content": "failed"},
-                    {"role": "user", "content": "failed"},
-                ],
+                messages_and_choices=list(messages) + [fallback_choice],
             )
             trajectory.reward = 0.0
             return trajectory


### PR DESCRIPTION
## Summary

- Add `ITSRollout` adapter class that lets users plug ITS Hub inference-time scaling algorithms (BestOfN, SelfConsistency, BeamSearch, ParticleFiltering) into `lora_grpo()` as custom rollout functions
- Add example script demonstrating usage with SelfConsistency and BestOfN
- ART backend only — verl support is a follow-up

## Motivation

Users can already pass custom `rollout_fn` to `lora_grpo()` with the ART backend, but must manually implement generation logic. ITS Hub provides sophisticated generation strategies that produce higher-quality training signal for GRPO. This adapter bridges the two with minimum changes — one new file, no modifications to `lora_grpo.py`.

## Design

`ITSRollout` is a picklable callable class that:
1. Points ITS Hub's `OpenAICompatibleLanguageModel` at the training model's co-located vLLM server (using `include_raw_choices=True` to preserve full API response data)
2. Runs the user's chosen ITS Hub algorithm to generate and select a response
3. Converts the result to an `art.Trajectory` with the reward set by the user's reward function

The user provides:
- `algorithm_factory` — module-level function `(lm) -> algorithm` (picklable)
- `reward_fn` — module-level function `(response_text, task) -> float` (picklable)
- `budget` — candidates per rollout

## Dependencies

Requires ITS Hub with `include_raw_choices` support (merged in its_hub#226).

## Files changed

- **New:** `src/training_hub/algorithms/its_rollout.py` — `_dict_to_choice()` helper + `ITSRollout` class
- **Edit:** `src/training_hub/__init__.py` — export `ITSRollout`
- **New:** `examples/scripts/its_rollout_example.py` — example with SelfConsistency and BestOfN

## Test plan

- [x] Verify `ITSRollout` is importable: `from training_hub import ITSRollout`
- [x] Verify picklability: `pickle.dumps/loads` round-trips successfully (including `mp.get_context("spawn")`)
- [x] Verify no regressions on existing imports
- [ ] End-to-end test with SelfConsistency on full GRPO training loop (requires `openpipe-art`)

## Verified with real vLLM

Tested against a live vLLM 0.9.1 server serving **Qwen/Qwen2.5-0.5B-Instruct** on an NVIDIA H100.

### `_dict_to_choice` conversion

- [x] Converts text response to OpenAI SDK `Choice` — correct `finish_reason`, `message.role`, `message.content`
- [x] Preserves `tool_calls` when present

### `_raw_choice` correctness

- [x] `_raw_choice` present when `include_raw_choices=True` — keys: `index`, `message`, `logprobs`, `finish_reason`, `stop_reason`
- [x] No circular reference: `result is not result["_raw_choice"]["message"]` → `True`
- [x] `json.dumps()` succeeds (270 bytes) — no infinite recursion
- [x] JSON roundtrip preserves all data
- [x] `_raw_choice` absent when `include_raw_choices=False` (default behavior unchanged)

### SelfConsistency end-to-end (budget=3)

- [x] `ITSRollout._init_its_hub()` creates `OpenAICompatibleLanguageModel` + `SelfConsistency` from mock ART model
- [x] 3 candidates generated via live vLLM
- [x] `_raw_choice` present on **all** candidates (flows through ITS Hub algorithm)
- [x] `_dict_to_choice` converts each candidate to OpenAI SDK `Choice`
- [x] `json.dumps()` succeeds on all responses (822 bytes)
- [x] Selected response correct ("180" for "What is 12*15?"), reward=1.0

### Picklability

- [x] `pickle.dumps/loads` roundtrip preserves `budget`, `max_concurrency`, all config
- [x] Lazy state (`_lm`, `_algorithm`) correctly `None` after unpickling
- [x] Works with `mp.get_context("spawn")` pickle protocol

### Not yet tested

- [ ] Full `ITSRollout.__call__` with `art.Trajectory` construction (`openpipe-art` not installed in test venv)
- [ ] BestOfN with `LLMJudge` as `algorithm_factory`
- [ ] Full GRPO training loop with `lora_grpo(rollout_fn=ITSRollout(...), backend="art")`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an ITS Hub–backed rollout adapter for GRPO training with selectable rollout strategies and custom reward scoring.
  * Exposed `ITSRollout` in the public `training_hub` API.
  * Added an example script to configure ITS rollout + LoRA-based GRPO training (including SelfConsistency and BestOfN options).

* **Bug Fixes**
  * Improved resilience by handling connection/timeout failures with a safe fallback trajectory during rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->