### PR TITLE
Fix sft() ValidationError for optional data_output_dir and max_batch_len

### DIFF
--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -31,6 +31,14 @@ class InstructLabTrainingSFTBackend(Backend):
         if 'max_tokens_per_gpu' in training_params:
             training_params['max_batch_len'] = training_params.pop('max_tokens_per_gpu')
 
+        if 'data_output_dir' not in training_params:
+            training_params['data_output_dir'] = os.path.join(
+                training_params['ckpt_output_dir'], 'data'
+            )
+
+        if 'max_batch_len' not in training_params:
+            training_params['max_batch_len'] = training_params.get('max_seq_len', 60000)
+
         # AdamW parameter translation
         if 'beta1' in training_params and 'beta2' in training_params:
             training_params['adamw_betas'] = (

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -37,6 +37,7 @@ class InstructLabTrainingSFTBackend(Backend):
             )
 
         if 'max_batch_len' not in training_params:
+            # max_seq_len is required by TrainingArgs, so the 60000 fallback is a defensive default
             training_params['max_batch_len'] = training_params.get('max_seq_len', 60000)
 
         # AdamW parameter translation
@@ -230,13 +231,13 @@ class SFTAlgorithm(Algorithm):
             'effective_batch_size': int,
             'learning_rate': float,
             'max_seq_len': int,
-            'max_batch_len': int,
         }
 
     def get_optional_params(self) -> Dict[str, Type]:
         """Return optional parameters for SFT."""
         return {
             'max_tokens_per_gpu': int,
+            'max_batch_len': int,
             'data_output_dir': str,
             'save_samples': int,
             'warmup_steps': int,


### PR DESCRIPTION
## Summary

- Default `data_output_dir` to `ckpt_output_dir/data` when not provided, matching the pattern used by OSFT
- Default `max_batch_len` to `max_seq_len` (or 60000 if `max_seq_len` is also absent) when `max_tokens_per_gpu` is not provided
- Both defaults are applied in `InstructLabTrainingSFTBackend.execute_training()` before constructing `TrainingArgs`

Closes #94

## Test plan

- [x] Reproduced the exact error from #94 on unpatched code (confirmed `ValidationError: 2 validation errors for TrainingArgs`)
- [x] Verified fix resolves the reproduction case — `sft()` with minimal params creates `TrainingArgs` successfully
- [x] Verified explicit `data_output_dir` and `max_tokens_per_gpu` values are preserved when provided
- [x] Ran `model_validation.py --models qwen2 --mode sft --simple --liger off` — PASS (loss 11.94)
- [x] Ran `model_validation.py --models granite --mode sft --simple --liger off` — PASS (loss 10.81)
- [x] All tests on rh-ilab-a100-1 (8x A100-SXM4-80GB), commit cf79fe9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SFT training now automatically sets a data output location when one isn’t provided.
  * Added support for configuring the maximum batch length, with sensible defaults when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->