### PR TITLE
feat: first-class OSFT validation parameters + mini-trainer v0.9.0

### DIFF
--- a/docs/api/backends/mini-trainer.md
+++ b/docs/api/backends/mini-trainer.md
@@ -140,7 +140,7 @@ The Mini-Trainer backend supports validation loss monitoring with configurable e
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `0.0` | Fraction of training data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. Mutually exclusive with `validation_data_path`. |
+| `validation_split` | `float` | `0.0` | Fraction of training data to hold out for validation (greater than `0.0`, less than `1.0`). `0.0` disables validation. Mutually exclusive with `validation_data_path`. |
 | `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. The data is tokenized automatically using the same processing pipeline as the training data. Mutually exclusive with `validation_split`. |
 
 ### Validation Triggers

--- a/docs/api/backends/mini-trainer.md
+++ b/docs/api/backends/mini-trainer.md
@@ -140,7 +140,7 @@ The Mini-Trainer backend supports validation loss monitoring with configurable e
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `0.0` | Fraction of training data to hold out for validation (greater than `0.0`, less than `1.0`). `0.0` disables validation. Mutually exclusive with `validation_data_path`. |
+| `validation_split` | `float` | `None` | Fraction of training data to hold out for validation (greater than `0.0`, less than `1.0`). `None` disables validation. Mutually exclusive with `validation_data_path`. |
 | `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. The data is tokenized automatically using the same processing pipeline as the training data. Mutually exclusive with `validation_split`. |
 
 ### Validation Triggers

--- a/docs/api/backends/mini-trainer.md
+++ b/docs/api/backends/mini-trainer.md
@@ -132,18 +132,36 @@ These parameter names match the mini-trainer `TrainingArgs` dataclass fields dir
 | `rdzv_endpoint` | Master node endpoint |
 
 
-## Validation Loss
+## Validation
 
-The Mini-Trainer backend supports validation loss monitoring with optional best-val-loss checkpointing.
+The Mini-Trainer backend supports validation loss monitoring with configurable event-based triggers and optional best-val-loss checkpointing. All validation parameters are first-class parameters of `osft()` and `OSFTAlgorithm.train()`.
+
+### Validation Data Sources
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. |
-| `validation_frequency` | `int` | `None` | Steps between validation evaluations. Required when `validation_split > 0`. |
+| `validation_split` | `float` | `0.0` | Fraction of training data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. Mutually exclusive with `validation_data_path`. |
+| `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. The data is tokenized automatically using the same processing pipeline as the training data. Mutually exclusive with `validation_split`. |
+
+### Validation Triggers
+
+At least one trigger must be configured when validation data is present. Multiple triggers can be combined and are coalesced so validation runs at most once per step.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_frequency` | `int` | `None` | Run validation every N training steps. |
+| `validate_at_epoch` | `bool` | `False` | Run validation at the end of each epoch. |
+| `min_samples_per_validation` | `int` | `None` | Minimum accumulated samples between validation runs. Must be a positive integer. |
+| `validate_at_final` | `bool` | `False` | Run validation at the end of training. |
+
+### Best-Val-Loss Checkpointing
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
 | `save_best_val_loss` | `bool` | `False` | Save a checkpoint whenever validation loss improves. |
 | `val_loss_improvement_threshold` | `float` | `0.0` | Minimum improvement in validation loss required to trigger a best-val-loss checkpoint save. |
 
-Pass these as kwargs through `osft()`:
+### Example: Step-Based Validation with Data Split
 
 ```python
 osft(
@@ -159,6 +177,25 @@ osft(
     validation_split=0.1,
     validation_frequency=100,
     save_best_val_loss=True,
+)
+```
+
+### Example: Separate Validation Dataset with Event-Based Triggers
+
+```python
+osft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./train_data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    unfreeze_rank_ratio=0.25,
+    effective_batch_size=16,
+    max_tokens_per_gpu=2048,
+    max_seq_len=1024,
+    learning_rate=5e-6,
+    num_epochs=5,
+    validation_data_path="./val_data.jsonl",
+    validate_at_epoch=True,
+    validate_at_final=True,
 )
 ```
 

--- a/docs/api/classes/OSFTAlgorithm.md
+++ b/docs/api/classes/OSFTAlgorithm.md
@@ -173,6 +173,21 @@ Loggers are automatically enabled when their configuration parameters are set:
 
 > **Note:** OSFT does not support TensorBoard logging.
 
+###### Validation
+
+See the [Validation Loss Guide](/guides/validation-loss) for full details.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_split` | `float` | `None` | Fraction of training data to hold out for validation. Mutually exclusive with `validation_data_path`. |
+| `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. Tokenized automatically. Mutually exclusive with `validation_split`. |
+| `validation_frequency` | `int` | `None` | Run validation every N training steps. |
+| `validate_at_epoch` | `bool` | `None` | Run validation at the end of each epoch. |
+| `min_samples_per_validation` | `int` | `None` | Minimum accumulated samples between validation runs. |
+| `validate_at_final` | `bool` | `None` | Run validation at the end of training. |
+| `save_best_val_loss` | `bool` | `None` | Save a checkpoint whenever validation loss improves. |
+| `val_loss_improvement_threshold` | `float` | `None` | Minimum improvement to trigger a best-val-loss checkpoint save. |
+
 ###### Additional Backend Parameters
 
 | Parameter | Type | Default | Description |
@@ -264,6 +279,14 @@ Returns the optional parameters for OSFT.
     "beta2": float,
     "eps": float,
     "weight_decay": float,
+    "validation_split": float,
+    "validation_data_path": str,
+    "validation_frequency": int,
+    "validate_at_epoch": bool,
+    "min_samples_per_validation": int,
+    "validate_at_final": bool,
+    "save_best_val_loss": bool,
+    "val_loss_improvement_threshold": float,
     # Plus additional backend-specific parameters via **kwargs
 }
 ```

--- a/docs/api/functions/osft.md
+++ b/docs/api/functions/osft.md
@@ -41,6 +41,14 @@ def osft(
     node_rank: int | None = None,
     rdzv_id: int | None = None,
     rdzv_endpoint: str | None = None,
+    validation_split: float | None = None,
+    validation_data_path: str | None = None,
+    validation_frequency: int | None = None,
+    validate_at_epoch: bool | None = None,
+    min_samples_per_validation: int | None = None,
+    validate_at_final: bool | None = None,
+    save_best_val_loss: bool | None = None,
+    val_loss_improvement_threshold: float | None = None,
     **kwargs
 ) -> Any
 ```
@@ -149,16 +157,34 @@ Loggers are automatically enabled when their configuration parameters are set:
 
 > **Note:** OSFT does not support TensorBoard logging.
 
-#### Validation Loss
+#### Validation
 
-Validation loss is supported via `**kwargs`. See the [Validation Loss Guide](/guides/validation-loss) for full details.
+See the [Validation Loss Guide](/guides/validation-loss) for full details.
+
+##### Validation Data Sources
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation (`0.0` to `1.0`). `0.0` disables validation. |
-| `validation_frequency` | `int` | `None` | Steps between validation evaluations. Required when `validation_split > 0`. |
-| `save_best_val_loss` | `bool` | `False` | Save a checkpoint whenever validation loss improves. |
-| `val_loss_improvement_threshold` | `float` | `0.0` | Minimum improvement required to trigger a best-val-loss checkpoint save. |
+| `validation_split` | `float` | `None` | Fraction of training data to hold out for validation (`0.0` to `1.0`). Mutually exclusive with `validation_data_path`. |
+| `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. Tokenized automatically. Mutually exclusive with `validation_split`. |
+
+##### Validation Triggers
+
+At least one trigger must be configured when validation data is present. Multiple triggers can be combined.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_frequency` | `int` | `None` | Run validation every N training steps. |
+| `validate_at_epoch` | `bool` | `None` | Run validation at the end of each epoch. |
+| `min_samples_per_validation` | `int` | `None` | Minimum accumulated samples between validation runs. Must be a positive integer. |
+| `validate_at_final` | `bool` | `None` | Run validation at the end of training. |
+
+##### Best-Val-Loss Checkpointing
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `save_best_val_loss` | `bool` | `None` | Save a checkpoint whenever validation loss improves. |
+| `val_loss_improvement_threshold` | `float` | `None` | Minimum improvement required to trigger a best-val-loss checkpoint save. |
 
 #### Additional Parameters
 

--- a/docs/api/functions/osft.md
+++ b/docs/api/functions/osft.md
@@ -165,7 +165,7 @@ See the [Validation Loss Guide](/guides/validation-loss) for full details.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `None` | Fraction of training data to hold out for validation (`0.0` to `1.0`). Mutually exclusive with `validation_data_path`. |
+| `validation_split` | `float` | `None` | Fraction of training data to hold out for validation (greater than `0.0`, less than `1.0`). Mutually exclusive with `validation_data_path`. |
 | `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. Tokenized automatically. Mutually exclusive with `validation_split`. |
 
 ##### Validation Triggers

--- a/docs/guides/validation-loss.md
+++ b/docs/guides/validation-loss.md
@@ -76,7 +76,7 @@ As of mini-trainer v0.9.0, OSFT validation parameters are first-class — pass t
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `0.0` | Fraction of training data to hold out for validation. Range: `[0.0, 1.0)`. Mutually exclusive with `validation_data_path`. |
+| `validation_split` | `float` | `None` | Fraction of training data to hold out for validation. Range: `(0.0, 1.0)`. Mutually exclusive with `validation_data_path`. |
 | `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. Tokenized automatically. Mutually exclusive with `validation_split`. |
 
 ### Validation Triggers

--- a/docs/guides/validation-loss.md
+++ b/docs/guides/validation-loss.md
@@ -11,7 +11,7 @@ Training Hub supports validation loss monitoring through its underlying backends
 | [LoRA](/api/functions/lora_sft) | [Unsloth](/api/backends/unsloth) | No | No |
 | [LoRA GRPO](/api/functions/lora_grpo) | [ART](/api/backends/art-grpo) / [verl](/api/backends/verl) | No | No |
 
-?> **Validation loss is not a first-class Training Hub parameter yet.** SFT and OSFT support it through their backends via `**kwargs`. Pass the backend-native parameter names listed below directly to the convenience function or `Algorithm.train()` call.
+?> **OSFT validation parameters are first-class.** As of mini-trainer v0.9.0, OSFT supports validation data, event-based triggers, and best-val-loss checkpointing as named parameters on `osft()` and `OSFTAlgorithm.train()`. SFT still supports validation through `**kwargs`.
 
 ## How It Works
 
@@ -70,14 +70,30 @@ result = sft(
 
 ## OSFT (mini-trainer backend)
 
-### Parameters
+As of mini-trainer v0.9.0, OSFT validation parameters are first-class — pass them directly to `osft()` or `OSFTAlgorithm.train()`.
 
-Pass these as `**kwargs` to `osft()` or `OSFTAlgorithm.train()`:
+### Validation Data Sources
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `validation_split` | `float` | `0.0` | Fraction of data to hold out for validation. Range: `[0.0, 1.0)`. Setting `0.0` (default) disables validation. |
-| `validation_frequency` | `int` | `None` | How often to run validation, in training steps. **Required** when `validation_split > 0`. |
+| `validation_split` | `float` | `0.0` | Fraction of training data to hold out for validation. Range: `[0.0, 1.0)`. Mutually exclusive with `validation_data_path`. |
+| `validation_data_path` | `str` | `None` | Path to a separate validation dataset in JSONL format. Tokenized automatically. Mutually exclusive with `validation_split`. |
+
+### Validation Triggers
+
+At least one trigger must be configured when validation data is present. Multiple triggers can be combined; they are coalesced so validation runs at most once per step.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validation_frequency` | `int` | `None` | Run validation every N training steps. |
+| `validate_at_epoch` | `bool` | `False` | Run validation at the end of each epoch. |
+| `min_samples_per_validation` | `int` | `None` | Minimum accumulated samples between validation runs. Must be a positive integer. |
+| `validate_at_final` | `bool` | `False` | Run validation at the end of training. |
+
+### Best-Val-Loss Checkpointing
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
 | `save_best_val_loss` | `bool` | `False` | Save a checkpoint whenever validation loss improves. |
 | `val_loss_improvement_threshold` | `float` | `0.0` | Minimum improvement in validation loss required to trigger a best-val-loss checkpoint save. |
 
@@ -97,11 +113,7 @@ These appear in:
 - **wandb** (if configured)
 - **MLflow** (if configured)
 
-### Best-Val-Loss Checkpointing
-
-The mini-trainer backend can automatically save a checkpoint when validation loss improves. Enable this with `save_best_val_loss=True`. The checkpoint directory will have a `_best_val_loss` suffix.
-
-Use `val_loss_improvement_threshold` to require a minimum improvement before saving, which avoids excessive checkpoint writes when loss is plateauing:
+### Example: Step-Based Validation with Data Split
 
 ```python
 from training_hub import osft
@@ -116,23 +128,21 @@ result = osft(
     max_seq_len=1024,
     learning_rate=5e-6,
     num_epochs=5,
-    # Validation loss configuration
-    validation_split=0.1,                  # Hold out 10% of data
-    validation_frequency=100,              # Evaluate every 100 steps
-    # Best-val-loss checkpointing
-    save_best_val_loss=True,               # Save checkpoint on improvement
-    val_loss_improvement_threshold=0.01,   # Require at least 0.01 improvement
+    validation_split=0.1,
+    validation_frequency=100,
+    save_best_val_loss=True,
+    val_loss_improvement_threshold=0.01,
 )
 ```
 
-### Basic Example
+### Example: Separate Validation Dataset with Event-Based Triggers
 
 ```python
 from training_hub import osft
 
 result = osft(
     model_path="meta-llama/Llama-3.1-8B-Instruct",
-    data_path="./continual_learning_data.jsonl",
+    data_path="./train_data.jsonl",
     ckpt_output_dir="./checkpoints",
     unfreeze_rank_ratio=0.25,
     effective_batch_size=32,
@@ -141,9 +151,32 @@ result = osft(
     learning_rate=2e-5,
     num_epochs=3,
     nproc_per_node=4,
-    # Validation loss configuration
-    validation_split=0.1,        # Hold out 10% of data
-    validation_frequency=50,     # Evaluate every 50 steps
+    validation_data_path="./val_data.jsonl",
+    validate_at_epoch=True,
+    validate_at_final=True,
+)
+```
+
+### Example: Multiple Triggers Combined
+
+```python
+from training_hub import osft
+
+result = osft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./data.jsonl",
+    ckpt_output_dir="./checkpoints",
+    unfreeze_rank_ratio=0.25,
+    effective_batch_size=16,
+    max_tokens_per_gpu=2048,
+    max_seq_len=1024,
+    learning_rate=5e-6,
+    num_epochs=5,
+    validation_split=0.1,
+    validation_frequency=200,
+    validate_at_epoch=True,
+    validate_at_final=True,
+    save_best_val_loss=True,
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "packaging>=24.2",
     "wheel>=0.43",
     "instructlab-training>=0.14.0",
-    "rhai-innovation-mini-trainer>=0.6.0",
+    "rhai-innovation-mini-trainer>=0.9.0",
     "torch>=2.6.0",
     "numba>=0.61.2",
     "transformers>=4.57.6",
@@ -54,7 +54,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 cuda = [
     "instructlab-training[cuda]>=0.14.0",
-    "rhai-innovation-mini-trainer[cuda]>=0.6.0",
+    "rhai-innovation-mini-trainer[cuda]>=0.9.0",
     "flash-attn>=2.8",
     "einops>=0.8",
     "kernels>=0.9.0",

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -76,6 +76,15 @@ class OSFTAlgorithm(Algorithm):
         mlflow_tracking_uri: str | None = None,
         mlflow_experiment_name: str | None = None,
         mlflow_run_name: str | None = None,
+        # Validation
+        validation_split: float | None = None,
+        validation_data_path: str | None = None,
+        validation_frequency: int | None = None,
+        validate_at_epoch: bool | None = None,
+        min_samples_per_validation: int | None = None,
+        validate_at_final: bool | None = None,
+        save_best_val_loss: bool | None = None,
+        val_loss_improvement_threshold: float | None = None,
         # Model loading
         trust_remote_code: bool | None = None,
         **kwargs,
@@ -165,6 +174,16 @@ class OSFTAlgorithm(Algorithm):
             mlflow_tracking_uri (str): MLflow tracking server URI.
             mlflow_experiment_name (str): MLflow experiment name.
             mlflow_run_name (str): MLflow run name.
+            validation_split (float): Fraction of training data to hold out for validation (0.0 to 1.0).
+                Mutually exclusive with validation_data_path.
+            validation_data_path (str): Path to a separate validation dataset in JSONL format.
+                Mutually exclusive with validation_split.
+            validation_frequency (int): Run validation every N training steps.
+            validate_at_epoch (bool): Whether to run validation at the end of each epoch.
+            min_samples_per_validation (int): Minimum accumulated samples between validation runs.
+            validate_at_final (bool): Whether to run validation at the end of training.
+            save_best_val_loss (bool): Save a checkpoint whenever validation loss improves.
+            val_loss_improvement_threshold (float): Minimum improvement to trigger a best-val-loss checkpoint.
             **kwargs: Additional parameters passed to the backend.
 
         Returns:
@@ -182,6 +201,12 @@ class OSFTAlgorithm(Algorithm):
         if is_pretraining and unmask_messages:
             raise ValueError(
                 'Cannot use both is_pretraining=True and unmask_messages=True. These are mutually exclusive modes.'
+            )
+
+        if validation_data_path is not None and validation_split is not None and validation_split > 0:
+            raise ValueError(
+                'validation_data_path and validation_split are mutually exclusive. '
+                'Provide either a separate validation dataset or a split fraction, not both.'
             )
 
         if not is_pretraining and block_size is not None:
@@ -239,6 +264,15 @@ class OSFTAlgorithm(Algorithm):
             'mlflow_tracking_uri': mlflow_tracking_uri,
             'mlflow_experiment_name': mlflow_experiment_name,
             'mlflow_run_name': mlflow_run_name,
+            # validation
+            'validation_split': validation_split,
+            'validation_data_path': validation_data_path,
+            'validation_frequency': validation_frequency,
+            'validate_at_epoch': validate_at_epoch,
+            'min_samples_per_validation': min_samples_per_validation,
+            'validate_at_final': validate_at_final,
+            'save_best_val_loss': save_best_val_loss,
+            'val_loss_improvement_threshold': val_loss_improvement_threshold,
             # model loading
             'trust_remote_code': trust_remote_code,
         }
@@ -310,6 +344,15 @@ class OSFTAlgorithm(Algorithm):
             'mlflow_tracking_uri': str,
             'mlflow_experiment_name': str,
             'mlflow_run_name': str,
+            # validation
+            'validation_split': float,
+            'validation_data_path': str,
+            'validation_frequency': int,
+            'validate_at_epoch': bool,
+            'min_samples_per_validation': int,
+            'validate_at_final': bool,
+            'save_best_val_loss': bool,
+            'val_loss_improvement_threshold': float,
         }
 
     def _validate_param_types(self, params: dict[str, any]):
@@ -450,17 +493,34 @@ class MiniTrainerOSFTBackend(Backend):
 
         # since mini trainer itself does not process data, we delegate this to
         # a separate backend, and expect to receive the correct data path
+        use_processed_dataset = algorithm_params.get('use_processed_dataset', False)
         training_ready_data_path = self._process_data(
             data_path=algorithm_params['data_path'],  # should be there
             model_name_or_path=algorithm_params['model_name_or_path'],  # should be there
             output_dir=data_output_dir,
             max_seq_len=algorithm_params['max_seq_len'],
             num_cpu_procs=8,  # this is a safe default
-            use_processed_dataset=algorithm_params.get('use_processed_dataset', False),
+            use_processed_dataset=use_processed_dataset,
             unmask_messages=algorithm_params.get('unmask_messages', False),
             is_pretraining=algorithm_params.get('is_pretraining', False),
             document_column_name=algorithm_params.get('document_column_name'),
         )
+
+        # Process validation data if a separate validation dataset is provided
+        if (val_data_path := algorithm_params.get('validation_data_path')) is not None:
+            val_output_dir = os.path.join(data_output_dir, 'validation')
+            processed_val_path = self._process_data(
+                data_path=val_data_path,
+                model_name_or_path=algorithm_params['model_name_or_path'],
+                output_dir=val_output_dir,
+                max_seq_len=algorithm_params['max_seq_len'],
+                num_cpu_procs=8,
+                use_processed_dataset=use_processed_dataset,
+                unmask_messages=algorithm_params.get('unmask_messages', False),
+                is_pretraining=algorithm_params.get('is_pretraining', False),
+                document_column_name=algorithm_params.get('document_column_name'),
+            )
+            algorithm_params['validation_data_path'] = processed_val_path
 
         # adjust arguments to align with the API definition
         training_args_pre = {k: v for k, v in algorithm_params.items() if k in training_args_fields and v is not None}
@@ -613,6 +673,15 @@ def osft(
     mlflow_tracking_uri: str | None = None,
     mlflow_experiment_name: str | None = None,
     mlflow_run_name: str | None = None,
+    # Validation
+    validation_split: float | None = None,
+    validation_data_path: str | None = None,
+    validation_frequency: int | None = None,
+    validate_at_epoch: bool | None = None,
+    min_samples_per_validation: int | None = None,
+    validate_at_final: bool | None = None,
+    save_best_val_loss: bool | None = None,
+    val_loss_improvement_threshold: float | None = None,
     # Model loading
     trust_remote_code: bool | None = None,
     **kwargs,
@@ -698,6 +767,18 @@ def osft(
         mlflow_tracking_uri: MLflow tracking server URI.
         mlflow_experiment_name: MLflow experiment name.
         mlflow_run_name: MLflow run name.
+        validation_split: Fraction of training data to hold out for validation (0.0 to 1.0).
+            Mutually exclusive with ``validation_data_path``.
+        validation_data_path: Path to a separate validation dataset in JSONL format.
+            The dataset will be tokenized automatically. Mutually exclusive with
+            ``validation_split``.
+        validation_frequency: Run validation every N training steps.
+        validate_at_epoch: Run validation at the end of each epoch.
+        min_samples_per_validation: Minimum accumulated samples between validation runs.
+        validate_at_final: Run validation at the end of training.
+        save_best_val_loss: Save a checkpoint whenever validation loss improves.
+        val_loss_improvement_threshold: Minimum improvement in validation loss
+            required to trigger a best-val-loss checkpoint save.
         trust_remote_code: Whether to trust remote code when loading the model.
         **kwargs: Additional backend-specific parameters passed to the backend.
 
@@ -755,6 +836,14 @@ def osft(
         mlflow_tracking_uri=mlflow_tracking_uri,
         mlflow_experiment_name=mlflow_experiment_name,
         mlflow_run_name=mlflow_run_name,
+        validation_split=validation_split,
+        validation_data_path=validation_data_path,
+        validation_frequency=validation_frequency,
+        validate_at_epoch=validate_at_epoch,
+        min_samples_per_validation=min_samples_per_validation,
+        validate_at_final=validate_at_final,
+        save_best_val_loss=save_best_val_loss,
+        val_loss_improvement_threshold=val_loss_improvement_threshold,
         trust_remote_code=trust_remote_code,
         **kwargs,
     )

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -174,8 +174,8 @@ class OSFTAlgorithm(Algorithm):
             mlflow_tracking_uri (str): MLflow tracking server URI.
             mlflow_experiment_name (str): MLflow experiment name.
             mlflow_run_name (str): MLflow run name.
-            validation_split (float): Fraction of training data to hold out for validation (0.0 to 1.0).
-                Mutually exclusive with validation_data_path.
+            validation_split (float): Fraction of training data to hold out for validation
+                (greater than 0.0, less than 1.0). Mutually exclusive with validation_data_path.
             validation_data_path (str): Path to a separate validation dataset in JSONL format.
                 Mutually exclusive with validation_split.
             validation_frequency (int): Run validation every N training steps.
@@ -207,6 +207,26 @@ class OSFTAlgorithm(Algorithm):
             raise ValueError(
                 'validation_data_path and validation_split are mutually exclusive. '
                 'Provide either a separate validation dataset or a split fraction, not both.'
+            )
+
+        if validation_split is not None and (validation_split < 0.0 or validation_split >= 1.0):
+            raise ValueError(
+                f'validation_split must be greater than 0.0 and less than 1.0, got {validation_split}'
+            )
+
+        if validation_frequency is not None and validation_frequency < 1:
+            raise ValueError(
+                f'validation_frequency must be a positive integer, got {validation_frequency}'
+            )
+
+        if min_samples_per_validation is not None and min_samples_per_validation < 1:
+            raise ValueError(
+                f'min_samples_per_validation must be a positive integer, got {min_samples_per_validation}'
+            )
+
+        if val_loss_improvement_threshold is not None and val_loss_improvement_threshold < 0:
+            raise ValueError(
+                f'val_loss_improvement_threshold must be non-negative, got {val_loss_improvement_threshold}'
             )
 
         if not is_pretraining and block_size is not None:
@@ -515,7 +535,7 @@ class MiniTrainerOSFTBackend(Backend):
                 output_dir=val_output_dir,
                 max_seq_len=algorithm_params['max_seq_len'],
                 num_cpu_procs=8,
-                use_processed_dataset=use_processed_dataset,
+                use_processed_dataset=False,
                 unmask_messages=algorithm_params.get('unmask_messages', False),
                 is_pretraining=algorithm_params.get('is_pretraining', False),
                 document_column_name=algorithm_params.get('document_column_name'),
@@ -767,8 +787,8 @@ def osft(
         mlflow_tracking_uri: MLflow tracking server URI.
         mlflow_experiment_name: MLflow experiment name.
         mlflow_run_name: MLflow run name.
-        validation_split: Fraction of training data to hold out for validation (0.0 to 1.0).
-            Mutually exclusive with ``validation_data_path``.
+        validation_split: Fraction of training data to hold out for validation
+            (greater than 0.0, less than 1.0). Mutually exclusive with ``validation_data_path``.
         validation_data_path: Path to a separate validation dataset in JSONL format.
             The dataset will be tokenized automatically. Mutually exclusive with
             ``validation_split``.

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -209,7 +209,7 @@ class OSFTAlgorithm(Algorithm):
                 'Provide either a separate validation dataset or a split fraction, not both.'
             )
 
-        if validation_split is not None and (validation_split < 0.0 or validation_split >= 1.0):
+        if validation_split is not None and (validation_split <= 0.0 or validation_split >= 1.0):
             raise ValueError(
                 f'validation_split must be greater than 0.0 and less than 1.0, got {validation_split}'
             )
@@ -227,6 +227,23 @@ class OSFTAlgorithm(Algorithm):
         if val_loss_improvement_threshold is not None and val_loss_improvement_threshold < 0:
             raise ValueError(
                 f'val_loss_improvement_threshold must be non-negative, got {val_loss_improvement_threshold}'
+            )
+
+        has_validation = (
+            (validation_split is not None and validation_split > 0)
+            or validation_data_path is not None
+        )
+        has_trigger = (
+            (validation_frequency is not None and validation_frequency > 0)
+            or (validate_at_epoch is not None and validate_at_epoch)
+            or (min_samples_per_validation is not None and min_samples_per_validation > 0)
+            or (validate_at_final is not None and validate_at_final)
+        )
+        if has_validation and not has_trigger:
+            raise ValueError(
+                'Validation data is provided but no validation trigger is configured. '
+                'Set at least one of: validation_frequency, validate_at_epoch, '
+                'min_samples_per_validation, or validate_at_final.'
             )
 
         if not is_pretraining and block_size is not None:


### PR DESCRIPTION
## Summary

- **Promote validation parameters to first-class** on `OSFTAlgorithm.train()` and `osft()` — no longer kwargs-only
- **Add mini-trainer v0.9.0 event-based validation triggers**: `validate_at_epoch`, `min_samples_per_validation`, `validate_at_final` alongside existing `validation_frequency`
- **Add `validation_data_path`** support with automatic tokenization of separate validation datasets
- **Bump `rhai-innovation-mini-trainer`** dependency from `>=0.6.0` to `>=0.9.0`
- **Update all documentation**: backend docs, validation-loss guide, function reference, class reference

## Changes

### Code (`src/training_hub/algorithms/osft.py`)
- 8 new named parameters on `OSFTAlgorithm.train()` and `osft()`: `validation_split`, `validation_data_path`, `validation_frequency`, `validate_at_epoch`, `min_samples_per_validation`, `validate_at_final`, `save_best_val_loss`, `val_loss_improvement_threshold`
- All 8 added to `optional_params` dict and `get_optional_params()` (per the nnodes incident lesson)
- Mutual exclusivity validation between `validation_data_path` and `validation_split`
- `MiniTrainerOSFTBackend.execute_training()` now tokenizes `validation_data_path` through the same `_process_data()` pipeline as training data

### Dependencies (`pyproject.toml`)
- `rhai-innovation-mini-trainer` floor bumped to `>=0.9.0` (both main and `[cuda]` extras)

### Documentation
- `docs/api/backends/mini-trainer.md` — expanded Validation section with data sources, triggers, and checkpointing subsections
- `docs/api/functions/osft.md` — updated signature and parameter tables
- `docs/api/classes/OSFTAlgorithm.md` — added validation section and updated `get_optional_params()` listing
- `docs/guides/validation-loss.md` — updated OSFT section with event-based triggers, separate dataset support, and multiple examples

## Test plan

- [ ] Verify `python3 -c "import ast; ast.parse(open('src/training_hub/algorithms/osft.py').read())"` passes
- [ ] Verify validation params appear in `osft.__code__.co_varnames` and `OSFTAlgorithm.train.__code__.co_varnames`
- [ ] GPU test: run OSFT with `validation_split=0.1, validation_frequency=10` on A100
- [ ] GPU test: run OSFT with `validation_data_path="val.jsonl", validate_at_epoch=True` on A100
- [ ] Verify mutual exclusivity error when both `validation_data_path` and `validation_split > 0` provided

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable OSFT validation, supporting either split-based validation or a separate validation dataset.
  - Validation can be triggered by step frequency and/or epoch end/final, with minimum-sample gating; multiple triggers are coalesced so validation runs at most once per step.
  - Added optional “best validation loss” checkpointing with an improvement threshold.
  - Exposed validation options in the public OSFT API.

- **Documentation**
  - Reorganized validation docs and updated API references with the new parameters and examples.

- **Chores**
  - Updated the mini-trainer dependency requirement to version 0.9.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->