### PR TITLE
Add InstructLab and Mini-Trainer adapters for TrainingHubCallback (RHOAIENG-77627)

### DIFF
--- a/examples/scripts/callback_smoke_instructlab.py
+++ b/examples/scripts/callback_smoke_instructlab.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Minimal InstructLab SFT callback smoke for RHOAIENG-77627.
+
+Example:
+    python callback_smoke_instructlab.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+
+DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+DEFAULT_OUT = "/tmp/callback_smoke_ilab_out"
+DEFAULT_DATA = "/tmp/callback_smoke_ilab_data.jsonl"
+
+
+def _clear_mlflow_env() -> None:
+    # Workbench injects MLflow env; ilab torchrun worker crashes on missing experiment.
+    for key in (
+        "MLFLOW_TRACKING_URI",
+        "MLFLOW_EXPERIMENT_NAME",
+        "MLFLOW_RUN_NAME",
+        "MLFLOW_TRACKING_AUTH",
+        "MLFLOW_K8S_INTEGRATION",
+    ):
+        os.environ.pop(key, None)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test TrainingHubCallback on InstructLab sft() (RHOAIENG-77627).",
+    )
+    parser.add_argument("--model-path", default=DEFAULT_MODEL)
+    parser.add_argument("--out-dir", default=DEFAULT_OUT)
+    parser.add_argument("--data-path", default=DEFAULT_DATA)
+    parser.add_argument("--nproc-per-node", default="1")
+    return parser.parse_args()
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+class InstructLabSmokeLogger(TrainingHubCallback):
+    """Module-level callback — class source must survive torchrun serialize."""
+
+    def on_train_begin(self, context: TrainingHubContext) -> None:
+        print(f"[BEGIN] out={context.output_dir} main={context.is_main_process}", flush=True)
+
+    def on_log(self, context: TrainingHubContext) -> None:
+        print(
+            f"[LOG] step={context.step} loss={context.loss} lr={context.learning_rate}",
+            flush=True,
+        )
+
+    def on_step_end(self, context: TrainingHubContext) -> None:
+        print(f"[STEP_END] step={context.step}", flush=True)
+
+    def on_train_end(self, context: TrainingHubContext) -> None:
+        print(f"[END] step={context.step}", flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    _clear_mlflow_env()
+    from training_hub import sft
+
+    out = Path(args.out_dir)
+    data = Path(args.data_path)
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        {
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Capital of France?"},
+                {"role": "assistant", "content": "Paris"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Say hello"},
+                {"role": "assistant", "content": "Hello!"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Color of the sky?"},
+                {"role": "assistant", "content": "Blue"},
+            ]
+        },
+    ]
+    _write_jsonl(data, rows)
+
+    print("Starting sft smoke with InstructLabSmokeLogger...", flush=True)
+    sft(
+        model_path=args.model_path,
+        data_path=str(data),
+        ckpt_output_dir=str(out),
+        num_epochs=1,
+        max_seq_len=128,
+        effective_batch_size=4,
+        learning_rate=2e-5,
+        nproc_per_node=args.nproc_per_node,
+        save_samples=0,
+        checkpoint_at_epoch=True,
+        callbacks=[InstructLabSmokeLogger()],
+    )
+    print("SMOKE OK — InstructLab sft() accepted callbacks and finished", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scripts/callback_smoke_mini_trainer.py
+++ b/examples/scripts/callback_smoke_mini_trainer.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Minimal Mini-Trainer OSFT callback smoke for RHOAIENG-77627.
+
+Example:
+    python callback_smoke_mini_trainer.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+
+DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+DEFAULT_OUT = "/tmp/callback_smoke_mini_out"
+DEFAULT_DATA = "/tmp/callback_smoke_mini_data.jsonl"
+
+
+def _clear_mlflow_env() -> None:
+    for key in (
+        "MLFLOW_TRACKING_URI",
+        "MLFLOW_EXPERIMENT_NAME",
+        "MLFLOW_RUN_NAME",
+        "MLFLOW_TRACKING_AUTH",
+        "MLFLOW_K8S_INTEGRATION",
+    ):
+        os.environ.pop(key, None)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test TrainingHubCallback on Mini-Trainer osft() (RHOAIENG-77627).",
+    )
+    parser.add_argument("--model-path", default=DEFAULT_MODEL)
+    parser.add_argument("--out-dir", default=DEFAULT_OUT)
+    parser.add_argument("--data-path", default=DEFAULT_DATA)
+    parser.add_argument("--nproc-per-node", default="1")
+    return parser.parse_args()
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+class MiniTrainerSmokeLogger(TrainingHubCallback):
+    """Module-level callback — class source must survive torchrun serialize."""
+
+    def on_train_begin(self, context: TrainingHubContext) -> None:
+        print(f"[BEGIN] out={context.output_dir} main={context.is_main_process}", flush=True)
+
+    def on_log(self, context: TrainingHubContext) -> None:
+        print(
+            f"[LOG] step={context.step} loss={context.loss} lr={context.learning_rate}",
+            flush=True,
+        )
+
+    def on_step_end(self, context: TrainingHubContext) -> None:
+        print(f"[STEP_END] step={context.step}", flush=True)
+
+    def on_train_end(self, context: TrainingHubContext) -> None:
+        print(f"[END] step={context.step}", flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    _clear_mlflow_env()
+    from training_hub import osft
+
+    out = Path(args.out_dir)
+    data = Path(args.data_path)
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        {
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Capital of France?"},
+                {"role": "assistant", "content": "Paris"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Say hello"},
+                {"role": "assistant", "content": "Hello!"},
+            ]
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "Color of the sky?"},
+                {"role": "assistant", "content": "Blue"},
+            ]
+        },
+    ]
+    _write_jsonl(data, rows)
+
+    print("Starting osft smoke with MiniTrainerSmokeLogger...", flush=True)
+    osft(
+        model_path=args.model_path,
+        data_path=str(data),
+        ckpt_output_dir=str(out),
+        unfreeze_rank_ratio=0.1,
+        effective_batch_size=4,
+        max_tokens_per_gpu=2048,
+        max_seq_len=128,
+        learning_rate=2e-5,
+        num_epochs=1,
+        nproc_per_node=int(args.nproc_per_node),
+        checkpoint_at_epoch=True,
+        callbacks=[MiniTrainerSmokeLogger()],
+    )
+    print("SMOKE OK — Mini-Trainer osft() accepted callbacks and finished", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scripts/callback_smoke_mini_trainer.py
+++ b/examples/scripts/callback_smoke_mini_trainer.py
@@ -115,7 +115,11 @@ def main() -> None:
         max_seq_len=128,
         learning_rate=2e-5,
         num_epochs=1,
-        nproc_per_node=int(args.nproc_per_node),
+        nproc_per_node=(
+            int(args.nproc_per_node)
+            if args.nproc_per_node.isdigit()
+            else args.nproc_per_node
+        ),
         checkpoint_at_epoch=True,
         callbacks=[MiniTrainerSmokeLogger()],
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "setuptools>=80.0",
     "packaging>=24.2",
     "wheel>=0.43",
-    "instructlab-training>=0.14.0",
-    "rhai-innovation-mini-trainer>=0.6.0",
+    "instructlab-training>=0.16.2",
+    "rhai-innovation-mini-trainer>=0.8.3",
     "torch>=2.6.0",
     "numba>=0.61.2",
     "transformers>=4.57.6",
@@ -53,8 +53,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 cuda = [
-    "instructlab-training[cuda]>=0.14.0",
-    "rhai-innovation-mini-trainer[cuda]>=0.6.0",
+    "instructlab-training[cuda]>=0.16.2",
+    "rhai-innovation-mini-trainer[cuda]>=0.8.3",
     "flash-attn>=2.8",
     "einops>=0.8",
     "kernels>=0.9.0",

--- a/src/training_hub/adapters/__init__.py
+++ b/src/training_hub/adapters/__init__.py
@@ -1,5 +1,8 @@
 """Backend adapters for TrainingHubCallback.
 
 Each adapter translates TrainingHubCallback lifecycle hooks into a
-backend's native callback interface.
+backend's native callback interface:
+
+- ``unsloth``: in-process HuggingFace TrainerCallback wrap
+- ``instructlab`` / ``mini_trainer``: torchrun-safe bridges + payload file
 """

--- a/src/training_hub/adapters/distributed.py
+++ b/src/training_hub/adapters/distributed.py
@@ -42,7 +42,9 @@ def build_hub_context_from_native(context: Any) -> TrainingHubContext:
     if loss is None:
         loss = metrics.get("loss")
     if loss is None:
-        loss = metrics.get("eval_loss") or metrics.get("val_loss")
+        loss = metrics.get("eval_loss")
+    if loss is None:
+        loss = metrics.get("val_loss")
 
     return TrainingHubContext(
         step=int(getattr(context, "step", 0) or 0),
@@ -63,7 +65,14 @@ class HubCallbackDispatcher:
 
     def _callbacks(self) -> list[TrainingHubCallback]:
         if self._hub_callbacks is None:
-            self._hub_callbacks = load_hub_callbacks_payload()
+            try:
+                self._hub_callbacks = load_hub_callbacks_payload()
+            except Exception:
+                logger.exception(
+                    "Failed to load hub callback payload; callbacks are disabled "
+                    "for this worker"
+                )
+                self._hub_callbacks = []
         return self._hub_callbacks
 
     def dispatch(self, method_name: str, native_context: Any) -> None:

--- a/src/training_hub/adapters/distributed.py
+++ b/src/training_hub/adapters/distributed.py
@@ -1,0 +1,83 @@
+"""Shared helpers for InstructLab / Mini-Trainer TrainingHub bridges.
+
+These helpers are imported inside bridge method bodies so the module-level
+native TrainerCallback classes remain ``inspect.getsource``-serializable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from training_hub.adapters.serialize import load_hub_callbacks_payload
+from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+
+logger = logging.getLogger(__name__)
+
+HUB_HOOKS = (
+    "on_train_begin",
+    "on_epoch_begin",
+    "on_step_begin",
+    "on_log",
+    "on_evaluate",
+    "on_save",
+    "on_step_end",
+    "on_epoch_end",
+    "on_train_end",
+)
+
+
+def build_hub_context_from_native(context: Any) -> TrainingHubContext:
+    """Map InstructLab/Mini-Trainer TrainingContext → TrainingHubContext."""
+    metrics: dict[str, Any] = {}
+    batch_metrics = getattr(context, "batch_metrics", None) or {}
+    val_metrics = getattr(context, "val_metrics", None) or {}
+    metrics.update(batch_metrics)
+    metrics.update(val_metrics)
+    checkpoint_path = getattr(context, "checkpoint_path", None)
+    if checkpoint_path is not None:
+        metrics["checkpoint_path"] = checkpoint_path
+
+    loss = getattr(context, "loss", None)
+    if loss is None:
+        loss = metrics.get("loss")
+    if loss is None:
+        loss = metrics.get("eval_loss") or metrics.get("val_loss")
+
+    return TrainingHubContext(
+        step=int(getattr(context, "step", 0) or 0),
+        epoch=int(getattr(context, "epoch", 0) or 0),
+        loss=loss,
+        learning_rate=getattr(context, "learning_rate", None),
+        is_main_process=bool(getattr(context, "is_world_process_zero", True)),
+        output_dir=str(getattr(context, "output_dir", "") or ""),
+        metrics=metrics,
+    )
+
+
+class HubCallbackDispatcher:
+    """Lazy-load hub callbacks from payload and dispatch with isolation/rank guard."""
+
+    def __init__(self) -> None:
+        self._hub_callbacks: list[TrainingHubCallback] | None = None
+
+    def _callbacks(self) -> list[TrainingHubCallback]:
+        if self._hub_callbacks is None:
+            self._hub_callbacks = load_hub_callbacks_payload()
+        return self._hub_callbacks
+
+    def dispatch(self, method_name: str, native_context: Any) -> None:
+        hub_ctx = build_hub_context_from_native(native_context)
+        for cb in self._callbacks():
+            if not hub_ctx.is_main_process and not getattr(
+                cb, "run_on_all_ranks", False
+            ):
+                continue
+            try:
+                getattr(cb, method_name)(hub_ctx)
+            except Exception:
+                logger.exception(
+                    "%s.%s raised an exception (ignored)",
+                    type(cb).__name__,
+                    method_name,
+                )

--- a/src/training_hub/adapters/instructlab.py
+++ b/src/training_hub/adapters/instructlab.py
@@ -1,0 +1,95 @@
+"""InstructLab Training adapter for TrainingHubCallback.
+
+Produces a module-level ``instructlab.training.TrainerCallback`` bridge that
+survives torchrun serialization. Hub callback class sources are written to a
+payload file and reloaded in the worker via ``TRAINING_HUB_CALLBACKS_PATH``.
+"""
+
+from __future__ import annotations
+
+from instructlab.training.callbacks import TrainerCallback
+
+from training_hub.adapters.serialize import (
+    normalize_hub_callbacks,
+    set_callbacks_payload_env,
+    write_hub_callbacks_payload,
+)
+from training_hub.callbacks import TrainingHubCallback
+
+
+class InstructLabCallbackBridge(TrainerCallback):
+    """Native InstructLab callback that dispatches to TrainingHubCallbacks.
+
+    Must remain module-level with a no-arg constructor so InstructLab's
+    ``inspect.getsource`` + base64 torchrun serialize/deserialize works.
+    Imports that load hub callbacks happen inside methods.
+
+    Class body must not reference free names from this module — upstream
+    ``exec`` only injects ``TrainerCallback`` / ``TrainingContext``.
+    """
+
+    # Literal string so getsource/exec reconstruct works without module imports.
+    _path_env = "TRAINING_HUB_CALLBACKS_PATH"
+
+    def __init__(self) -> None:
+        # Lazy: reconstructed via classes[0]() in the torchrun worker.
+        self._dispatcher = None
+
+    def _get_dispatcher(self):
+        if self._dispatcher is None:
+            from training_hub.adapters.distributed import HubCallbackDispatcher
+
+            self._dispatcher = HubCallbackDispatcher()
+        return self._dispatcher
+
+    def _dispatch(self, method_name, context) -> None:
+        self._get_dispatcher().dispatch(method_name, context)
+
+    def on_train_begin(self, context) -> None:
+        self._dispatch("on_train_begin", context)
+
+    def on_epoch_begin(self, context) -> None:
+        self._dispatch("on_epoch_begin", context)
+
+    def on_step_begin(self, context) -> None:
+        self._dispatch("on_step_begin", context)
+
+    def on_log(self, context) -> None:
+        self._dispatch("on_log", context)
+
+    def on_evaluate(self, context) -> None:
+        self._dispatch("on_evaluate", context)
+
+    def on_save(self, context) -> None:
+        self._dispatch("on_save", context)
+
+    def on_step_end(self, context) -> None:
+        self._dispatch("on_step_end", context)
+
+    def on_epoch_end(self, context) -> None:
+        self._dispatch("on_epoch_end", context)
+
+    def on_train_end(self, context) -> None:
+        self._dispatch("on_train_end", context)
+
+
+def adapt_hub_callbacks(
+    callbacks: list[TrainingHubCallback] | TrainingHubCallback,
+    payload_dir: str | None = None,
+) -> list[TrainerCallback]:
+    """Write hub callback payload and return InstructLab bridge callbacks.
+
+    Args:
+        callbacks: TrainingHubCallback instance or list.
+        payload_dir: Directory for the payload file (prefer ckpt_output_dir).
+
+    Returns:
+        List containing a single ``InstructLabCallbackBridge`` for
+        ``TrainingArgs.callbacks``.
+    """
+    normalized = normalize_hub_callbacks(callbacks)
+    if not normalized:
+        return []
+    path = write_hub_callbacks_payload(normalized, payload_dir=payload_dir)
+    set_callbacks_payload_env(path)
+    return [InstructLabCallbackBridge()]

--- a/src/training_hub/adapters/mini_trainer.py
+++ b/src/training_hub/adapters/mini_trainer.py
@@ -1,0 +1,94 @@
+"""Mini-Trainer adapter for TrainingHubCallback.
+
+Produces a module-level ``mini_trainer.TrainerCallback`` bridge that survives
+torchrun serialization. Hub callback class sources are written to a payload
+file and reloaded in the worker via ``TRAINING_HUB_CALLBACKS_PATH``.
+"""
+
+from __future__ import annotations
+
+from mini_trainer.callbacks import TrainerCallback
+
+from training_hub.adapters.serialize import (
+    normalize_hub_callbacks,
+    set_callbacks_payload_env,
+    write_hub_callbacks_payload,
+)
+from training_hub.callbacks import TrainingHubCallback
+
+
+class MiniTrainerCallbackBridge(TrainerCallback):
+    """Native Mini-Trainer callback that dispatches to TrainingHubCallbacks.
+
+    Must remain module-level with a no-arg constructor so Mini-Trainer's
+    ``inspect.getsource`` + base64 torchrun serialize/deserialize works.
+    Imports that load hub callbacks happen inside methods.
+
+    Class body must not reference free names from this module — upstream
+    ``exec`` only injects ``TrainerCallback`` / ``TrainingContext``.
+    """
+
+    # Literal string so getsource/exec reconstruct works without module imports.
+    _path_env = "TRAINING_HUB_CALLBACKS_PATH"
+
+    def __init__(self) -> None:
+        self._dispatcher = None
+
+    def _get_dispatcher(self):
+        if self._dispatcher is None:
+            from training_hub.adapters.distributed import HubCallbackDispatcher
+
+            self._dispatcher = HubCallbackDispatcher()
+        return self._dispatcher
+
+    def _dispatch(self, method_name, context) -> None:
+        self._get_dispatcher().dispatch(method_name, context)
+
+    def on_train_begin(self, context) -> None:
+        self._dispatch("on_train_begin", context)
+
+    def on_epoch_begin(self, context) -> None:
+        self._dispatch("on_epoch_begin", context)
+
+    def on_step_begin(self, context) -> None:
+        self._dispatch("on_step_begin", context)
+
+    def on_log(self, context) -> None:
+        self._dispatch("on_log", context)
+
+    def on_evaluate(self, context) -> None:
+        self._dispatch("on_evaluate", context)
+
+    def on_save(self, context) -> None:
+        self._dispatch("on_save", context)
+
+    def on_step_end(self, context) -> None:
+        self._dispatch("on_step_end", context)
+
+    def on_epoch_end(self, context) -> None:
+        self._dispatch("on_epoch_end", context)
+
+    def on_train_end(self, context) -> None:
+        self._dispatch("on_train_end", context)
+
+
+def adapt_hub_callbacks(
+    callbacks: list[TrainingHubCallback] | TrainingHubCallback,
+    payload_dir: str | None = None,
+) -> list[TrainerCallback]:
+    """Write hub callback payload and return Mini-Trainer bridge callbacks.
+
+    Args:
+        callbacks: TrainingHubCallback instance or list.
+        payload_dir: Directory for the payload file (prefer output_dir).
+
+    Returns:
+        List containing a single ``MiniTrainerCallbackBridge`` for
+        ``TrainingArgs.callbacks``.
+    """
+    normalized = normalize_hub_callbacks(callbacks)
+    if not normalized:
+        return []
+    path = write_hub_callbacks_payload(normalized, payload_dir=payload_dir)
+    set_callbacks_payload_env(path)
+    return [MiniTrainerCallbackBridge()]

--- a/src/training_hub/adapters/serialize.py
+++ b/src/training_hub/adapters/serialize.py
@@ -135,6 +135,7 @@ def write_hub_callbacks_payload(
         "callbacks": [encode_hub_callback(cb) for cb in callbacks],
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o600)
     return str(path.resolve())
 
 

--- a/src/training_hub/adapters/serialize.py
+++ b/src/training_hub/adapters/serialize.py
@@ -1,0 +1,160 @@
+"""Serialize TrainingHubCallback classes across the torchrun boundary.
+
+InstructLab and Mini-Trainer reconstruct native TrainerCallback subclasses via
+``inspect.getsource`` + base64. Live hub callback instances cannot survive that
+path, so we:
+
+1. Extract each hub callback **class** source with ``inspect.getsource``
+2. Write the payload to a file (shared filesystem / local tmp)
+3. Point workers at the file via ``TRAINING_HUB_CALLBACKS_PATH``
+4. Register a module-level native bridge that reloads hub callbacks in-worker
+
+Instance state is not preserved (same constraint as upstream native callbacks).
+"""
+
+from __future__ import annotations
+
+import base64
+import inspect
+import json
+import os
+import tempfile
+import textwrap
+from pathlib import Path
+from typing import Any
+
+from training_hub.callbacks import TrainingHubCallback
+
+CALLBACKS_PATH_ENV = "TRAINING_HUB_CALLBACKS_PATH"
+
+
+def normalize_hub_callbacks(
+    callbacks: list[TrainingHubCallback] | TrainingHubCallback | None,
+) -> list[TrainingHubCallback]:
+    """Normalize a single callback or list into a list of instances."""
+    if callbacks is None:
+        return []
+    if isinstance(callbacks, TrainingHubCallback):
+        callbacks = [callbacks]
+    for cb in callbacks:
+        if not isinstance(cb, TrainingHubCallback):
+            raise TypeError(
+                "Expected TrainingHubCallback instance, "
+                f"got {type(cb).__name__}"
+            )
+    return list(callbacks)
+
+
+def encode_hub_callback(callback: TrainingHubCallback) -> dict[str, str]:
+    """Encode one hub callback class source for payload transport.
+
+    Args:
+        callback: TrainingHubCallback instance (class source is extracted).
+
+    Returns:
+        Dict with ``name`` and base64-encoded ``source``.
+
+    Raises:
+        ValueError: If class source cannot be extracted (nested/lambda/etc.).
+    """
+    cls = type(callback)
+    try:
+        source = textwrap.dedent(inspect.getsource(cls))
+    except (OSError, TypeError) as e:
+        raise ValueError(
+            f"Cannot serialize callback {cls.__name__}: {e}. "
+            "Define TrainingHubCallback subclasses at module level "
+            "(not nested, not in __main__/notebook cells without a file), "
+            "with imports inside method bodies and a no-arg constructor."
+        ) from e
+    return {
+        "name": cls.__name__,
+        "source": base64.b64encode(source.encode("utf-8")).decode("ascii"),
+    }
+
+
+def encode_hub_callbacks(callbacks: list[TrainingHubCallback]) -> str:
+    """Encode a list of hub callbacks to a base64 JSON payload string."""
+    encoded = [encode_hub_callback(cb) for cb in callbacks]
+    return base64.b64encode(json.dumps(encoded).encode("utf-8")).decode("ascii")
+
+
+def decode_hub_callback(entry: dict[str, str]) -> TrainingHubCallback:
+    """Reconstruct a TrainingHubCallback instance from an encoded entry."""
+    source = base64.b64decode(entry["source"]).decode("utf-8")
+    namespace: dict[str, Any] = {
+        "TrainingHubCallback": TrainingHubCallback,
+        "TrainingHubContext": __import__(
+            "training_hub.callbacks", fromlist=["TrainingHubContext"]
+        ).TrainingHubContext,
+    }
+    # Payload written by encode_hub_callback in this process / TrainJob — not untrusted input
+    exec(source, namespace)  # noqa: S102
+    classes = [
+        v
+        for v in namespace.values()
+        if isinstance(v, type)
+        and issubclass(v, TrainingHubCallback)
+        and v is not TrainingHubCallback
+    ]
+    if len(classes) != 1:
+        raise ValueError(
+            f"Expected exactly one TrainingHubCallback subclass in payload "
+            f"entry {entry.get('name')!r}, got {len(classes)}"
+        )
+    return classes[0]()
+
+
+def decode_hub_callbacks(encoded: str) -> list[TrainingHubCallback]:
+    """Reconstruct hub callbacks from a base64 JSON payload string."""
+    entries = json.loads(base64.b64decode(encoded).decode("utf-8"))
+    return [decode_hub_callback(entry) for entry in entries]
+
+
+def write_hub_callbacks_payload(
+    callbacks: list[TrainingHubCallback],
+    payload_dir: str | None = None,
+) -> str:
+    """Write encoded hub callbacks to a JSON file and return its path.
+
+    Args:
+        callbacks: Hub callback instances to serialize.
+        payload_dir: Directory for the payload file. Defaults to a temp dir.
+            Prefer checkpoint output_dir so multi-node workers can share it.
+
+    Returns:
+        Absolute path to the written payload file.
+    """
+    if payload_dir is None:
+        payload_dir = tempfile.mkdtemp(prefix="training_hub_callbacks_")
+    else:
+        os.makedirs(payload_dir, exist_ok=True)
+
+    path = Path(payload_dir) / "training_hub_callbacks.json"
+    payload = {
+        "callbacks": [encode_hub_callback(cb) for cb in callbacks],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path.resolve())
+
+
+def load_hub_callbacks_payload(path: str | None = None) -> list[TrainingHubCallback]:
+    """Load hub callbacks from a payload file.
+
+    Args:
+        path: Payload file path. If None, reads ``TRAINING_HUB_CALLBACKS_PATH``.
+
+    Returns:
+        List of reconstructed TrainingHubCallback instances.
+    """
+    if path is None:
+        path = os.environ.get(CALLBACKS_PATH_ENV)
+    if not path:
+        return []
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return [decode_hub_callback(entry) for entry in data.get("callbacks", [])]
+
+
+def set_callbacks_payload_env(path: str) -> None:
+    """Set ``TRAINING_HUB_CALLBACKS_PATH`` for torchrun worker inheritance."""
+    os.environ[CALLBACKS_PATH_ENV] = path

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -5,6 +5,7 @@ import warnings
 
 import datasets
 from training_hub.algorithms import Algorithm, Backend, AlgorithmRegistry
+from training_hub.callbacks import TrainingHubCallback
 from training_hub.utils import format_type_name, get_torchrun_params
 
 
@@ -78,6 +79,9 @@ class OSFTAlgorithm(Algorithm):
         mlflow_run_name: str | None = None,
         # Model loading
         trust_remote_code: bool | None = None,
+        # Callback parameters (keyword-only)
+        *,
+        callbacks: list[TrainingHubCallback] | TrainingHubCallback | None = None,
         **kwargs,
     ) -> any:
         """
@@ -198,6 +202,9 @@ class OSFTAlgorithm(Algorithm):
             'unfreeze_rank_ratio': unfreeze_rank_ratio,
         }
 
+        if isinstance(callbacks, TrainingHubCallback):
+            callbacks = [callbacks]
+
         optional_params = {
             'target_patterns': target_patterns,
             # for data processing
@@ -241,6 +248,7 @@ class OSFTAlgorithm(Algorithm):
             'mlflow_run_name': mlflow_run_name,
             # model loading
             'trust_remote_code': trust_remote_code,
+            'callbacks': callbacks,
         }
 
         # now do validation now that we've set everything up
@@ -310,6 +318,7 @@ class OSFTAlgorithm(Algorithm):
             'mlflow_tracking_uri': str,
             'mlflow_experiment_name': str,
             'mlflow_run_name': str,
+            'callbacks': list,
         }
 
     def _validate_param_types(self, params: dict[str, any]):
@@ -416,6 +425,16 @@ class MiniTrainerOSFTBackend(Backend):
 
         # Rename parameters before sending to backend
         algorithm_params = {renames.get(k, k): v for k, v in algorithm_params.items()}
+
+        # Adapt TrainingHubCallbacks → Mini-Trainer TrainerCallback bridge
+        hub_callbacks = algorithm_params.pop('callbacks', None)
+        if hub_callbacks:
+            from training_hub.adapters.mini_trainer import adapt_hub_callbacks
+
+            payload_dir = algorithm_params.get('output_dir')
+            algorithm_params['callbacks'] = adapt_hub_callbacks(
+                hub_callbacks, payload_dir=payload_dir
+            )
 
         # Populate logging params from environment variables if not explicitly set
         if not algorithm_params.get('mlflow_tracking_uri'):
@@ -615,6 +634,9 @@ def osft(
     mlflow_run_name: str | None = None,
     # Model loading
     trust_remote_code: bool | None = None,
+    # Callback parameters (keyword-only)
+    *,
+    callbacks: list[TrainingHubCallback] | TrainingHubCallback | None = None,
     **kwargs,
 ) -> any:
     """Convenience function to run Orthogonal Subspace Fine-Tuning (OSFT) training.
@@ -699,6 +721,7 @@ def osft(
         mlflow_experiment_name: MLflow experiment name.
         mlflow_run_name: MLflow run name.
         trust_remote_code: Whether to trust remote code when loading the model.
+        callbacks: TrainingHubCallback or list of them for lifecycle hooks.
         **kwargs: Additional backend-specific parameters passed to the backend.
 
     Returns:
@@ -756,5 +779,6 @@ def osft(
         mlflow_experiment_name=mlflow_experiment_name,
         mlflow_run_name=mlflow_run_name,
         trust_remote_code=trust_remote_code,
+        callbacks=callbacks,
         **kwargs,
     )

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -427,13 +427,13 @@ class MiniTrainerOSFTBackend(Backend):
         algorithm_params = {renames.get(k, k): v for k, v in algorithm_params.items()}
 
         # Adapt TrainingHubCallbacks → Mini-Trainer TrainerCallback bridge
-        hub_callbacks = algorithm_params.pop('callbacks', None)
-        if hub_callbacks:
+        user_hub_callbacks = algorithm_params.pop('callbacks', None)
+        if user_hub_callbacks:
             from training_hub.adapters.mini_trainer import adapt_hub_callbacks
 
             payload_dir = algorithm_params.get('output_dir')
             algorithm_params['callbacks'] = adapt_hub_callbacks(
-                hub_callbacks, payload_dir=payload_dir
+                user_hub_callbacks, payload_dir=payload_dir
             )
 
         # Populate logging params from environment variables if not explicitly set
@@ -453,6 +453,13 @@ class MiniTrainerOSFTBackend(Backend):
         # Separate parameters into their respective dataclass fields
         torchrun_args_fields = {f.name for f in fields(TorchrunArgs)}
         training_args_fields = {f.name for f in fields(TrainingArgs)}
+
+        if user_hub_callbacks and 'callbacks' not in training_args_fields:
+            raise RuntimeError(
+                "callbacks= was provided but the installed mini-trainer does not "
+                "support TrainingArgs.callbacks. "
+                "Upgrade rhai-innovation-mini-trainer to >=0.8.3."
+            )
 
         # process this up here so we can exit early
         torchrun_args_pre = {k: v for k, v in algorithm_params.items() if k in torchrun_args_fields and v is not None}

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -9,6 +9,7 @@ from instructlab.training import (
 
 from . import Algorithm, Backend, AlgorithmRegistry
 from training_hub import utils
+from training_hub.callbacks import TrainingHubCallback
 
 
 class InstructLabTrainingSFTBackend(Backend):
@@ -26,6 +27,17 @@ class InstructLabTrainingSFTBackend(Backend):
         # Note: instructlab-training auto-detects loggers based on mlflow_tracking_uri,
         # wandb_project, and tensorboard_log_dir parameters
         training_params = {k: v for k, v in algorithm_params.items() if k not in torchrun_keys}
+
+        # Adapt TrainingHubCallbacks → InstructLab TrainerCallback bridge
+        # (payload file + env for torchrun worker; upstream serializes the bridge)
+        hub_callbacks = training_params.pop('callbacks', None)
+        if hub_callbacks:
+            from training_hub.adapters.instructlab import adapt_hub_callbacks
+
+            payload_dir = training_params.get('ckpt_output_dir')
+            training_params['callbacks'] = adapt_hub_callbacks(
+                hub_callbacks, payload_dir=payload_dir
+            )
         
         # Map training_hub parameter names to instructlab-training parameter names
         if 'max_tokens_per_gpu' in training_params:
@@ -128,6 +140,9 @@ class SFTAlgorithm(Algorithm):
               mlflow_tracking_uri: Optional[str] = None,
               mlflow_experiment_name: Optional[str] = None,
               mlflow_run_name: Optional[str] = None,
+              # Callback parameters (keyword-only)
+              *,
+              callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
               **kwargs) -> Any:
         """Execute SFT training.
         
@@ -166,11 +181,15 @@ class SFTAlgorithm(Algorithm):
             mlflow_tracking_uri: MLflow tracking server URI
             mlflow_experiment_name: MLflow experiment name
             mlflow_run_name: MLflow run name
+            callbacks: TrainingHubCallback or list of them for lifecycle hooks
             **kwargs: Additional parameters passed to the backend
             
         Returns:
             Training result from the backend
         """
+        if isinstance(callbacks, TrainingHubCallback):
+            callbacks = [callbacks]
+
         # Build parameters dict, only including non-None values
         params = {'model_path': model_path, 'data_path': data_path, 'ckpt_output_dir': ckpt_output_dir}
         
@@ -210,6 +229,7 @@ class SFTAlgorithm(Algorithm):
             'mlflow_tracking_uri': mlflow_tracking_uri,
             'mlflow_experiment_name': mlflow_experiment_name,
             'mlflow_run_name': mlflow_run_name,
+            'callbacks': callbacks,
         }
         
         # Only add non-None parameters (let TrainingArgs handle defaults)
@@ -267,6 +287,7 @@ class SFTAlgorithm(Algorithm):
             'mlflow_tracking_uri': str,
             'mlflow_experiment_name': str,
             'mlflow_run_name': str,
+            'callbacks': list,
         }
 
 
@@ -314,6 +335,9 @@ def sft(model_path: str,
         mlflow_tracking_uri: Optional[str] = None,
         mlflow_experiment_name: Optional[str] = None,
         mlflow_run_name: Optional[str] = None,
+        # Callback parameters (keyword-only)
+        *,
+        callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
         **kwargs) -> Any:
     """Convenience function to run SFT training.
     
@@ -353,6 +377,7 @@ def sft(model_path: str,
         mlflow_tracking_uri: MLflow tracking server URI
         mlflow_experiment_name: MLflow experiment name
         mlflow_run_name: MLflow run name
+        callbacks: TrainingHubCallback or list of them for lifecycle hooks
         **kwargs: Additional parameters passed to the backend
     
     Returns:
@@ -396,6 +421,7 @@ def sft(model_path: str,
         mlflow_tracking_uri=mlflow_tracking_uri,
         mlflow_experiment_name=mlflow_experiment_name,
         mlflow_run_name=mlflow_run_name,
+        callbacks=callbacks,
         **kwargs
     )
 

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -38,6 +38,13 @@ class InstructLabTrainingSFTBackend(Backend):
             training_params['callbacks'] = adapt_hub_callbacks(
                 hub_callbacks, payload_dir=payload_dir
             )
+            model_fields = getattr(TrainingArgs, 'model_fields', None)
+            if model_fields is None or 'callbacks' not in model_fields:
+                raise RuntimeError(
+                    "callbacks= was provided but the installed instructlab-training "
+                    "does not support TrainingArgs.callbacks. "
+                    "Upgrade instructlab-training to >=0.16.2."
+                )
         
         # Map training_hub parameter names to instructlab-training parameter names
         if 'max_tokens_per_gpu' in training_params:

--- a/src/training_hub/callbacks.py
+++ b/src/training_hub/callbacks.py
@@ -2,7 +2,7 @@
 
 Provides TrainingHubCallback (base class) and TrainingHubContext (normalized
 training state) so users can write lifecycle hooks once and run them across
-backends (Unsloth first; InstructLab / Mini-Trainer adapters follow).
+backends (Unsloth, InstructLab Training, Mini-Trainer).
 
 Users subclass TrainingHubCallback and override only the hooks they need.
 Backend adapters translate these to each trainer's native callback interface.
@@ -10,8 +10,18 @@ Backend adapters translate these to each trainer's native callback interface.
 Callbacks are fire-and-forget: adapter layers catch exceptions so a failing
 user hook cannot abort training.
 
+Torchrun backends (InstructLab / Mini-Trainer):
+    Callbacks cross the subprocess boundary via class-source serialization.
+    Requirements:
+    - Define subclasses at **module level** (not nested / not ephemeral notebook cells)
+    - Put imports **inside method bodies**
+    - Use a no-arg (or all-default) constructor — **instance state is not preserved**
+    - Keep helpers/constants **inside the callback class** — module-level names
+      outside the class are not included in class-source serialization
+    - Prefer class attributes or re-read config from files/env inside hooks
+
 Example:
-    from training_hub import TrainingHubCallback, TrainingHubContext, lora_sft
+    from training_hub import TrainingHubCallback, TrainingHubContext, lora_sft, sft, osft
 
     class MetricsLogger(TrainingHubCallback):
         def on_log(self, context: TrainingHubContext) -> None:
@@ -20,14 +30,10 @@ Example:
         def on_evaluate(self, context: TrainingHubContext) -> None:
             print(f"eval step={context.step} metrics={context.metrics}")
 
-    lora_sft(
-        model_path="...",
-        data_path="train.jsonl",
-        ckpt_output_dir="...",
-        eval_data_path="eval.jsonl",
-        eval_steps=100,
-        callbacks=[MetricsLogger()],
-    )
+    # Same callback class works across backends:
+    lora_sft(..., callbacks=[MetricsLogger()])
+    sft(..., callbacks=[MetricsLogger()])
+    osft(..., callbacks=[MetricsLogger()])
 """
 
 from __future__ import annotations
@@ -74,10 +80,9 @@ class TrainingHubCallback:
         This is intentionally *not* an ABC. All hooks are optional.
 
     Attributes:
-        run_on_all_ranks: When False (default), Unsloth/HF adapters only
-            dispatch on rank 0. Set True on a subclass to opt into
-            per-rank hooks (e.g. per-node GPU memory logging) before
-            multi-node InstructLab / Mini-Trainer adapters land.
+        run_on_all_ranks: When False (default), adapters only dispatch on
+            rank 0. Set True on a subclass to opt into per-rank hooks
+            (e.g. per-node GPU memory logging).
     """
 
     run_on_all_ranks: bool = False

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -404,6 +405,7 @@ class TestSerializeHubCallbacks:
         path = write_hub_callbacks_payload([original], payload_dir=str(tmp_path))
         loaded = load_hub_callbacks_payload(path)
         assert len(loaded) == 1
+        assert oct(Path(path).stat().st_mode & 0o777) == oct(0o600)
         loaded[0].on_train_begin(TrainingHubContext(step=1))
         # Fresh instance — events list starts empty then gets begin
         assert loaded[0].events == ["begin"]
@@ -449,6 +451,23 @@ class TestDistributedContextAndDispatch:
         assert ctx.metrics["tok"] == 10
         assert ctx.metrics["eval_loss"] == 0.4
         assert ctx.metrics["checkpoint_path"] == "/out/ckpt-7"
+
+    def test_build_context_preserves_zero_eval_loss(self):
+        from training_hub.adapters.distributed import build_hub_context_from_native
+
+        native = SimpleNamespace(
+            step=1,
+            epoch=0,
+            loss=None,
+            learning_rate=None,
+            is_world_process_zero=True,
+            output_dir="/out",
+            batch_metrics={},
+            val_metrics={"eval_loss": 0.0},
+            checkpoint_path=None,
+        )
+        ctx = build_hub_context_from_native(native)
+        assert ctx.loss == 0.0
 
     def test_rank_guard_and_exception_isolation(self, tmp_path, caplog):
         from training_hub.adapters.distributed import HubCallbackDispatcher
@@ -499,6 +518,28 @@ class TestDistributedContextAndDispatch:
         ]
         assert len(ranks) == 1
         assert ranks[0].calls == 1
+
+    def test_load_failure_disables_callbacks(self, tmp_path, caplog):
+        from training_hub.adapters.distributed import HubCallbackDispatcher
+        from training_hub.adapters.serialize import set_callbacks_payload_env
+
+        set_callbacks_payload_env(str(tmp_path / "missing_payload.json"))
+        dispatcher = HubCallbackDispatcher()
+        native = SimpleNamespace(
+            step=1,
+            epoch=0,
+            loss=0.1,
+            learning_rate=None,
+            is_world_process_zero=True,
+            output_dir="/out",
+            batch_metrics={},
+            val_metrics={},
+            checkpoint_path=None,
+        )
+        with caplog.at_level(logging.ERROR):
+            dispatcher.dispatch("on_log", native)
+        assert dispatcher._callbacks() == []
+        assert "Failed to load hub callback payload" in caplog.text
 
 
 @pytest.mark.skipif(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -349,3 +349,245 @@ class TestAdaptHubCallbacks:
 
     def test_empty_list(self):
         assert adapt_hub_callbacks([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Serialize helpers + InstructLab / Mini-Trainer bridges
+# ---------------------------------------------------------------------------
+
+
+class _SerializableLogger(TrainingHubCallback):
+    """Module-level callback for serialization tests."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def on_log(self, context: TrainingHubContext) -> None:
+        self.events.append(f"log:{context.step}:{context.loss}")
+
+    def on_train_begin(self, context: TrainingHubContext) -> None:
+        self.events.append("begin")
+
+
+class _AllRanksLogger(TrainingHubCallback):
+    run_on_all_ranks = True
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def on_step_end(self, context: TrainingHubContext) -> None:
+        self.calls += 1
+
+
+class _BoomCallback(TrainingHubCallback):
+    def on_log(self, context: TrainingHubContext) -> None:
+        raise RuntimeError("boom")
+
+
+class TestSerializeHubCallbacks:
+    """Tests for torchrun payload encode/decode."""
+
+    def test_round_trip(self, tmp_path):
+        from training_hub.adapters.serialize import (
+            decode_hub_callbacks,
+            encode_hub_callbacks,
+            load_hub_callbacks_payload,
+            write_hub_callbacks_payload,
+        )
+
+        original = _SerializableLogger()
+        encoded = encode_hub_callbacks([original])
+        restored = decode_hub_callbacks(encoded)
+        assert len(restored) == 1
+        assert type(restored[0]).__name__ == "_SerializableLogger"
+
+        path = write_hub_callbacks_payload([original], payload_dir=str(tmp_path))
+        loaded = load_hub_callbacks_payload(path)
+        assert len(loaded) == 1
+        loaded[0].on_train_begin(TrainingHubContext(step=1))
+        # Fresh instance — events list starts empty then gets begin
+        assert loaded[0].events == ["begin"]
+
+    def test_rejects_non_callback(self):
+        from training_hub.adapters.serialize import normalize_hub_callbacks
+
+        with pytest.raises(TypeError, match="TrainingHubCallback"):
+            normalize_hub_callbacks([object()])  # type: ignore[list-item]
+
+    def test_dynamic_class_fails_getsource(self):
+        from training_hub.adapters.serialize import encode_hub_callback
+
+        Dyn = type("DynCallback", (TrainingHubCallback,), {})
+        with pytest.raises(ValueError, match="Cannot serialize"):
+            encode_hub_callback(Dyn())
+
+
+class TestDistributedContextAndDispatch:
+    """Shared native-context mapping + dispatcher behavior."""
+
+    def test_build_context_maps_fields(self):
+        from training_hub.adapters.distributed import build_hub_context_from_native
+
+        native = SimpleNamespace(
+            step=7,
+            epoch=2,
+            loss=0.3,
+            learning_rate=1e-5,
+            is_world_process_zero=True,
+            output_dir="/out",
+            batch_metrics={"loss": 0.3, "tok": 10},
+            val_metrics={"eval_loss": 0.4},
+            checkpoint_path="/out/ckpt-7",
+        )
+        ctx = build_hub_context_from_native(native)
+        assert ctx.step == 7
+        assert ctx.epoch == 2
+        assert ctx.loss == 0.3
+        assert ctx.learning_rate == 1e-5
+        assert ctx.is_main_process is True
+        assert ctx.output_dir == "/out"
+        assert ctx.metrics["tok"] == 10
+        assert ctx.metrics["eval_loss"] == 0.4
+        assert ctx.metrics["checkpoint_path"] == "/out/ckpt-7"
+
+    def test_rank_guard_and_exception_isolation(self, tmp_path, caplog):
+        from training_hub.adapters.distributed import HubCallbackDispatcher
+        from training_hub.adapters.serialize import (
+            set_callbacks_payload_env,
+            write_hub_callbacks_payload,
+        )
+
+        path = write_hub_callbacks_payload(
+            [_SerializableLogger(), _BoomCallback(), _AllRanksLogger()],
+            payload_dir=str(tmp_path),
+        )
+        set_callbacks_payload_env(path)
+        dispatcher = HubCallbackDispatcher()
+
+        native_main = SimpleNamespace(
+            step=1,
+            epoch=0,
+            loss=0.1,
+            learning_rate=None,
+            is_world_process_zero=True,
+            output_dir="/out",
+            batch_metrics={},
+            val_metrics={},
+            checkpoint_path=None,
+        )
+        with caplog.at_level(logging.ERROR):
+            dispatcher.dispatch("on_log", native_main)
+        assert "boom" in caplog.text or "BoomCallback" in caplog.text or "ignored" in caplog.text
+
+        # Non-main: only run_on_all_ranks callbacks fire
+        dispatcher2 = HubCallbackDispatcher()
+        native_worker = SimpleNamespace(
+            step=2,
+            epoch=0,
+            loss=0.2,
+            learning_rate=None,
+            is_world_process_zero=False,
+            output_dir="/out",
+            batch_metrics={},
+            val_metrics={},
+            checkpoint_path=None,
+        )
+        dispatcher2.dispatch("on_step_end", native_worker)
+        # Fresh load — AllRanksLogger should have been called once
+        ranks = [
+            cb for cb in dispatcher2._callbacks() if type(cb).__name__ == "_AllRanksLogger"
+        ]
+        assert len(ranks) == 1
+        assert ranks[0].calls == 1
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util").util.find_spec("instructlab") is None,
+    reason="instructlab-training not installed",
+)
+class TestInstructLabBridge:
+    def test_adapt_writes_payload_and_returns_bridge(self, tmp_path):
+        from training_hub.adapters.instructlab import (
+            InstructLabCallbackBridge,
+            adapt_hub_callbacks,
+        )
+        from training_hub.adapters.serialize import CALLBACKS_PATH_ENV
+        import os
+
+        adapted = adapt_hub_callbacks([_SerializableLogger()], payload_dir=str(tmp_path))
+        assert len(adapted) == 1
+        assert isinstance(adapted[0], InstructLabCallbackBridge)
+        assert os.environ.get(CALLBACKS_PATH_ENV)
+        assert (tmp_path / "training_hub_callbacks.json").exists()
+
+        native = SimpleNamespace(
+            step=3,
+            epoch=1,
+            loss=0.5,
+            learning_rate=2e-4,
+            is_world_process_zero=True,
+            output_dir=str(tmp_path),
+            batch_metrics={"loss": 0.5},
+            val_metrics={},
+            checkpoint_path=None,
+        )
+        adapted[0].on_log(native)
+
+    def test_bridge_survives_upstream_serialize_roundtrip(self, tmp_path):
+        from instructlab.training.callbacks import (
+            deserialize_callback,
+            serialize_callback,
+        )
+        from training_hub.adapters.instructlab import (
+            InstructLabCallbackBridge,
+            adapt_hub_callbacks,
+        )
+
+        adapt_hub_callbacks([_SerializableLogger()], payload_dir=str(tmp_path))
+        bridge = InstructLabCallbackBridge()
+        restored = deserialize_callback(serialize_callback(bridge))
+        assert type(restored).__name__ == "InstructLabCallbackBridge"
+
+        native = SimpleNamespace(
+            step=9,
+            epoch=0,
+            loss=0.9,
+            learning_rate=None,
+            is_world_process_zero=True,
+            output_dir=str(tmp_path),
+            batch_metrics={},
+            val_metrics={},
+            checkpoint_path=None,
+        )
+        restored.on_train_begin(native)
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util").util.find_spec("mini_trainer") is None,
+    reason="mini_trainer not installed",
+)
+class TestMiniTrainerBridge:
+    def test_adapt_and_upstream_serialize(self, tmp_path):
+        from mini_trainer.callbacks import deserialize_callback, serialize_callback
+        from training_hub.adapters.mini_trainer import (
+            MiniTrainerCallbackBridge,
+            adapt_hub_callbacks,
+        )
+
+        adapted = adapt_hub_callbacks([_SerializableLogger()], payload_dir=str(tmp_path))
+        assert isinstance(adapted[0], MiniTrainerCallbackBridge)
+        restored = deserialize_callback(serialize_callback(adapted[0]))
+        assert type(restored).__name__ == "MiniTrainerCallbackBridge"
+        restored.on_train_end(
+            SimpleNamespace(
+                step=1,
+                epoch=0,
+                loss=None,
+                learning_rate=None,
+                is_world_process_zero=True,
+                output_dir=str(tmp_path),
+                batch_metrics={},
+                val_metrics={},
+                checkpoint_path=None,
+            )
+        )


### PR DESCRIPTION
## Summary

Extension of #128 (RHOAIENG-77626): completes unified callbacks across all Training Hub backends.

#128 added `TrainingHubCallback` + `TrainingHubContext` and the Unsloth adapter for `lora_sft(callbacks=...)`. This PR adds the **InstructLab** and **Mini-Trainer** bridge adapters so the same callback API works on `sft()` and `osft()` — including torchrun serialization across the subprocess boundary.

Split 2 of [RHOAIENG-54744](https://redhat.atlassian.net/browse/RHOAIENG-54744). Closes [RHOAIENG-77627](https://redhat.atlassian.net/browse/RHOAIENG-77627).

## What's included

| Piece | Details |
| --- | --- |
| `adapters/serialize.py` | Class-source encode/decode for torchrun boundary |
| `adapters/distributed.py` | `HubCallbackDispatcher`, native → `TrainingHubContext` mapping |
| `adapters/instructlab.py` | `InstructLabCallbackBridge` + `adapt_hub_callbacks()` |
| `adapters/mini_trainer.py` | `MiniTrainerCallbackBridge` + `adapt_hub_callbacks()` |
| `sft()` / `osft()` | `callbacks=` param wired through algorithm + backend |
| `callbacks.py` | Torchrun serialization constraints documented |
| Tests | `tests/test_callbacks.py` (+242 lines) |
| Examples | `callback_smoke_instructlab.py`, `callback_smoke_mini_trainer.py` |

## Backend requirements

Requires native callback modules in upstream backends:

| Package | Minimum version |
| --- | --- |
| `instructlab-training` | **0.16.2** |
| `rhai-innovation-mini-trainer` | **0.8.3** |

Universal image tracking (not a merge blocker): [RHOAIENG-81150](https://redhat.atlassian.net/browse/RHOAIENG-81150)

## Test plan

- [x] `pytest tests/test_callbacks.py` (26 tests; mini bridge needs mini-trainer ≥0.8.3)
- [x] E2E on OC workbench: `sft(callbacks=...)` + `osft(callbacks=...)` with pinned backend versions
- [x] Verified `import instructlab.training.callbacks` + `import mini_trainer.callbacks` with 0.16.2 / 0.8.3

Smoke (GPU):
```bash
python examples/scripts/callback_smoke_instructlab.py
python examples/scripts/callback_smoke_mini_trainer.py
```

## Related

- #128 — TrainingHubCallback + Unsloth adapter (merged)
- [RHOAIENG-81150](https://redhat.atlassian.net/browse/RHOAIENG-81150) — universal image backend versions
- [RHOAIENG-79848](https://redhat.atlassian.net/browse/RHOAIENG-79848) — Kubeflow SDK `callbacks=` (follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added callback support to SFT and OSFT training workflows.
  * Added lifecycle event reporting across InstructLab and Mini-Trainer backends.
  * Added callback persistence and restoration for distributed training.
  * Added standalone smoke-test scripts for both training workflows.

* **Documentation**
  * Expanded callback documentation with backend support, distributed usage, and examples.
  * Documented backend user-experience differences and configuration considerations.

* **Tests**
  * Added coverage for callback dispatch, serialization, distributed execution, and backend integration.
  * Added a validation script for callback tests and optional smoke checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->