### PR TITLE
docs: document AdamW optimizer hyperparameters for SFT and OSFT

### DIFF
--- a/docs/api/backends/instructlab-training.md
+++ b/docs/api/backends/instructlab-training.md
@@ -91,6 +91,19 @@ The InstructLab Training backend supports all standard SFT parameters. See the [
 | `checkpoint_at_epoch` | Save checkpoint after each epoch |
 | `accelerate_full_state_at_epoch` | Save full state for resumption |
 
+### Optimizer (AdamW) Parameters
+
+The InstructLab Training backend uses the AdamW optimizer. Training Hub exposes these hyperparameters as first-class parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beta1` | `float` | `0.9` | AdamW beta1 coefficient (first moment / momentum). |
+| `beta2` | `float` | `0.95` | AdamW beta2 coefficient (second moment / RMSprop). Note: default is `0.95`, not PyTorch's `0.999`. |
+| `eps` | `float` | `1e-8` | Epsilon for numerical stability. |
+| `weight_decay` | `float` | `0.0` | Weight decay (L2 regularization). |
+
+Training Hub translates these to the backend's native parameter names (`adamw_betas`, `adamw_eps`, `adamw_weight_decay`) automatically.
+
 ### Distributed Training Parameters
 
 | Parameter | Description |

--- a/docs/api/backends/mini-trainer.md
+++ b/docs/api/backends/mini-trainer.md
@@ -108,6 +108,19 @@ The Mini-Trainer backend supports all standard OSFT parameters. See the [`osft()
 | `checkpoint_at_epoch` | Save checkpoint after each epoch |
 | `save_final_checkpoint` | Save final model |
 
+### Optimizer (AdamW) Parameters
+
+The Mini-Trainer backend uses the AdamW optimizer. Training Hub exposes these hyperparameters as first-class parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beta1` | `float` | `0.9` | AdamW beta1 coefficient (first moment / momentum). |
+| `beta2` | `float` | `0.95` | AdamW beta2 coefficient (second moment / RMSprop). Note: default is `0.95`, not PyTorch's `0.999`. |
+| `eps` | `float` | `1e-8` | Epsilon for numerical stability. |
+| `weight_decay` | `float` | `0.0` | Weight decay (L2 regularization). |
+
+These parameter names match the mini-trainer `TrainingArgs` dataclass fields directly.
+
 ### Distributed Training Parameters
 
 | Parameter | Description |

--- a/docs/api/classes/OSFTAlgorithm.md
+++ b/docs/api/classes/OSFTAlgorithm.md
@@ -127,6 +127,15 @@ Executes the OSFT training process.
 | `use_liger` | `bool` | Backend default | Whether to use Liger kernels for improved performance. Requires `liger-kernel` package. |
 | `seed` | `int` | Backend default | Random seed for reproducibility. |
 
+###### Optimizer (AdamW) Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beta1` | `float` | `0.9` | AdamW beta1 coefficient — controls the exponential decay rate for the first moment estimates (momentum). |
+| `beta2` | `float` | `0.95` | AdamW beta2 coefficient — controls the exponential decay rate for the second moment estimates (RMSprop). Note: the backend default is `0.95`, not PyTorch's standard `0.999`. |
+| `eps` | `float` | `1e-8` | AdamW epsilon — a small constant added to the denominator for numerical stability. |
+| `weight_decay` | `float` | `0.0` | AdamW weight decay coefficient (L2 regularization). `0.0` means no weight decay. |
+
 ###### Checkpointing
 
 | Parameter | Type | Default | Description |
@@ -251,6 +260,10 @@ Returns the optional parameters for OSFT.
     "node_rank": int,
     "rdzv_id": int,
     "rdzv_endpoint": str,
+    "beta1": float,
+    "beta2": float,
+    "eps": float,
+    "weight_decay": float,
     # Plus additional backend-specific parameters via **kwargs
 }
 ```

--- a/docs/api/classes/SFTAlgorithm.md
+++ b/docs/api/classes/SFTAlgorithm.md
@@ -95,6 +95,15 @@ Executes the supervised fine-tuning process.
 | `warmup_steps` | `int` | Backend default | Number of warmup steps for the learning rate scheduler. |
 | `max_tokens_per_gpu` | `int` | Maximum number of tokens that can be on a single GPU at once. |
 
+###### Optimizer (AdamW) Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beta1` | `float` | `0.9` | AdamW beta1 coefficient — controls the exponential decay rate for the first moment estimates (momentum). |
+| `beta2` | `float` | `0.95` | AdamW beta2 coefficient — controls the exponential decay rate for the second moment estimates (RMSprop). Note: the backend default is `0.95`, not PyTorch's standard `0.999`. |
+| `eps` | `float` | `1e-8` | AdamW epsilon — a small constant added to the denominator for numerical stability. |
+| `weight_decay` | `float` | `0.0` | AdamW weight decay coefficient (L2 regularization). `0.0` means no weight decay. |
+
 ###### Data Processing
 
 | Parameter | Type | Default | Description |
@@ -151,7 +160,7 @@ Loggers are automatically enabled when their configuration parameters are set:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `**kwargs` | `Any` | - | Additional backend-specific parameters passed directly to `instructlab.training.TrainingArgs`. Examples include optimizer settings (e.g., `weight_decay`, `adam_beta1`), gradient clipping, and DeepSpeed configuration. |
+| `**kwargs` | `Any` | - | Additional backend-specific parameters passed directly to `instructlab.training.TrainingArgs`. Examples include gradient clipping and DeepSpeed configuration. |
 
 #### Default Behavior
 
@@ -238,6 +247,10 @@ This method is useful for discovering available configuration options programmat
     "node_rank": int,
     "rdzv_id": int,
     "rdzv_endpoint": str,
+    "beta1": float,
+    "beta2": float,
+    "eps": float,
+    "weight_decay": float,
     # Plus additional backend-specific parameters via **kwargs
 }
 ```

--- a/docs/api/functions/osft.md
+++ b/docs/api/functions/osft.md
@@ -32,6 +32,10 @@ def osft(
     checkpoint_at_epoch: bool | None = None,
     save_final_checkpoint: bool | None = None,
     num_epochs: int | None = None,
+    beta1: float | None = None,
+    beta2: float | None = None,
+    eps: float | None = None,
+    weight_decay: float | None = None,
     nproc_per_node: int | None = None,
     nnodes: int | None = None,
     node_rank: int | None = None,
@@ -96,6 +100,17 @@ def osft(
 | `lr_scheduler_kwargs` | `dict[str, str]` | `None` | Additional keyword arguments for the learning rate scheduler. |
 | `use_liger` | `bool` | Backend default | Whether to use Liger kernels for improved performance. Requires `liger-kernel` package. |
 | `seed` | `int` | Backend default | Random seed for reproducibility. |
+
+#### Optimizer (AdamW) Parameters
+
+The mini-trainer backend uses the AdamW optimizer. These parameters control its behavior:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beta1` | `float` | `0.9` | AdamW beta1 coefficient — controls the exponential decay rate for the first moment estimates (momentum). |
+| `beta2` | `float` | `0.95` | AdamW beta2 coefficient — controls the exponential decay rate for the second moment estimates (RMSprop). Note: the backend default is `0.95`, not PyTorch's standard `0.999`. |
+| `eps` | `float` | `1e-8` | AdamW epsilon — a small constant added to the denominator for numerical stability. |
+| `weight_decay` | `float` | `0.0` | AdamW weight decay coefficient (L2 regularization). `0.0` means no weight decay. |
 
 #### Checkpointing
 

--- a/docs/api/functions/sft.md
+++ b/docs/api/functions/sft.md
@@ -25,6 +25,10 @@ def sft(
     is_pretraining: Optional[bool] = None,
     block_size: Optional[int] = None,
     document_column_name: Optional[str] = None,
+    beta1: Optional[float] = None,
+    beta2: Optional[float] = None,
+    eps: Optional[float] = None,
+    weight_decay: Optional[float] = None,
     nproc_per_node: Optional[int] = None,
     nnodes: Optional[int] = None,
     node_rank: Optional[int] = None,
@@ -66,6 +70,17 @@ def sft(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `warmup_steps` | `int` | Backend default | Number of warmup steps for the learning rate scheduler. |
+
+#### Optimizer (AdamW) Parameters
+
+Both backends use the AdamW optimizer. These parameters control its behavior:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beta1` | `float` | `0.9` | AdamW beta1 coefficient — controls the exponential decay rate for the first moment estimates (momentum). |
+| `beta2` | `float` | `0.95` | AdamW beta2 coefficient — controls the exponential decay rate for the second moment estimates (RMSprop). Note: the backend default is `0.95`, not PyTorch's standard `0.999`. |
+| `eps` | `float` | `1e-8` | AdamW epsilon — a small constant added to the denominator for numerical stability. |
+| `weight_decay` | `float` | `0.0` | AdamW weight decay coefficient (L2 regularization). `0.0` means no weight decay. |
 
 #### Data Processing
 


### PR DESCRIPTION
## Summary

- Document AdamW optimizer hyperparameters (`beta1`, `beta2`, `eps`, `weight_decay`) across all SFT and OSFT documentation pages
- These parameters are fully implemented as first-class API params in the code but were missing from all docs — users could only find them via source code or the `**kwargs` catch-all
- Add parameter tables and signature entries to function refs (`sft.md`, `osft.md`), class refs (`SFTAlgorithm.md`, `OSFTAlgorithm.md`), and backend pages (`instructlab-training.md`, `mini-trainer.md`)
- Note the non-standard default `beta2=0.95` (vs PyTorch's `0.999`) in both backends

## Test plan

- [ ] Verify docs render correctly with `docsify serve` (docs-only change, no code changes)
- [ ] Confirm parameter names match source code signatures in `sft.py` and `osft.py`
- [ ] Confirm default values match `instructlab.training.TrainingArgs` and `mini_trainer.TrainingArgs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AdamW optimizer parameter references across training and API docs.
  * Documented `beta1`, `beta2`, `eps`, and `weight_decay` with defaults and descriptions.
  * Updated function signatures in the docs to show the new optional optimizer settings.
  * Clarified how these parameters are exposed and mapped in supported training backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->