### PR TITLE
Fix multi-iteration GRPO with art 0.5.18

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -1135,12 +1135,10 @@ class ARTLoRAGRPOBackend(Backend):
 
             logger.info("Shutting down ART backend...")
             await _shutdown_art_backend(backend)
-            # Always force-exit after shutdown. Results are saved to disk
-            # both here and inside _run_training_loop (before model.train),
-            # so they survive the exit. Without this, asyncio.run() hangs
-            # on non-daemon threads left by vLLM's EngineCore.
-            logger.info("ART backend shut down — force-exiting subprocess")
-            os._exit(0 if result is not None else 1)
+            if result is not None:
+                logger.info("ART backend shut down — force-exiting subprocess")
+                os._exit(0)
+            logger.info("ART backend shut down")
 
     async def _run_training_loop(
         self, model, backend, art, train_data, *,
@@ -1297,11 +1295,18 @@ class ARTLoRAGRPOBackend(Backend):
                 json.dump(results, f, indent=2)
 
             # Train GRPO step — ART writes loss metrics to its own
-            # history.jsonl live during training
-            await model.train(
-                train_groups,
-                config=art.TrainConfig(learning_rate=learning_rate),
-            )
+            # history.jsonl live during training.
+            # art 0.5.18 moved train() from TrainableModel to LocalBackend.
+            if hasattr(model, "train"):
+                await model.train(
+                    train_groups,
+                    config=art.TrainConfig(learning_rate=learning_rate),
+                )
+            else:
+                await backend.train(
+                    model, train_groups,
+                    learning_rate=learning_rate,
+                )
 
             iter_time = time.time() - iter_start
             timing_history.append(iter_time)


### PR DESCRIPTION
## Summary

Fixes multi-iteration GRPO training with art 0.5.18. Previously, training would exit after 1 iteration instead of completing all configured iterations.

## Root Cause

Two issues:

1. **Unconditional `os._exit` in `finally` block** (from v0.9.5): When `model.train()` raised `AttributeError` (see #2), the `finally` block in `_run_training` called `os._exit(0)` unconditionally, killing the subprocess before the loop could continue. Reverted to conditional (`if result is not None`), since the parent-side join timeout from v0.9.6 handles the hang independently.

2. **`model.train()` API removed in art 0.5.18**: `TrainableModel.train()` was removed in art 0.5.18. The replacement is `backend.train(model, trajectory_groups, learning_rate=...)`. Added a `hasattr` check to use the correct API for both art 0.5.17 and 0.5.18.

## Verification

Tested on H100 with 3-iteration GRPO (AIPCC GA stack, art 0.5.18):

```
Iter 1/3: 100% - reward=0.281
Iter 2/3: 100% - reward=0.188  
Iter 3/3: 100% - reward=0.406
[198s] DONE
REWARDS: [0.28125, 0.1875, 0.40625]
EXIT_CODE=0
```

All 3 iterations completed, process exited cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training subprocess shutdown behavior to avoid unnecessary forced exits.
  * Added compatibility with multiple supported training API formats, improving training reliability across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->