### PR TITLE
Patch GRPOTrainer reward_funcs default in art.unsloth.service too

### DIFF
--- a/src/training_hub/algorithms/lora_grpo.py
+++ b/src/training_hub/algorithms/lora_grpo.py
@@ -897,7 +897,7 @@ class ARTLoRAGRPOBackend(Backend):
             import art
             from art.local.backend import LocalBackend
 
-            # ART 0.5.18 passes reward_funcs=[] to GRPOTrainer, but trl 1.8+
+            # ART passes reward_funcs=[] to GRPOTrainer, but trl 1.8+
             # requires at least one reward source.  ART overrides compute_loss
             # entirely, so the no-op is never called at runtime.
             _noop_reward = lambda completions, **kw: [0.0] * len(completions)
@@ -911,7 +911,16 @@ class ARTLoRAGRPOBackend(Backend):
                     elif not kwargs.get("reward_funcs"):
                         kwargs["reward_funcs"] = [_noop_reward]
                     super().__init__(*args, **kwargs)
+            # art 0.5.18 instantiates GRPOTrainer in art.unsloth.train;
+            # art 0.5.17 instantiates it in art.unsloth.service.  Patch the
+            # reference in both modules so either version gets the default.
             _art_train.GRPOTrainer = _GRPOTrainerWithDefaultReward
+            try:
+                import art.unsloth.service as _art_service
+                if hasattr(_art_service, "GRPOTrainer"):
+                    _art_service.GRPOTrainer = _GRPOTrainerWithDefaultReward
+            except ImportError:
+                pass
             asyncio.run(
                 ARTLoRAGRPOBackend()._run_training(algorithm_params, art, LocalBackend)
             )


### PR DESCRIPTION
## Summary

Extends the trl 1.8+ `reward_funcs` workaround to cover art 0.5.17. art 0.5.18 instantiates `GRPOTrainer` in `art.unsloth.train`, but art 0.5.17 instantiates it in `art.unsloth.service` (line 971). The existing monkeypatch only replaced the `train` module's class reference, so a functional art 0.5.17 combined with trl 1.8+ still crashed with `ValueError: No reward source provided`. Now the patched class is installed into both modules (guarded by `hasattr`/`ImportError` so either layout works).

## Context

The AIPCC index's `openpipe_art-0.5.17` wheel is currently **empty** (25KB, zero `.py` files — build defect, being reported to AIPCC separately). Upstream 0.5.17 has both `art.local.backend.LocalBackend` and `TrainableModel.train()`, i.e. the original `No module named 'art.local'` failure was the broken wheel, not an API difference. Once AIPCC rebuilds 0.5.17, this change makes training-hub work correctly with **both** art versions and trl 1.8.

## Verification (H100, AIPCC GA stack: vLLM 0.21.0+rhaiv.10, trl 1.8.0, unsloth 2026.6.9)

Exact branch commit tested, 3-iteration GRPO (`Qwen2.5-1.5B`, Toucan tool-call):

| art version | Result |
|---|---|
| upstream 0.5.17 (`model.train` path, `enforce_eager=True`) | 3/3 iterations, rewards `[0.297, 0.203, 0.375]`, 96 rollouts, clean exit |
| AIPCC 0.5.18 (`backend.train` path) | 3/3 iterations, rewards `[0.344, 0.203, 0.406]`, 96 rollouts, clean exit |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across ART versions by applying the default reward behavior consistently in supported training environments.
  * Added graceful handling when optional training components are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->