### PR TITLE
Force-exit subprocess after training to prevent vLLM 0.21+ hang

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -710,6 +710,7 @@ class ARTLoRAGRPOBackend(Backend):
         # vLLM V1's eager add_lora validation finds a valid adapter on disk.
         # Pass results_path into params so _run_training can save before shutdown
         algorithm_params["_results_path"] = results_path
+        exit_code = 0
         try:
             # Import unsloth first to apply vLLM/TRL compatibility patches
             # (e.g. GuidedDecodingParams shim for older vLLM versions)
@@ -736,11 +737,12 @@ class ARTLoRAGRPOBackend(Backend):
             )
         except SystemExit:
             pass  # os._exit from shutdown — results saved in _run_training
-        except Exception as e:
+        except Exception:
             if not os.path.exists(results_path):
                 with open(error_path, "w") as f:
                     import traceback
                     f.write(traceback.format_exc())
+                exit_code = 1
             else:
                 import traceback
                 import logging
@@ -750,7 +752,7 @@ class ARTLoRAGRPOBackend(Backend):
                 )
         # vLLM 0.21+ spawns EngineCore/APIServer as non-daemon threads that
         # can prevent the subprocess from exiting. Results are already on disk.
-        os._exit(0)
+        os._exit(exit_code)
 
     async def _run_training(self, params: Dict[str, Any], art, LocalBackend) -> Dict[str, Any]:
         """Async training loop."""

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -748,6 +748,9 @@ class ARTLoRAGRPOBackend(Backend):
                     "Post-training cleanup error (training completed successfully):\n%s",
                     traceback.format_exc(),
                 )
+        # vLLM 0.21+ spawns EngineCore/APIServer as non-daemon threads that
+        # can prevent the subprocess from exiting. Results are already on disk.
+        os._exit(0)
 
     async def _run_training(self, params: Dict[str, Any], art, LocalBackend) -> Dict[str, Any]:
         """Async training loop."""
@@ -938,8 +941,7 @@ class ARTLoRAGRPOBackend(Backend):
             )
             return result
         finally:
-            # Save results BEFORE shutdown — _shutdown_art_backend calls
-            # os._exit() which kills the process immediately.
+            # Save results BEFORE shutdown so they survive os._exit below.
             results_path = params.get("_results_path")
             if results_path and result is not None:
                 try:
@@ -951,6 +953,9 @@ class ARTLoRAGRPOBackend(Backend):
 
             logger.info("Shutting down ART backend...")
             await _shutdown_art_backend(backend)
+            if result is not None:
+                logger.info("ART backend shut down — force-exiting subprocess")
+                os._exit(0)
             logger.info("ART backend shut down")
 
     async def _run_training_loop(


### PR DESCRIPTION
**Problem**
With vLLM 0.21+, the lora_grpo training subprocess hangs indefinitely after training completes. The V1 engine architecture spawns EngineCore and APIServer as non-daemon threads that prevent asyncio.run() from completing its shutdown. This blocks the parent at proc.join() and prevents the Kubeflow pod from completing — even though training succeeded and results are on disk.

This is a progression from #78, which handled the ConnectionRefusedError from ART's health monitor hitting the dead vLLM server. That fix prevented the error from being treated as a failure, but with vLLM 0.21 the failure mode changed: the exception no longer propagates out (it's caught internally as an unhandled asyncio task), and instead the event loop hangs on shutdown.

**Fix**
Add os._exit(0) after results are saved and backend shutdown is attempted:

1. Primary — at the end of _run_training's finally block, which fires inside the coroutine before asyncio.run() reaches its own cleanup phase.
2. Fallback — at the end of _subprocess_entry, for the case where asyncio.run() returns or raises but non-daemon threads still prevent normal exit.

**Why this is safe**

- The subprocess is isolated — its sole purpose is to write training_results.json to disk
- Results are saved before os._exit(0) runs 
- Checkpoints are saved during the training loop after each iteration
- The parent reads results from disk after proc.join() returns
- _shutdown_art_backend has already attempted a clean vLLM engine shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented some training jobs from hanging at the end of execution by ensuring the training subprocess always exits cleanly.
  * Improved shutdown behavior so training outputs are saved before the subprocess is force-terminated.
  * Enhanced end-of-run termination to reduce the chance of stuck reruns and ensure training completes reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->