### PR TITLE
Fix subprocess hang after GRPO training completes

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1124,10 +1124,12 @@ class ARTLoRAGRPOBackend(Backend):
 
             logger.info("Shutting down ART backend...")
             await _shutdown_art_backend(backend)
-            if result is not None:
-                logger.info("ART backend shut down — force-exiting subprocess")
-                os._exit(0)
-            logger.info("ART backend shut down")
+            # Always force-exit after shutdown. Results are saved to disk
+            # both here and inside _run_training_loop (before model.train),
+            # so they survive the exit. Without this, asyncio.run() hangs
+            # on non-daemon threads left by vLLM's EngineCore.
+            logger.info("ART backend shut down — force-exiting subprocess")
+            os._exit(0)
 
     async def _run_training_loop(
         self, model, backend, art, train_data, *,

--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1129,7 +1129,7 @@ class ARTLoRAGRPOBackend(Backend):
             # so they survive the exit. Without this, asyncio.run() hangs
             # on non-daemon threads left by vLLM's EngineCore.
             logger.info("ART backend shut down — force-exiting subprocess")
-            os._exit(0)
+            os._exit(0 if result is not None else 1)
 
     async def _run_training_loop(
         self, model, backend, art, train_data, *,


### PR DESCRIPTION
## Summary

Fixes the subprocess hang reported by the downstream team where the GRPO training process doesn't exit after training completes, keeping the pod alive and GPU allocated indefinitely.

## Root Cause

In `_run_training`, the `finally` block only called `os._exit(0)` when `result is not None`. When `_run_training_loop` raises an exception (e.g. art 0.5.18's `TrainableModel.train` AttributeError), `result` stays `None` and the force-exit is skipped. `asyncio.run()` then hangs on non-daemon threads left by vLLM's EngineCore subprocess.

## Fix

Always call `os._exit(0)` after `_shutdown_art_backend()`, regardless of whether `result` is set. Results and checkpoints are already written to disk inside `_run_training_loop` (before `model.train()` is called), so they survive the force-exit.

## Verification

Tested on A100 with AIPCC 3.5 GA stack. Process exits cleanly after training instead of hanging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training subprocess shutdown to terminate consistently after the backend shutdown completes.
  * Enhanced shutdown logging so it’s clearer when the process will force-exit, including when a normal shutdown outcome is not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->