### PR TITLE
ART 0.5.18 megatron import stub

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -207,6 +207,11 @@ def _install_megatron_bridge_stub():
     class _StubMeta(type):
         """Metaclass that returns a new stub for any attribute access."""
         def __getattr__(cls, name):
+            logger.warning(
+                "megatron stub: attribute %s.%s accessed — stubs are import-only "
+                "placeholders; actual megatron functionality is not available",
+                cls.__name__, name,
+            )
             return type(name, (), {"__init__": lambda self, *a, **kw: None})
 
     class _Stub(metaclass=_StubMeta):
@@ -216,7 +221,7 @@ def _install_megatron_bridge_stub():
 
     def _make_stub_module(fqn, attrs=None):
         mod = types.ModuleType(fqn)
-        mod.__package__ = fqn.rsplit(".", 1)[0] if "." in fqn else fqn
+        mod.__package__ = fqn
         mod.__path__ = []
         if attrs:
             for k, v in attrs.items():
@@ -226,6 +231,9 @@ def _install_megatron_bridge_stub():
 
     bridge = _make_stub_module("megatron.bridge")
 
+    # Sub-modules known to be imported by ART 0.5.18.
+    # If ART 0.5.19+ adds new megatron.bridge.* imports, update this list.
+    # To discover: grep -r 'from megatron.bridge' $(python -c "import art; print(art.__path__[0])")
     sub_modules = [
         "megatron.bridge.megatron_model",
         "megatron.bridge.megatron_model.qwen3_5",
@@ -268,9 +276,13 @@ def _install_megatron_bridge_stub():
 
     # Ensure megatron package itself and megatron.core exist as stubs if not
     # already installed (megatron-core --no-deps provides the real ones).
+    # Try real import first to avoid shadowing a real installation.
     for pkg in ("megatron", "megatron.core"):
         if pkg not in sys.modules:
-            _make_stub_module(pkg)
+            try:
+                __import__(pkg)
+            except ImportError:
+                _make_stub_module(pkg)
 
     logger.debug("Installed megatron.bridge stub modules for ART 0.5.18 compat")
 

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -219,10 +219,11 @@ def _install_megatron_bridge_stub():
         def __init__(self, *args, **kwargs):
             pass
 
-    def _make_stub_module(fqn, attrs=None):
+    def _make_stub_module(fqn, is_package=True, attrs=None):
         mod = types.ModuleType(fqn)
         mod.__package__ = fqn
-        mod.__path__ = []
+        if is_package:
+            mod.__path__ = []
         if attrs:
             for k, v in attrs.items():
                 setattr(mod, k, v)
@@ -234,17 +235,21 @@ def _install_megatron_bridge_stub():
     # Sub-modules known to be imported by ART 0.5.18.
     # If ART 0.5.19+ adds new megatron.bridge.* imports, update this list.
     # To discover: grep -r 'from megatron.bridge' $(python -c "import art; print(art.__path__[0])")
-    sub_modules = [
+    sub_packages = [
         "megatron.bridge.megatron_model",
-        "megatron.bridge.megatron_model.qwen3_5",
         "megatron.bridge.pipeline",
-        "megatron.bridge.pipeline.megatron_pipeline",
         "megatron.bridge.utils",
+    ]
+    leaf_modules = [
+        "megatron.bridge.megatron_model.qwen3_5",
+        "megatron.bridge.pipeline.megatron_pipeline",
         "megatron.bridge.utils.config",
         "megatron.bridge.utils.weight_converter",
     ]
-    for fqn in sub_modules:
-        _make_stub_module(fqn)
+    for fqn in sub_packages:
+        _make_stub_module(fqn, is_package=True)
+    for fqn in leaf_modules:
+        _make_stub_module(fqn, is_package=False)
 
     # Attach sub-package references so dotted access works
     bridge.megatron_model = sys.modules["megatron.bridge.megatron_model"]
@@ -265,14 +270,16 @@ def _install_megatron_bridge_stub():
     )
 
     # Populate commonly imported names with stubs
-    for fqn in sub_modules:
+    class _StubModuleType(types.ModuleType):
+        def __getattr__(self, name):
+            if name.startswith("__") and name.endswith("__"):
+                raise AttributeError(name)
+            return _Stub
+
+    for fqn in sub_packages + leaf_modules:
         mod = sys.modules[fqn]
         mod.__dict__.setdefault("__all__", [])
-        mod.__class__ = type(
-            mod.__class__.__name__,
-            (type(mod),),
-            {"__getattr__": lambda self, name: _Stub},
-        )
+        mod.__class__ = _StubModuleType
 
     # Ensure megatron package itself and megatron.core exist as stubs if not
     # already installed (megatron-core --no-deps provides the real ones).
@@ -281,7 +288,11 @@ def _install_megatron_bridge_stub():
         if pkg not in sys.modules:
             try:
                 __import__(pkg)
-            except ImportError:
+            except Exception as exc:
+                logger.warning(
+                    "Could not import %s (%s: %s), falling back to stub",
+                    pkg, type(exc).__name__, exc,
+                )
                 _make_stub_module(pkg)
 
     logger.debug("Installed megatron.bridge stub modules for ART 0.5.18 compat")

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -178,6 +178,104 @@ def _create_seed_lora_checkpoint(
 
 
 # ---------------------------------------------------------------------------
+# Megatron bridge stub for ART 0.5.18+
+# ---------------------------------------------------------------------------
+
+def _install_megatron_bridge_stub():
+    """Install stub modules for megatron.bridge so ART 0.5.18 can import.
+
+    ART 0.5.18 added Qwen3.5 Megatron support with module-level imports from
+    megatron.core and megatron.bridge that fire even when using the Unsloth
+    (non-Megatron) backend. megatron-core can be installed with --no-deps
+    (~2 MB) to provide the real megatron.core module, but megatron.bridge is
+    not available as a standalone package.
+
+    This function injects placeholder modules into sys.modules so that
+    ``from megatron.bridge.<submodule> import <name>`` succeeds at import
+    time. The stub classes/functions are never instantiated at runtime when
+    using the Unsloth backend — they exist only to satisfy the import graph.
+
+    Remove this stub when ART makes the megatron import lazy, or when
+    megatron-core is added to the AIPCC index with bridge support.
+    """
+    import sys
+    import types
+
+    if "megatron.bridge" in sys.modules:
+        return
+
+    class _StubMeta(type):
+        """Metaclass that returns a new stub for any attribute access."""
+        def __getattr__(cls, name):
+            return type(name, (), {"__init__": lambda self, *a, **kw: None})
+
+    class _Stub(metaclass=_StubMeta):
+        """A class whose attributes are all no-op classes."""
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def _make_stub_module(fqn, attrs=None):
+        mod = types.ModuleType(fqn)
+        mod.__package__ = fqn.rsplit(".", 1)[0] if "." in fqn else fqn
+        mod.__path__ = []
+        if attrs:
+            for k, v in attrs.items():
+                setattr(mod, k, v)
+        sys.modules[fqn] = mod
+        return mod
+
+    bridge = _make_stub_module("megatron.bridge")
+
+    sub_modules = [
+        "megatron.bridge.megatron_model",
+        "megatron.bridge.megatron_model.qwen3_5",
+        "megatron.bridge.pipeline",
+        "megatron.bridge.pipeline.megatron_pipeline",
+        "megatron.bridge.utils",
+        "megatron.bridge.utils.config",
+        "megatron.bridge.utils.weight_converter",
+    ]
+    for fqn in sub_modules:
+        _make_stub_module(fqn)
+
+    # Attach sub-package references so dotted access works
+    bridge.megatron_model = sys.modules["megatron.bridge.megatron_model"]
+    bridge.pipeline = sys.modules["megatron.bridge.pipeline"]
+    bridge.utils = sys.modules["megatron.bridge.utils"]
+
+    sys.modules["megatron.bridge.megatron_model"].qwen3_5 = (
+        sys.modules["megatron.bridge.megatron_model.qwen3_5"]
+    )
+    sys.modules["megatron.bridge.pipeline"].megatron_pipeline = (
+        sys.modules["megatron.bridge.pipeline.megatron_pipeline"]
+    )
+    sys.modules["megatron.bridge.utils"].config = (
+        sys.modules["megatron.bridge.utils.config"]
+    )
+    sys.modules["megatron.bridge.utils"].weight_converter = (
+        sys.modules["megatron.bridge.utils.weight_converter"]
+    )
+
+    # Populate commonly imported names with stubs
+    for fqn in sub_modules:
+        mod = sys.modules[fqn]
+        mod.__dict__.setdefault("__all__", [])
+        mod.__class__ = type(
+            mod.__class__.__name__,
+            (type(mod),),
+            {"__getattr__": lambda self, name: _Stub},
+        )
+
+    # Ensure megatron package itself and megatron.core exist as stubs if not
+    # already installed (megatron-core --no-deps provides the real ones).
+    for pkg in ("megatron", "megatron.core"):
+        if pkg not in sys.modules:
+            _make_stub_module(pkg)
+
+    logger.debug("Installed megatron.bridge stub modules for ART 0.5.18 compat")
+
+
+# ---------------------------------------------------------------------------
 # Built-in dataset loading (Toucan-style tool-call data)
 # ---------------------------------------------------------------------------
 
@@ -729,6 +827,9 @@ class ARTLoRAGRPOBackend(Backend):
                 mod.listen_for_disconnect = listen_for_disconnect
                 sys.modules["vllm.entrypoints.utils"] = mod
                 vllm.entrypoints.utils = mod
+
+            # ART 0.5.18 has module-level megatron imports for Qwen3.5 support
+            _install_megatron_bridge_stub()
 
             import art
             from art.local.backend import LocalBackend


### PR DESCRIPTION
## Summary

- Add `_install_megatron_bridge_stub()` function that injects placeholder modules for `megatron.bridge.*` into `sys.modules` before importing ART
- Called from `_subprocess_entry()` before `import art` to handle ART 0.5.18's module-level megatron imports for Qwen3.5 support
- Stub classes are never instantiated at runtime (Unsloth backend path) — they exist only to satisfy the import graph

## Context

ART 0.5.18 added Qwen3.5 Megatron support with unconditional module-level imports from `megatron.core` and `megatron.bridge`. These fire even when using the non-Megatron Unsloth backend. `megatron-core` can be installed with `--no-deps` (~2 MB) for the real module, but `megatron.bridge` is not available standalone.

This stub should be removed when ART makes the megatron import lazy, or when megatron-core with bridge support is added to the AIPCC index.

See the dependency validation report in MT-67 for full context.

## Test plan

- [ ] Verify `import art` succeeds with stub installed and without megatron.bridge package
- [ ] Run GRPO smoke test with openpipe-art 0.5.18 (Qwen2.5-1.5B, ART backend)
- [ ] Run `model_validation.py --run-all --mode all --simple` (smoke test)
- [ ] Verify stub does not interfere when megatron.bridge IS installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)