### PR TITLE
Fix ART backend compatibility with newer NVIDIA drivers

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -711,6 +711,12 @@ class ARTLoRAGRPOBackend(Backend):
         # Pass results_path into params so _run_training can save before shutdown
         algorithm_params["_results_path"] = results_path
         try:
+            # Import unsloth first to apply vLLM/TRL compatibility patches
+            # (e.g. GuidedDecodingParams shim for older vLLM versions)
+            try:
+                import unsloth  # noqa: F401
+            except ImportError:
+                pass
             import art
             from art.local.backend import LocalBackend
             asyncio.run(
@@ -832,6 +838,8 @@ class ARTLoRAGRPOBackend(Backend):
         # appear here (not just in init_args) because ART reads it from
         # engine_args when constructing AsyncEngineArgs for vLLM.
         engine_kwargs = {"gpu_memory_utilization": gpu_memory_utilization}
+        if params.get("enforce_eager"):
+            engine_kwargs["enforce_eager"] = True
         effective_max_lora_rank = max_lora_rank if max_lora_rank else lora_r
         if effective_max_lora_rank > 16:
             engine_kwargs["max_lora_rank"] = effective_max_lora_rank
@@ -1292,6 +1300,7 @@ class LoRAGRPOAlgorithm(Algorithm):
         # vLLM configuration
         gpu_memory_utilization: Optional[float] = None,
         max_lora_rank: Optional[int] = None,
+        enforce_eager: Optional[bool] = None,
         # Multi-GPU/multi-node configuration (verl backend)
         n_gpus: Optional[int] = None,
         nnodes: Optional[int] = None,
@@ -1409,6 +1418,7 @@ class LoRAGRPOAlgorithm(Algorithm):
             "max_grad_norm": max_grad_norm,
             "gpu_memory_utilization": gpu_memory_utilization,
             "max_lora_rank": max_lora_rank,
+            "enforce_eager": enforce_eager,
             "n_gpus": n_gpus,
             "nnodes": nnodes,
             "tensor_parallel_size": tensor_parallel_size,
@@ -1466,6 +1476,7 @@ class LoRAGRPOAlgorithm(Algorithm):
             # vLLM
             "gpu_memory_utilization": float,
             "max_lora_rank": int,
+            "enforce_eager": bool,
             "n_gpus": int,
             "nnodes": int,
             "tensor_parallel_size": int,
@@ -1526,6 +1537,7 @@ def lora_grpo(
     # vLLM configuration
     gpu_memory_utilization: float = 0.45,
     max_lora_rank: Optional[int] = None,
+    enforce_eager: bool = False,
     # Multi-GPU/multi-node configuration (verl backend)
     n_gpus: int = 1,
     nnodes: int = 1,
@@ -1688,6 +1700,7 @@ def lora_grpo(
         max_grad_norm=max_grad_norm,
         gpu_memory_utilization=gpu_memory_utilization,
         max_lora_rank=max_lora_rank,
+        enforce_eager=enforce_eager,
         n_gpus=n_gpus,
         nnodes=nnodes,
         tensor_parallel_size=tensor_parallel_size,


### PR DESCRIPTION
## Summary

Two fixes for `lora_grpo` with the ART backend that resolve crashes on nodes with newer NVIDIA drivers (580+/610+).

## Changes

### 1. Import unsloth before art in subprocess

The ART backend runs training in a spawned subprocess. That subprocess imports `art.unsloth.service` which imports `from trl import GRPOTrainer`, which in turn tries to import `GuidedDecodingParams` from vLLM. This class doesn't exist in vLLM ≤0.21, causing an `ImportError`.

Unsloth patches `vllm.sampling_params` with a `GuidedDecodingParams` shim, but only if imported first. Adding `import unsloth` before `import art` in `_subprocess_entry` ensures the patch is applied before trl tries the import.

### 2. Expose `enforce_eager` parameter

On nodes with newer NVIDIA drivers, vLLM's torch.fx compilation pipeline crashes with:
```
RuntimeError: Tried to erase Node size_X but it still had N users in the graph
```

This affects vLLM 0.19-0.23 with torch 2.10-2.11. Setting `enforce_eager=True` disables torch.compile and CUDA graph capture in vLLM, bypassing the issue entirely.

```python
# Before: crashes on newer drivers
lora_grpo(model_path="Qwen/Qwen3-4B", ...)

# After: works on all drivers
lora_grpo(model_path="Qwen/Qwen3-4B", ..., enforce_eager=True)
```

The parameter is exposed on `lora_grpo()`, `grpo()`, and the `LoRAGRPOAlgorithm.train()` method.

## Test plan

- [x] Basic `lora_grpo(backend="art", enforce_eager=True)` completes on node with driver 610
- [x] Unsloth GuidedDecodingParams patch applies correctly in subprocess
- [x] `enforce_eager=False` (default) preserves existing behavior on compatible systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added `enforce_eager` configuration option to LoRA+GRPO training pipeline, enabling control over eager execution behavior during training
  - Improved subprocess initialization with enhanced compatibility handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->