### PR TITLE
Fix subprocess hang: use join timeout instead of blocking forever

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -836,7 +836,18 @@ class ARTLoRAGRPOBackend(Backend):
             args=(algorithm_params, results_path, error_path),
         )
         proc.start()
-        proc.join()
+        # Join with timeout: vLLM's non-daemon EngineCore threads can prevent
+        # the subprocess from exiting even after os._exit is called from the
+        # training coroutine's finally block. Results are saved to disk inside
+        # the training loop before shutdown, so terminating is safe.
+        join_timeout = float(os.environ.get("TRAINING_HUB_JOIN_TIMEOUT", "7200"))
+        proc.join(timeout=join_timeout)
+        if proc.is_alive():
+            logger.warning("Training subprocess still alive after join timeout, terminating")
+            proc.terminate()
+            proc.join(timeout=10)
+            if proc.is_alive():
+                proc.kill()
 
         if os.path.exists(error_path):
             with open(error_path) as f:


### PR DESCRIPTION
## Summary

Fixes the subprocess hang where the GRPO training process doesn't exit after training completes, keeping the pod alive and GPU allocated indefinitely.

## Root Cause

`proc.join()` blocks forever because the training subprocess gets stuck in `asyncio.run()` event loop teardown. vLLM's EngineCore spawns non-daemon threads that prevent the event loop from shutting down. The subprocess's `os._exit(0)` in the `finally` block is never reached because `asyncio.run()` blocks before returning control to the `finally` clause.

The v0.9.5 fix (unconditional `os._exit` in the async `finally`) doesn't help because the hang occurs during `asyncio.run()`'s internal shutdown, AFTER the coroutine's `finally` block completes but BEFORE `asyncio.run()` returns.

## Fix

Replace `proc.join()` with `proc.join(timeout=...)` on the parent side. If the subprocess is still alive after the timeout, terminate it. Results and checkpoints are already saved to disk inside the training loop before the shutdown sequence begins, so terminating is safe.

Default timeout: 7200s (2 hours), configurable via `TRAINING_HUB_JOIN_TIMEOUT` env var.

## Verification

Reproduced and verified on A100 with AIPCC 3.5 GA stack:

| Test | Result |
|------|--------|
| v0.9.5 (blocking `proc.join()`) | Hung indefinitely (killed by timeout after 90s) |
| This fix (`proc.join(timeout=120)`) | Exited cleanly with results after ~70s training |

**Full Changelog**: https://github.com/Red-Hat-AI-Innovation-Team/training_hub/compare/v0.9.5...fix/subprocess-hang-join-timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training job shutdown handling to prevent indefinite hangs.
  * Added configurable timeouts and progressive termination for training processes that do not finish promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->