### PR TITLE
Document validation loss support for SFT and OSFT backends

### DIFF
--- a/.claude/skills/training-hub-guide/SKILL.md
+++ b/.claude/skills/training-hub-guide/SKILL.md
@@ -190,8 +190,8 @@ plot_loss(["./run1", "./run2"], labels=["baseline", "tuned"], ema=True)
 
 - **Train loss alone is insufficient.** A model can converge on train loss forever while overfitting badly.
 - **Validation loss is the real signal.** Look for where validation loss stops decreasing or starts increasing (optimal training regime vs overfitting).
-- SFT backend does not currently support validation loss (planned). OSFT and LoRA do support it but it must be explicitly enabled via backend kwargs. See [backend-kwargs.md](backend-kwargs.md).
-- When validation loss is unavailable, rely on downstream evaluation to gauge actual model quality.
+- SFT and OSFT backends support validation loss via `validation_split` and `validation_frequency` kwargs. OSFT also supports `save_best_val_loss`. See [backend-kwargs.md](backend-kwargs.md) and the [Validation Loss Guide](/guides/validation-loss).
+- When validation loss is unavailable (LoRA, GRPO), rely on downstream evaluation to gauge actual model quality.
 
 ## Backend kwargs passthrough
 

--- a/.claude/skills/training-hub-guide/backend-kwargs.md
+++ b/.claude/skills/training-hub-guide/backend-kwargs.md
@@ -42,7 +42,8 @@ Note: W&B, MLflow, and TensorBoard logging are now first-class parameters on all
 - **Config definitions**: https://github.com/instructlab/training/blob/main/src/instructlab/training/config.py
 - **Training entry point**: https://github.com/instructlab/training/blob/main/src/instructlab/training/main_ds.py
 
-Note: The SFT backend does not currently support validation loss (planned for future release).
+Notable hidden options:
+- Validation loss configuration (`validation_split`, `validation_frequency`) for convergence monitoring
 
 ### LoRA (Unsloth)
 
@@ -56,12 +57,12 @@ Note: W&B, MLflow, and TensorBoard logging are now first-class parameters on all
 
 ## Validation loss
 
-For determining optimal training duration, validation loss is more reliable than train loss.
+For determining optimal training duration, validation loss is more reliable than train loss. See the [Validation Loss Guide](/guides/validation-loss) for full documentation.
 
 | Backend | Validation loss support | How to enable |
 |---------|------------------------|---------------|
-| SFT (instructlab-training) | Not yet supported | Planned |
-| OSFT (mini-trainer) | Supported | Pass appropriate kwargs from `TrainingArgs` (see mini-trainer source) |
-| LoRA (Unsloth/TRL) | Supported | Configure via `SFTTrainer` evaluation kwargs |
+| SFT (instructlab-training) | Supported | Pass `validation_split` and `validation_frequency` as kwargs |
+| OSFT (mini-trainer) | Supported | Pass `validation_split` and `validation_frequency` as kwargs. Also supports `save_best_val_loss` and `val_loss_improvement_threshold` |
+| LoRA (Unsloth/TRL) | Not supported | No eval dataset is provided to the SFTTrainer |
 
 When validation loss is available, look for the point where it stops decreasing or begins increasing. Training beyond this point leads to overfitting: the train loss continues to drop but the model's actual performance degrades.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -45,6 +45,7 @@
 
 * Guides
   * [Experiment Tracking & Logging](/guides/logging)
+  * [Validation Loss](/guides/validation-loss)
   * [Distributed Training](/guides/distributed-training)
   * [Data Preparation](/guides/data-preparation)
   * [Continual Pretraining](/guides/continual-pretraining)

--- a/docs/api/backends/instructlab-training.md
+++ b/docs/api/backends/instructlab-training.md
@@ -102,6 +102,36 @@ The InstructLab Training backend supports all standard SFT parameters. See the [
 | `rdzv_endpoint` | Master node endpoint (host:port) |
 
 
+## Validation Loss
+
+The InstructLab Training backend supports validation loss monitoring. When enabled, a fraction of the training data is held out and the model is periodically evaluated on it.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. |
+| `validation_frequency` | `int` | `None` | Steps between validation evaluations. Required when `validation_split > 0`. |
+
+Pass these as kwargs through `sft()`:
+
+```python
+sft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    num_epochs=3,
+    effective_batch_size=32,
+    learning_rate=2e-5,
+    max_seq_len=2048,
+    max_tokens_per_gpu=45000,
+    validation_split=0.1,
+    validation_frequency=50,
+)
+```
+
+Validation metrics (`val_loss`, `val_num_tokens`) are logged to JSONL, TensorBoard, wandb, and MLflow alongside training metrics.
+
+See the [Validation Loss Guide](/guides/validation-loss) for details.
+
 ## Additional Parameters
 
 The InstructLab Training backend supports many additional parameters beyond those documented above. For a complete list of all available parameters, refer to the [`TrainingArgs` class in the InstructLab Training source code](https://github.com/instructlab/training/blob/main/src/instructlab/training/config.py).

--- a/docs/api/backends/mini-trainer.md
+++ b/docs/api/backends/mini-trainer.md
@@ -119,6 +119,42 @@ The Mini-Trainer backend supports all standard OSFT parameters. See the [`osft()
 | `rdzv_endpoint` | Master node endpoint |
 
 
+## Validation Loss
+
+The Mini-Trainer backend supports validation loss monitoring with optional best-val-loss checkpointing.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. |
+| `validation_frequency` | `int` | `None` | Steps between validation evaluations. Required when `validation_split > 0`. |
+| `save_best_val_loss` | `bool` | `False` | Save a checkpoint whenever validation loss improves. |
+| `val_loss_improvement_threshold` | `float` | `0.0` | Minimum improvement in validation loss required to trigger a best-val-loss checkpoint save. |
+
+Pass these as kwargs through `osft()`:
+
+```python
+osft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    unfreeze_rank_ratio=0.25,
+    effective_batch_size=16,
+    max_tokens_per_gpu=2048,
+    max_seq_len=1024,
+    learning_rate=5e-6,
+    num_epochs=5,
+    validation_split=0.1,
+    validation_frequency=100,
+    save_best_val_loss=True,
+)
+```
+
+Validation metrics (`val_loss`, `val_num_samples`, `val_num_loss_counted_tokens`, `val_num_batches`) are logged to JSONL, wandb, and MLflow alongside training metrics.
+
+See the [Validation Loss Guide](/guides/validation-loss) for details.
+
+## Additional Parameters
+
 Beyond the parameters listed above, the Mini-Trainer backend supports many additional parameters beyond those documented above. For a complete list of all available parameters, refer to the [`TrainingArgs` class in the Mini-Trainer source code](https://github.com/Red-Hat-AI-Innovation-Team/mini_trainer/blob/main/src/mini_trainer/training_types.py).
 
 The package provides many other useful parameters which we avoid documenting so our docs do not go out of sync with the package. 

--- a/docs/api/functions/osft.md
+++ b/docs/api/functions/osft.md
@@ -134,6 +134,17 @@ Loggers are automatically enabled when their configuration parameters are set:
 
 > **Note:** OSFT does not support TensorBoard logging.
 
+#### Validation Loss
+
+Validation loss is supported via `**kwargs`. See the [Validation Loss Guide](/guides/validation-loss) for full details.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. |
+| `validation_frequency` | `int` | `None` | Steps between validation evaluations. Required when `validation_split > 0`. |
+| `save_best_val_loss` | `bool` | `False` | Save a checkpoint whenever validation loss improves. |
+| `val_loss_improvement_threshold` | `float` | `0.0` | Minimum improvement required to trigger a best-val-loss checkpoint save. |
+
 #### Additional Parameters
 
 | Parameter | Type | Default | Description |

--- a/docs/api/functions/sft.md
+++ b/docs/api/functions/sft.md
@@ -119,6 +119,15 @@ Loggers are automatically enabled when their configuration parameters are set:
 | `wandb_run_name`         | `str` | `None`                     | W&B run name.                                                                   |
 | `tensorboard_log_dir`    | `str` | `None`                     | TensorBoard log directory. Enables TensorBoard.                                 |
 
+#### Validation Loss
+
+Validation loss is supported via `**kwargs`. See the [Validation Loss Guide](/guides/validation-loss) for full details.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. |
+| `validation_frequency` | `int` | `None` | Steps between validation evaluations. Required when `validation_split > 0`. |
+
 #### Additional Parameters
 
 | Parameter | Type | Default | Description |

--- a/docs/guides/validation-loss.md
+++ b/docs/guides/validation-loss.md
@@ -1,0 +1,178 @@
+# Validation Loss
+
+Training Hub supports validation loss monitoring through its underlying backends. When enabled, a fraction of the training data is held out and the model is periodically evaluated on it, giving you a signal for overfitting and helping you decide when to stop training.
+
+## Support Matrix
+
+| Algorithm | Backend | Validation Loss | Best-Val-Loss Checkpointing |
+|-----------|---------|:---------------:|:---------------------------:|
+| [SFT](/api/functions/sft) | [instructlab-training](/api/backends/instructlab-training) | Yes | No |
+| [OSFT](/api/functions/osft) | [mini-trainer](/api/backends/mini-trainer) | Yes | Yes |
+| [LoRA](/api/functions/lora_sft) | [Unsloth](/api/backends/unsloth) | No | No |
+| [LoRA GRPO](/api/functions/lora_grpo) | [ART](/api/backends/art-grpo) / [verl](/api/backends/verl) | No | No |
+
+?> **Validation loss is not a first-class Training Hub parameter yet.** SFT and OSFT support it through their backends via `**kwargs`. Pass the backend-native parameter names listed below directly to the convenience function or `Algorithm.train()` call.
+
+## How It Works
+
+Both supported backends follow the same approach:
+
+1. **Data splitting**: The training dataset is automatically split into train and validation sets using the `validation_split` ratio. The split uses a fixed seed for reproducibility.
+2. **Periodic evaluation**: Every `validation_frequency` training steps, the model is set to eval mode and the full validation set is processed under `torch.no_grad()`.
+3. **Loss computation**: Per-token cross-entropy loss is computed, summed across all tokens and all distributed ranks, then divided by the total number of loss-counted tokens to produce the average validation loss.
+4. **Metric logging**: Validation metrics are written to the same logging destinations as training metrics (JSONL file, wandb, MLflow, etc.).
+
+## SFT (instructlab-training backend)
+
+### Parameters
+
+Pass these as `**kwargs` to `sft()` or `SFTAlgorithm.train()`:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation. Range: `[0.0, 1.0)`. Setting `0.0` (default) disables validation. |
+| `validation_frequency` | `int` | `None` | How often to run validation, in training steps. **Required** when `validation_split > 0`. |
+
+### Metrics
+
+When validation runs, the following metrics are emitted alongside training metrics:
+
+| Metric | Description |
+|--------|-------------|
+| `val_loss` | Average per-token validation loss |
+| `val_num_tokens` | Total number of tokens evaluated |
+
+These appear in:
+- **JSONL file** (`training_params_and_metrics_global0.jsonl`)
+- **TensorBoard** (rank 0 only)
+- **wandb** (rank 0 only)
+- **MLflow** (rank 0 only)
+
+### Example
+
+```python
+from training_hub import sft
+
+result = sft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./training_data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    num_epochs=3,
+    effective_batch_size=32,
+    learning_rate=2e-5,
+    max_seq_len=2048,
+    max_tokens_per_gpu=45000,
+    # Validation loss configuration
+    validation_split=0.1,        # Hold out 10% of data
+    validation_frequency=50,     # Evaluate every 50 steps
+)
+```
+
+## OSFT (mini-trainer backend)
+
+### Parameters
+
+Pass these as `**kwargs` to `osft()` or `OSFTAlgorithm.train()`:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation. Range: `[0.0, 1.0)`. Setting `0.0` (default) disables validation. |
+| `validation_frequency` | `int` | `None` | How often to run validation, in training steps. **Required** when `validation_split > 0`. |
+| `save_best_val_loss` | `bool` | `False` | Save a checkpoint whenever validation loss improves. |
+| `val_loss_improvement_threshold` | `float` | `0.0` | Minimum improvement in validation loss required to trigger a best-val-loss checkpoint save. |
+
+### Metrics
+
+When validation runs, the following metrics are emitted alongside training metrics:
+
+| Metric | Description |
+|--------|-------------|
+| `val_loss` | Average per-token validation loss |
+| `val_num_samples` | Total number of validation samples processed |
+| `val_num_loss_counted_tokens` | Total tokens counted for loss computation |
+| `val_num_batches` | Number of validation batches processed |
+
+These appear in:
+- **JSONL file** (`training_metrics.jsonl`)
+- **wandb** (if configured)
+- **MLflow** (if configured)
+
+### Best-Val-Loss Checkpointing
+
+The mini-trainer backend can automatically save a checkpoint when validation loss improves. Enable this with `save_best_val_loss=True`. The checkpoint directory will have a `_best_val_loss` suffix.
+
+Use `val_loss_improvement_threshold` to require a minimum improvement before saving, which avoids excessive checkpoint writes when loss is plateauing:
+
+```python
+from training_hub import osft
+
+result = osft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./domain_data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    unfreeze_rank_ratio=0.25,
+    effective_batch_size=16,
+    max_tokens_per_gpu=2048,
+    max_seq_len=1024,
+    learning_rate=5e-6,
+    num_epochs=5,
+    # Validation loss configuration
+    validation_split=0.1,                  # Hold out 10% of data
+    validation_frequency=100,              # Evaluate every 100 steps
+    # Best-val-loss checkpointing
+    save_best_val_loss=True,               # Save checkpoint on improvement
+    val_loss_improvement_threshold=0.01,   # Require at least 0.01 improvement
+)
+```
+
+### Basic Example
+
+```python
+from training_hub import osft
+
+result = osft(
+    model_path="meta-llama/Llama-3.1-8B-Instruct",
+    data_path="./continual_learning_data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    unfreeze_rank_ratio=0.25,
+    effective_batch_size=32,
+    max_tokens_per_gpu=4096,
+    max_seq_len=2048,
+    learning_rate=2e-5,
+    num_epochs=3,
+    nproc_per_node=4,
+    # Validation loss configuration
+    validation_split=0.1,        # Hold out 10% of data
+    validation_frequency=50,     # Evaluate every 50 steps
+)
+```
+
+## Interpreting Validation Loss
+
+Validation loss is the primary signal for detecting overfitting:
+
+- **Both training and validation loss decreasing**: Training is progressing well. Continue training.
+- **Training loss decreasing but validation loss increasing**: The model is overfitting. Stop training or reduce the number of epochs.
+- **Validation loss plateauing**: The model has learned what it can from the data. Further training provides diminishing returns.
+
+?> **Tip**: Use `plot_loss()` to visualize training metrics. Validation loss metrics (`val_loss`) are included in the JSONL log files alongside training loss.
+
+```python
+from training_hub import plot_loss
+
+plot_loss("./checkpoints")
+```
+
+## Choosing `validation_split` and `validation_frequency`
+
+- **`validation_split`**: 5-15% is typical. Smaller datasets benefit from a smaller split (5%) to keep more data for training. Larger datasets can afford 10-15%.
+- **`validation_frequency`**: Balance between monitoring granularity and training speed. Validation pauses training while it runs. Every 50-200 steps is a common range. For short runs, evaluate less frequently; for long runs, more frequently.
+
+## See Also
+
+- [**Experiment Tracking & Logging**](/guides/logging) - Configure where metrics are logged
+- [**sft() Function**](/api/functions/sft) - SFT parameter reference
+- [**osft() Function**](/api/functions/osft) - OSFT parameter reference
+- [**InstructLab Training Backend**](/api/backends/instructlab-training) - Backend details
+- [**Mini-Trainer Backend**](/api/backends/mini-trainer) - Backend details
+- [**Data Preparation**](/guides/data-preparation) - Data splitting best practices


### PR DESCRIPTION
## Summary

- Adds a new **Validation Loss Guide** (`docs/guides/validation-loss.md`) documenting how to enable and use validation loss monitoring during SFT and OSFT training
- Adds **Validation Loss** sections to the instructlab-training and mini-trainer backend docs with parameter tables and examples
- Adds validation parameter tables to the `sft()` and `osft()` function reference docs
- Updates sidebar navigation to include the new guide
- Fixes internal skill docs (`backend-kwargs.md`, `SKILL.md`) which incorrectly stated that the SFT (instructlab-training) backend did not support validation loss

## Context

Both the `instructlab-training` and `mini_trainer` backends have supported validation loss for some time, but Training Hub never documented this capability. The backends support:

- **instructlab-training (SFT)**: `validation_split` and `validation_frequency` parameters, emitting `val_loss` and `val_num_tokens` metrics
- **mini-trainer (OSFT)**: Same two parameters plus `save_best_val_loss` and `val_loss_improvement_threshold` for automatic best-checkpoint saving, emitting `val_loss`, `val_num_samples`, `val_num_loss_counted_tokens`, and `val_num_batches` metrics

These are passed as `**kwargs` through the Training Hub convenience functions to the backend.

## Test plan

- [ ] Verify docs render correctly with `docsify serve`
- [ ] Verify all internal links resolve (sidebar, cross-references between guide and function/backend docs)
- [ ] Verify parameter names match the actual backend source code (`TrainingArgs` in both instructlab-training and mini_trainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation loss monitoring guidance across training backends.
  * Added a new guide and API docs for validation-loss settings, metric logging, and checkpointing.
  * Added navigation links to the new validation-loss documentation.

* **Documentation**
  * Clarified which training modes support validation loss and best-loss checkpointing.
  * Added usage examples and recommended settings for validation split and evaluation frequency.
  * Expanded guidance on interpreting validation loss trends and visualizing metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->