### PR TITLE
docs: add GEPA to the support matrix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ result = grpo(
 )
 ```
 
-### GEPA (Genetic-Pareto Prompt Optimization)
+### [GEPA (Genetic-Pareto Prompt Optimization)](/algorithms/gepa)
 
 Gradient-free prompt optimization using evolutionary search with Pareto-based selection and LLM-driven reflection. GEPA evolves textual prompts to maximize task performance **without modifying model weights**, so it needs no local GPU — it optimizes prompts by calling an LLM endpoint (hosted API or local vLLM/OpenAI-compatible server via `api_base`). Features:
 - Genetic-Pareto search with LLM reflection to propose improved prompts

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,19 +26,14 @@
 
 ## Support Matrix
 
-| Algorithm | InstructLab-Training | RHAI Innovation Mini-Trainer | PEFT | Unsloth | verl | Status |
-|-----------|----------------------|------------------------------|------|---------|------|--------|
-| **Supervised Fine-tuning (SFT)** | ✅ | - | - | - | - | Implemented |
-| Continual Learning (OSFT) | 🔄 | ✅ | 🔄 | - | - | Implemented |
-| **Low-Rank Adaptation (LoRA) + SFT** | - | - | - | ✅ | - | Implemented |
-| **LoRA + GRPO (Adapter-Based RLVR)** | - | - | - | ✅ | ✅ | Implemented |
-| **GRPO (Full Fine-Tuning RLVR)** | - | - | - | - | ✅ | Implemented |
-| Direct Preference Optimization (DPO) | - | - | - | - | 🔄 | Planned |
-
-**Legend:**
-- ✅ Implemented and tested
-- 🔄 Planned for future implementation
-- \- Not applicable or not planned
+| Algorithm | Backends | GPU Support | Install Extra |
+|-----------|----------|-------------|---------------|
+| **Supervised Fine-tuning (SFT)** | InstructLab-Training | Multi-GPU, multi-node | base |
+| **Continual Learning (OSFT)** | RHAI Innovation Mini-Trainer | Multi-GPU, multi-node | base |
+| **Low-Rank Adaptation (LoRA) + SFT** | Unsloth | Single-GPU, multi-GPU, multi-node | `[lora]` |
+| **LoRA + GRPO (Adapter-Based RLVR)** | ART + Unsloth, verl | Single-GPU (ART), multi-GPU, multi-node (verl) | `[grpo,lora]` |
+| **GRPO (Full Fine-Tuning RLVR)** | verl | Multi-GPU, multi-node | `[grpo]` |
+| **GEPA (Genetic-Pareto Prompt Optimization)** | GEPA, MLflow | CPU (API-based) | `[gepa]` |
 
 ## Implemented Algorithms
 
@@ -163,6 +158,26 @@ result = grpo(
 )
 ```
 
+### GEPA (Genetic-Pareto Prompt Optimization)
+
+Gradient-free prompt optimization using evolutionary search with Pareto-based selection and LLM-driven reflection. GEPA evolves textual prompts to maximize task performance **without modifying model weights**, so it needs no local GPU — it optimizes prompts by calling an LLM endpoint (hosted API or local vLLM/OpenAI-compatible server via `api_base`). Features:
+- Genetic-Pareto search with LLM reflection to propose improved prompts
+- Works with any model reachable through LiteLLM (hosted APIs or local endpoints)
+- Two backends: `gepa` (direct `gepa.optimize()`) and `mlflow` (MLflow prompt registry, scorers, and tracking)
+
+```python
+from training_hub import gepa
+
+result = gepa(
+    seed_candidate={"system_prompt": "You are a helpful assistant. Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="./eval_data.jsonl",
+    output_dir="./gepa_output",
+    reflection_lm="openai/gpt-4o",
+    max_metric_calls=200,
+)
+```
+
 ## Installation
 
 ### Basic Installation
@@ -208,6 +223,18 @@ pip install training-hub[grpo,lora]
 > The `[grpo]` extras constrain torch, vllm, and transformers versions for verl
 > compatibility, which may conflict with versions pulled by `[cuda]`. Sequential
 > installation lets the solver pick compatible versions.
+
+### GEPA Support
+For gradient-free prompt optimization (includes the MLflow backend):
+```bash
+pip install training-hub[gepa]
+# or for development
+pip install -e .[gepa]
+```
+
+**Note:** GEPA optimizes prompts via LLM API calls and does not require CUDA. To
+optimize against a local model, run a vLLM (or other OpenAI-compatible) server and
+pass its URL via the `api_base` parameter.
 
 ### CUDA Support
 For GPU training with CUDA support:

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,6 +14,7 @@
   * [LoRA - Low-Rank Adaptation](/algorithms/lora)
   * [LoRA + GRPO - Adapter RLVR](/algorithms/lora_grpo)
   * [GRPO - Full Fine-Tuning RLVR](/algorithms/grpo)
+  * [GEPA - Prompt Optimization](/algorithms/gepa)
 
 * API Reference
   * [API Overview](/api/)
@@ -23,6 +24,7 @@
     * [lora_sft()](/api/functions/lora_sft)
     * [lora_grpo()](/api/functions/lora_grpo)
     * [grpo()](/api/functions/grpo)
+    * [gepa()](/api/functions/gepa)
     * [create_algorithm()](/api/functions/create-algorithm)
   * Classes
     * [Algorithm](/api/classes/Algorithm)
@@ -31,6 +33,7 @@
     * [OSFTAlgorithm](/api/classes/OSFTAlgorithm)
     * [LoRASFTAlgorithm](/api/classes/LoRASFTAlgorithm)
     * [LoRAGRPOAlgorithm](/api/classes/LoRAGRPOAlgorithm)
+    * [GEPAAlgorithm](/api/classes/GEPAAlgorithm)
     * [PEFTExtender](/api/classes/PEFTExtender)
     * [LoRAPEFTExtender](/api/classes/LoRAPEFTExtender)
     * [AlgorithmRegistry](/api/classes/AlgorithmRegistry)
@@ -41,6 +44,7 @@
     * [Unsloth](/api/backends/unsloth)
     * [ART (GRPO)](/api/backends/art-grpo)
     * [verl (GRPO)](/api/backends/verl)
+    * [GEPA (Prompt Optimization)](/api/backends/gepa)
   * [Data Formats](/api/data-formats)
 
 * Guides

--- a/docs/algorithms/gepa.md
+++ b/docs/algorithms/gepa.md
@@ -1,0 +1,114 @@
+# GEPA — Genetic-Pareto Prompt Optimization
+
+GEPA is a **gradient-free** prompt optimization algorithm. Instead of updating model weights, it evolves the *text* of your prompts using evolutionary search with Pareto-based selection and LLM-driven reflection, keeping the candidates that perform best on your task.
+
+> Because GEPA optimizes prompts rather than weights, it needs **no local GPU**. It reaches the model through an LLM endpoint — a hosted API (OpenAI, Anthropic, …) or a local vLLM / OpenAI-compatible server via `api_base`.
+
+## When to Use
+
+- You want to improve a system prompt, few-shot template, or agent instructions without training the model
+- You cannot (or do not want to) fine-tune weights — e.g. you are calling a hosted API model
+- You have a small labeled evaluation set and a way to score responses
+- You want a cheap, fast iteration loop before committing to weight training
+
+For weight-training algorithms, see [SFT](/algorithms/sft), [OSFT](/algorithms/osft), [LoRA + SFT](/algorithms/lora), or [GRPO](/algorithms/grpo).
+
+## Quick Start
+
+```python
+from training_hub import gepa
+
+result = gepa(
+    seed_candidate={"system_prompt": "You are a helpful assistant. Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="./eval_data.jsonl",
+    output_dir="./gepa_output",
+    reflection_lm="openai/gpt-4o",   # defaults to task_lm if omitted
+    max_metric_calls=200,
+)
+
+print(result.best_candidate)  # the optimized prompt(s)
+```
+
+## How It Works
+
+1. **Seed** — you provide a starting prompt as `seed_candidate`, a dict mapping prompt field names to their text (e.g. `{"system_prompt": "..."}`).
+2. **Evaluate** — each candidate is scored against your training examples using an evaluator (the default checks whether the expected answer appears in the response).
+3. **Reflect & mutate** — a reflection LLM inspects failures and proposes improved prompt candidates.
+4. **Select** — GEPA keeps a Pareto frontier of candidates rather than a single best, preserving diversity across objectives.
+5. **Repeat** — until the evaluation budget (`max_metric_calls`) is exhausted.
+
+## Backends
+
+GEPA ships with two backends, selected via the `backend` parameter:
+
+| Backend | `backend=` | Description |
+|---------|-----------|-------------|
+| GEPA (default) | `"gepa"` | Calls `gepa.optimize()` directly. Returns a `GEPAResult`. Best for standalone prompt optimization. |
+| MLflow | `"mlflow"` | Wraps `mlflow.genai.optimize_prompts()`. Integrates with the MLflow prompt registry, scorer framework, and experiment tracking. Requires `mlflow>=3.5.0`. |
+
+See [GEPA Backends](/api/backends/gepa) for details.
+
+## Data Format
+
+Training data is a JSONL file where each line has an `input` and an `answer`, plus optional `additional_context`:
+
+```json
+{"input": "What is the capital of France?", "answer": "Paris"}
+{"input": "2 + 2 * 3 = ?", "answer": "8", "additional_context": {"topic": "arithmetic"}}
+```
+
+You can also pass data directly as a list of dicts via `trainset` instead of `data_path`.
+
+## Custom Scoring
+
+The default evaluator checks whether the expected `answer` appears in the model's response. For anything more nuanced, pass a custom `evaluator` (gepa backend) matching the gepa Evaluator protocol:
+
+```python
+def evaluator(data, response):
+    # returns (score, feedback, objective_scores)
+    score = 1.0 if data["answer"].lower() in response.lower() else 0.0
+    return score, "", {}
+```
+
+For the MLflow backend, supply MLflow `scorers` instead. When using a **local endpoint** with the MLflow backend, prefer custom `@scorer` functions — the built-in scorers (e.g. `Correctness`) hardcode the OpenAI endpoint and do not route through `api_base`.
+
+## Using Local Models
+
+Point GEPA at any OpenAI-compatible server (e.g. vLLM) with `api_base`. Model names use litellm format (`openai/<model-name>`):
+
+```python
+result = gepa(
+    seed_candidate={"system_prompt": "Answer the question."},
+    task_lm="openai/my-local-model",
+    api_base="http://localhost:8000/v1",
+    data_path="./eval_data.jsonl",
+    max_metric_calls=200,
+)
+```
+
+`api_base` is applied via `OPENAI_API_BASE` for the duration of the run and restored afterward. A dummy `OPENAI_API_KEY` is set automatically when none is configured, since litellm requires a key even for local endpoints.
+
+## Output
+
+When `output_dir` is set, results are written to disk:
+
+- `best_candidate.json` — the optimized prompt(s)
+- `result.json` — full optimization metadata (scores, candidates, etc.)
+
+The call also returns the result object: a `GEPAResult` (gepa backend) or `PromptOptimizationResult` (mlflow backend).
+
+## Tips
+
+- **Model size matters for reflection.** Very small models (< 3B) tend to produce poor reflections. Use a capable model for `reflection_lm` even if `task_lm` is small.
+- **Budget rule of thumb.** GEPA typically needs 100–500 evaluations (`max_metric_calls`). Roughly `num_examples * 20` is a reasonable starting budget.
+- **Design data where the prompt matters.** If a trivial prompt already scores ~1.0, there is nothing to optimize. Choose examples where a vague prompt fails but a precise one succeeds.
+- **Set `reflection_minibatch_size`** so reflection examines enough examples per step to catch failure patterns.
+
+## API Reference
+
+See [`gepa()`](/api/functions/gepa) for the full parameter reference and [`GEPAAlgorithm`](/api/classes/GEPAAlgorithm) for the class-based API.
+
+## Example Notebook
+
+- [GEPA Prompt Optimization](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/blob/main/examples/notebooks/gepa_prompt_optimization.ipynb) — runnable notebook demonstrating both backends against a local vLLM server.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,6 +15,7 @@ Training Hub provides convenient top-level functions for common training tasks:
 | [`lora_sft()`](/api/functions/lora_sft) | Parameter-efficient fine-tuning with LoRA | [Details](/api/functions/lora_sft) |
 | [`lora_grpo()`](/api/functions/lora_grpo) | LoRA + GRPO for tool-calling agents (RLVR) | [Details](/api/functions/lora_grpo) |
 | [`grpo()`](/api/functions/grpo) | Full-parameter GRPO training (verl backend) | [Details](/api/functions/grpo) |
+| [`gepa()`](/api/functions/gepa) | Gradient-free prompt optimization (no weight training) | [Details](/api/functions/gepa) |
 | [`create_algorithm()`](/api/functions/create-algorithm) | Factory function to create algorithm instances | [Details](/api/functions/create-algorithm) |
 
 ### Classes
@@ -29,6 +30,7 @@ Training Hub uses an object-oriented architecture with algorithms and pluggable 
 | [`OSFTAlgorithm`](/api/classes/OSFTAlgorithm) | OSFT algorithm implementation | [Details](/api/classes/OSFTAlgorithm) |
 | [`LoRASFTAlgorithm`](/api/classes/LoRASFTAlgorithm) | LoRA fine-tuning algorithm implementation | [Details](/api/classes/LoRASFTAlgorithm) |
 | [`LoRAGRPOAlgorithm`](/api/classes/LoRAGRPOAlgorithm) | LoRA + GRPO for tool-calling agents | [Details](/api/classes/LoRAGRPOAlgorithm) |
+| [`GEPAAlgorithm`](/api/classes/GEPAAlgorithm) | Genetic-Pareto prompt optimization (gradient-free) | [Details](/api/classes/GEPAAlgorithm) |
 | [`PEFTExtender`](/api/classes/PEFTExtender) | Base class for parameter-efficient fine-tuning extensions | [Details](/api/classes/PEFTExtender) |
 | [`LoRAPEFTExtender`](/api/classes/LoRAPEFTExtender) | LoRA-specific PEFT extension implementation | [Details](/api/classes/LoRAPEFTExtender) |
 | [`AlgorithmRegistry`](/api/classes/AlgorithmRegistry) | Central registry for algorithms and backends | [Details](/api/classes/AlgorithmRegistry) |
@@ -44,6 +46,7 @@ Backend implementations that power the algorithms:
 | [`UnslothLoRABackend`](/api/backends/unsloth) | LoRA | [Details](/api/backends/unsloth) |
 | [`ARTLoRAGRPOBackend`](/api/backends/art-grpo) | LoRA + GRPO (single-GPU) | [Details](/api/backends/art-grpo) |
 | [`VeRLLoRAGRPOBackend`](/api/backends/verl) | LoRA + GRPO (multi-GPU) | [Details](/api/backends/verl) |
+| [`GEPABackend` / `MLflowGEPABackend`](/api/backends/gepa) | GEPA prompt optimization | [Details](/api/backends/gepa) |
 
 For an overview of the backend system, see [Backends Overview](/api/backends/).
 

--- a/docs/api/backends/gepa.md
+++ b/docs/api/backends/gepa.md
@@ -1,0 +1,113 @@
+# GEPA Backends
+
+> Gradient-free prompt optimization. Two backends power the [`gepa()`](/api/functions/gepa) algorithm: the default `gepa` backend and an `mlflow` backend.
+
+## Overview
+
+**Classes:** `GEPABackend`, `MLflowGEPABackend`
+
+**Algorithm Support:** GEPA (prompt optimization)
+
+**Package:** `gepa` (and `mlflow>=3.5.0` for the MLflow backend)
+
+**Status:** Implemented
+
+GEPA optimizes prompt *text* rather than model weights, so neither backend requires a local GPU — both reach the model through an LLM endpoint (hosted API or local vLLM/OpenAI-compatible server via `api_base`).
+
+## `GEPABackend` (default, `backend="gepa"`)
+
+Calls `gepa.optimize()` directly. Best for standalone prompt optimization.
+
+### Usage
+
+```python
+from training_hub import gepa
+
+result = gepa(
+    seed_candidate={"system_prompt": "You are a helpful assistant. Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="./eval_data.jsonl",
+    output_dir="./gepa_output",
+    reflection_lm="openai/gpt-4o",
+    max_metric_calls=200,
+)
+print(result.best_candidate)
+```
+
+### Via Class-Based API
+
+```python
+from training_hub import GEPAAlgorithm, GEPABackend
+
+algo = GEPAAlgorithm(backend=GEPABackend())
+result = algo.train(
+    seed_candidate={"system_prompt": "Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="./eval_data.jsonl",
+)
+```
+
+### Notes
+
+- **Scoring:** Defaults to gepa's `ContainsAnswerEvaluator` (checks whether the expected answer appears in the response). Pass a custom `evaluator` for anything more nuanced.
+- **Reflection model:** `reflection_lm` defaults to `task_lm` if omitted.
+- **Returns:** a `GEPAResult`. With `output_dir` set, writes `best_candidate.json` and `result.json`.
+
+## `MLflowGEPABackend` (`backend="mlflow"`)
+
+Wraps `mlflow.genai.optimize_prompts()`, integrating with MLflow's prompt registry, scorer framework, and experiment tracking. Requires `mlflow>=3.5.0`.
+
+### Usage
+
+```python
+import mlflow
+from mlflow.genai.scorers import Correctness
+from training_hub import gepa
+
+prompt = mlflow.genai.register_prompt(name="qa", template="Answer: {{question}}")
+
+result = gepa(
+    seed_candidate={"qa": prompt.template},
+    task_lm="openai/gpt-4o-mini",
+    backend="mlflow",
+    predict_fn=my_predict_fn,
+    prompt_uris=[prompt.uri],
+    scorers=[Correctness(model="openai:/gpt-4o")],
+    data_path="./qa_data.jsonl",
+)
+```
+
+### Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `predict_fn` | `Callable` | Uses MLflow registered prompts to generate output. |
+| `prompt_uris` | `list[str]` | MLflow prompt URIs to optimize (e.g. `["prompts:/qa/1"]`). |
+| `reflection_lm` or `task_lm` | `str` | Reflection model for the `GepaPromptOptimizer`. |
+
+### Notes
+
+- **Model URIs:** litellm model strings (`openai/model`) are automatically converted to MLflow URI format (`openai:/model`).
+- **Data conversion:** GEPA-format data (`input`/`answer`) is automatically converted to MLflow's expected format.
+- **Local endpoints:** Prefer custom `@scorer` functions over built-in scorers like `Correctness(model="openai:/...")` — the built-ins hardcode the OpenAI endpoint and do not route through `api_base`.
+- **Ignored params:** Parameters not applicable to MLflow are logged as a warning rather than silently dropped.
+- **Returns:** a `PromptOptimizationResult`. With `output_dir` set, writes `result.json`.
+
+## Installation
+
+```bash
+pip install training-hub[gepa]
+```
+
+The `[gepa]` extra includes both `gepa` and `mlflow`, so both backends are available.
+
+## Environment Handling
+
+Both backends manage `OPENAI_API_BASE` and `OPENAI_API_KEY` for the duration of a run when `api_base` is set: a dummy API key is supplied if none is configured (litellm requires one even for local endpoints), and the previous environment is restored afterward.
+
+## See Also
+
+- [GEPA Algorithm Overview](/algorithms/gepa)
+- [`gepa()` Function Reference](/api/functions/gepa)
+- [`GEPAAlgorithm` Class Reference](/api/classes/GEPAAlgorithm)
+- [Backends Overview](/api/backends/)

--- a/docs/api/classes/GEPAAlgorithm.md
+++ b/docs/api/classes/GEPAAlgorithm.md
@@ -1,0 +1,223 @@
+# `GEPAAlgorithm` - Genetic-Pareto Prompt Optimization Algorithm Class
+
+> Concrete implementation of the Algorithm interface for GEPA, a gradient-free prompt optimization algorithm that evolves prompt text without modifying model weights.
+
+## Class Signature
+
+```python
+from training_hub import GEPAAlgorithm, Backend
+
+class GEPAAlgorithm(Algorithm):
+    """
+    Optimizes textual prompts using evolutionary search with Pareto-based
+    selection and LLM-driven reflection. Does not modify model weights.
+    """
+
+    def __init__(self, backend: Backend, **kwargs) -> None:
+        """Initialize GEPA algorithm with a backend."""
+
+    def train(
+        self,
+        seed_candidate: dict[str, str],
+        task_lm: str,
+        # ... all gepa() parameters
+        **kwargs
+    ) -> any:
+        """Execute GEPA prompt optimization."""
+
+    def get_required_params(self) -> dict[str, type]:
+        """Get required parameters."""
+
+    def get_optional_params(self) -> dict[str, type]:
+        """Get optional parameters."""
+```
+
+## Overview
+
+`GEPAAlgorithm` is the class-based implementation of GEPA (Genetic-Pareto) prompt optimization in Training Hub. It inherits from the [`Algorithm`](Algorithm.md) abstract base class.
+
+Unlike weight-training algorithms (SFT, OSFT, LoRA, GRPO), GEPA optimizes the *prompt itself* — useful for improving system prompts, few-shot templates, and agent instructions. It requires no local GPU; the model is reached through an LLM endpoint (hosted API or local vLLM/OpenAI-compatible server).
+
+This class is useful when you need:
+- To reuse an algorithm instance across multiple optimization runs
+- Direct access to the algorithm interface
+- Custom prompt-optimization pipelines
+
+For most use cases, the convenience function [`gepa()`](../functions/gepa.md) is simpler.
+
+## Constructor
+
+### `__init__(backend: Backend, **kwargs) -> None`
+
+Creates a new GEPAAlgorithm instance.
+
+**Parameters:**
+- `backend` (`Backend`): The backend implementation to use (`GEPABackend` or `MLflowGEPABackend`)
+- `**kwargs`: Additional configuration passed to the algorithm
+
+**Example:**
+```python
+from training_hub import GEPAAlgorithm, GEPABackend
+
+backend = GEPABackend()
+algorithm = GEPAAlgorithm(backend=backend)
+```
+
+## Methods
+
+### `train(**kwargs) -> Any`
+
+Executes GEPA prompt optimization.
+
+#### Parameters
+
+##### Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `seed_candidate` | `dict[str, str]` | Initial prompt to optimize, as a dict of field name → text (e.g. `{"system_prompt": "..."}`). |
+| `task_lm` | `str` | Model to optimize for, as a litellm model string (e.g. `"openai/gpt-4o-mini"`). |
+
+##### Optional Parameters
+
+###### Data
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `data_path` | `str` | `None` | Path to a JSONL file with `input`/`answer` (and optional `additional_context`) per line. |
+| `trainset` | `list` | `None` | Training examples as a list of dicts. Alternative to `data_path`. |
+| `valset` | `list` | `None` | Optional validation set (same format as `trainset`). |
+| `output_dir` | `str` | `None` | Directory to save `best_candidate.json` and `result.json`. |
+
+###### Backend Selection
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `backend` | `str` | `"gepa"` | `"gepa"` (direct) or `"mlflow"` (MLflow prompt registry + scorers). |
+
+###### Model Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `evaluator` | `Callable` | `None` | Custom scoring function `(data, response) -> (score, feedback, objective_scores)`. Defaults to gepa's `ContainsAnswerEvaluator`. |
+| `reflection_lm` | `str` | `None` | Model for reflection/mutation. Defaults to `task_lm` if omitted. |
+| `api_base` | `str` | `None` | Base URL for a local vLLM/OpenAI-compatible endpoint. |
+
+###### Optimization Hyperparameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_metric_calls` | `int` | `None` | Evaluation budget (typically 100–500). |
+| `candidate_selection_strategy` | `str` | `None` | `"pareto"`, `"current_best"`, `"epsilon_greedy"`, `"top_k_pareto"`. |
+| `frontier_type` | `str` | `None` | `"instance"`, `"objective"`, `"hybrid"`, `"cartesian"`. |
+| `skip_perfect_score` | `bool` | `None` | Whether to skip perfect-scoring candidates. |
+| `perfect_score` | `float` | `None` | Score considered perfect (default `1.0`). |
+| `reflection_minibatch_size` | `int` | `None` | Examples examined per reflection step. |
+| `seed` | `int` | `None` | Random seed for reproducibility. |
+
+###### Tracking
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `use_wandb` | `bool` | `None` | Enable Weights & Biases logging. |
+| `use_mlflow` | `bool` | `None` | Enable MLflow logging. |
+| `mlflow_tracking_uri` | `str` | `None` | MLflow tracking server URI. |
+| `mlflow_experiment_name` | `str` | `None` | MLflow experiment name. |
+
+###### MLflow Backend Only (`backend="mlflow"`)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `predict_fn` | `Callable` | `None` | Required. Callable using MLflow registered prompts to generate output. |
+| `prompt_uris` | `list` | `None` | Required. MLflow prompt URIs to optimize. |
+| `scorers` | `list` | `None` | MLflow `Scorer` instances. |
+| `aggregation` | `Callable` | `None` | Combines individual scorer outputs into an overall score. |
+| `enable_tracking` | `bool` | `None` | Log optimization progress to MLflow (default `True`). |
+| `gepa_kwargs` | `dict` | `None` | Extra kwargs forwarded to `gepa.optimize()`. |
+
+> Additional advanced parameters (`adapter`, `run_dir`, `batch_sampler`, `reflection_prompt_template`, `custom_candidate_proposer`, `module_selector`, `use_merge`, `stop_callbacks`, `callbacks`, `display_progress_bar`, `cache_evaluation`, `raise_on_exception`, W&B keys) are also accepted via `**kwargs`.
+
+#### Returns
+
+**Type:** `Any`
+
+- `GEPAResult` for the `gepa` backend (`result.best_candidate` holds the optimized prompt).
+- `PromptOptimizationResult` for the `mlflow` backend.
+
+When `output_dir` is set, `best_candidate.json` and `result.json` are also written to disk.
+
+#### Raises
+
+- **`ValueError`**: When neither `trainset` nor `data_path` is provided, or when the MLflow backend is missing `predict_fn`/`prompt_uris`/reflection model.
+- **`ImportError`**: When the `gepa` package (or `mlflow>=3.5.0` for the MLflow backend) is not installed.
+
+### `get_required_params() -> Dict[str, Type]`
+
+Returns the required parameters for GEPA.
+
+**Returns:**
+
+```python
+{
+    "seed_candidate": dict,
+    "task_lm": str,
+}
+```
+
+### `get_optional_params() -> Dict[str, Type]`
+
+Returns the optional parameters for GEPA (data, model configuration, optimization hyperparameters, tracking, and MLflow-backend parameters). See the [`gepa()` function reference](../functions/gepa.md) for the full list.
+
+## Examples
+
+### Basic Usage
+
+```python
+from training_hub import GEPAAlgorithm, GEPABackend
+
+backend = GEPABackend()
+algorithm = GEPAAlgorithm(backend=backend)
+
+result = algorithm.train(
+    seed_candidate={"system_prompt": "You are a helpful assistant. Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="./eval_data.jsonl",
+    output_dir="./gepa_output",
+    max_metric_calls=200,
+)
+
+print(result.best_candidate)
+```
+
+### MLflow Backend
+
+```python
+from training_hub import GEPAAlgorithm, MLflowGEPABackend
+
+backend = MLflowGEPABackend()
+algorithm = GEPAAlgorithm(backend=backend)
+
+result = algorithm.train(
+    seed_candidate={"qa": "Answer: {{question}}"},
+    task_lm="openai/gpt-4o-mini",
+    predict_fn=my_predict_fn,
+    prompt_uris=["prompts:/qa/1"],
+    data_path="./qa_data.jsonl",
+)
+```
+
+## Relationship to gepa() Function
+
+The [`gepa()`](../functions/gepa.md) function is a convenience wrapper around `GEPAAlgorithm`. Both use identical parameters. Prefer the function for most use cases; use the class directly when reusing an instance across multiple optimization runs.
+
+## See Also
+
+- [**gepa() Function**](/api/functions/gepa) - Convenience wrapper function
+- [**Algorithm Class**](/api/classes/Algorithm) - Base class interface
+- [**GEPA Backends**](/api/backends/gepa) - `gepa` and `mlflow` backends
+- [**create_algorithm() Function**](/api/functions/create-algorithm) - Factory function
+- [**GEPA Algorithm Overview**](/algorithms/gepa) - Conceptual overview and tips
+
+## Source
+
+[View source on GitHub](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/blob/main/src/training_hub/algorithms/gepa.py)

--- a/docs/api/functions/gepa.md
+++ b/docs/api/functions/gepa.md
@@ -1,0 +1,162 @@
+# `gepa()`
+
+Gradient-free prompt optimization using GEPA (Genetic-Pareto) evolutionary search. Optimizes the *text* of prompts without modifying model weights.
+
+## Signature
+
+```python
+from training_hub import gepa
+
+result = gepa(
+    seed_candidate: dict[str, str],
+    task_lm: str,
+    # Data
+    data_path: str = None,
+    trainset: list[dict] = None,
+    valset: list[dict] = None,
+    output_dir: str = None,
+    # Backend
+    backend: str = "gepa",
+    # Model configuration
+    evaluator: Callable = None,
+    reflection_lm: str = None,
+    api_base: str = None,
+    # Optimization
+    max_metric_calls: int = None,
+    candidate_selection_strategy: str = None,
+    frontier_type: str = None,
+    skip_perfect_score: bool = None,
+    perfect_score: float = None,
+    reflection_minibatch_size: int = None,
+    seed: int = None,
+    # Tracking
+    use_wandb: bool = None,
+    use_mlflow: bool = None,
+    mlflow_tracking_uri: str = None,
+    mlflow_experiment_name: str = None,
+    # MLflow backend (backend="mlflow")
+    predict_fn: Callable = None,
+    prompt_uris: list[str] = None,
+    scorers: list = None,
+    aggregation: Callable = None,
+    enable_tracking: bool = None,
+    gepa_kwargs: dict = None,
+    **kwargs,
+)
+```
+
+## Quick Example
+
+```python
+from training_hub import gepa
+
+result = gepa(
+    seed_candidate={"system_prompt": "You are a helpful assistant. Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="./eval_data.jsonl",
+    output_dir="./gepa_output",
+    max_metric_calls=200,
+)
+print(result.best_candidate)
+```
+
+## Parameters
+
+### Required
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `seed_candidate` | `dict[str, str]` | Initial prompt to optimize, as a dict of field name → text (e.g. `{"system_prompt": "..."}`). |
+| `task_lm` | `str` | Model to optimize for, as a litellm model string (e.g. `"openai/gpt-4o-mini"`). |
+
+### Data
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `data_path` | `None` | Path to a JSONL file with `input`/`answer` (and optional `additional_context`) per line. |
+| `trainset` | `None` | Training examples as a list of dicts. Alternative to `data_path`. |
+| `valset` | `None` | Optional validation set (same format as `trainset`). |
+| `output_dir` | `None` | Directory to save `best_candidate.json` and `result.json`. |
+
+### Backend
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `backend` | `"gepa"` | `"gepa"` calls `gepa.optimize()` directly; `"mlflow"` uses `mlflow.genai.optimize_prompts()`. |
+
+### Model Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `evaluator` | `None` | Custom scoring function `(data, response) -> (score, feedback, objective_scores)`. Defaults to gepa's `ContainsAnswerEvaluator`. |
+| `reflection_lm` | `None` | Model for reflection/mutation (e.g. `"openai/gpt-4o"`). Defaults to `task_lm` if omitted. |
+| `api_base` | `None` | Base URL for a local vLLM/OpenAI-compatible endpoint (e.g. `"http://localhost:8000/v1"`). |
+
+### Optimization Hyperparameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_metric_calls` | `None` | Evaluation budget. GEPA typically needs 100–500 calls. |
+| `candidate_selection_strategy` | `None` | One of `"pareto"`, `"current_best"`, `"epsilon_greedy"`, `"top_k_pareto"`. |
+| `frontier_type` | `None` | Pareto frontier type: `"instance"`, `"objective"`, `"hybrid"`, `"cartesian"`. |
+| `skip_perfect_score` | `None` | Whether to skip perfect-scoring candidates. |
+| `perfect_score` | `None` | Score considered perfect (default `1.0`). |
+| `reflection_minibatch_size` | `None` | Number of examples examined per reflection step. |
+| `seed` | `None` | Random seed for reproducibility. |
+
+### Tracking
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `use_wandb` | `None` | Enable Weights & Biases logging. |
+| `use_mlflow` | `None` | Enable MLflow logging. |
+| `mlflow_tracking_uri` | `None` | MLflow tracking server URI. |
+| `mlflow_experiment_name` | `None` | MLflow experiment name. |
+
+### MLflow Backend Only (`backend="mlflow"`)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `predict_fn` | `None` | **Required.** Callable that uses MLflow registered prompts to generate output. |
+| `prompt_uris` | `None` | **Required.** List of MLflow prompt URIs to optimize (e.g. `["prompts:/my_prompt/1"]`). |
+| `scorers` | `None` | List of MLflow `Scorer` instances. |
+| `aggregation` | `None` | Callable computing an overall score from individual scorer outputs. |
+| `enable_tracking` | `None` | Whether to log optimization progress to MLflow (default `True`). |
+| `gepa_kwargs` | `None` | Additional kwargs forwarded to `gepa.optimize()` via `GepaPromptOptimizer`. |
+
+> Additional advanced parameters (`adapter`, `run_dir`, `batch_sampler`, `reflection_prompt_template`, `custom_candidate_proposer`, `module_selector`, `use_merge`, `stop_callbacks`, `callbacks`, `display_progress_bar`, `cache_evaluation`, `raise_on_exception`, and W&B keys) are also accepted — see the [`gepa()` docstring](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/blob/main/src/training_hub/algorithms/gepa.py) for the complete list.
+
+## Returns
+
+**Type:** `Any`
+
+- `GEPAResult` for the `gepa` backend (`result.best_candidate` holds the optimized prompt).
+- `PromptOptimizationResult` for the `mlflow` backend.
+
+When `output_dir` is set, `best_candidate.json` and `result.json` are also written to disk.
+
+## MLflow Backend Example
+
+```python
+import mlflow
+from mlflow.genai.scorers import Correctness
+from training_hub import gepa
+
+prompt = mlflow.genai.register_prompt(name="qa", template="Answer: {{question}}")
+
+result = gepa(
+    seed_candidate={"qa": prompt.template},
+    task_lm="openai/gpt-4o-mini",
+    backend="mlflow",
+    predict_fn=my_predict_fn,
+    prompt_uris=[prompt.uri],
+    scorers=[Correctness(model="openai:/gpt-4o")],
+    data_path="./qa_data.jsonl",
+)
+```
+
+## Related
+
+- [GEPA Algorithm Guide](/algorithms/gepa) — conceptual overview and tips
+- [`GEPAAlgorithm`](/api/classes/GEPAAlgorithm) — class-based API
+- [GEPA Backends](/api/backends/gepa) — `gepa` and `mlflow` backend details

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -116,6 +116,31 @@ result = lora_sft(
 )
 ```
 
+### GEPA (Genetic-Pareto Prompt Optimization)
+
+GEPA is a gradient-free algorithm that optimizes prompt *text* — system prompts, few-shot templates, agent instructions — without modifying model weights, so it requires no local GPU. It uses evolutionary search with Pareto-based selection and LLM-driven reflection, reaching the model through a hosted API or a local vLLM/OpenAI-compatible endpoint.
+
+**Documentation:**
+- [GEPA Usage Guide](/algorithms/gepa) - Conceptual overview, backends, data format, and tips
+- [gepa() Function Reference](/api/functions/gepa) - Full parameter reference
+
+**Tutorials:**
+- [GEPA Prompt Optimization](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/blob/main/examples/notebooks/gepa_prompt_optimization.ipynb) - Interactive notebook demonstrating both backends (direct and MLflow) against a local vLLM server
+
+**Quick Example:**
+```python
+from training_hub import gepa
+
+result = gepa(
+    seed_candidate={"system_prompt": "You are a helpful assistant. Answer the question."},
+    task_lm="openai/gpt-4o-mini",
+    data_path="/path/to/eval_data.jsonl",
+    output_dir="/path/to/gepa_output",
+    max_metric_calls=200,
+)
+print(result.best_candidate)
+```
+
 ### Memory Estimation (Experimental)
 
 training_hub includes a library for estimating the expected amount of GPU memory that will be allocated during fine-tuning.


### PR DESCRIPTION
## Summary

The GEPA prompt-optimization algorithm (#77) was merged, but the README support matrix was never updated to include it, and it had no documentation pages. That matrix update was supposed to ride along with the speculative-decoding PR (#88), which covered the README changes for **both** algorithms. Since #88 isn't being merged for now, this PR lands the GEPA documentation independently — **GEPA only** (no speculative-decoding content).

## Support matrix

- **Reworked the Support Matrix** into a `Backends | GPU Support | Install Extra` format. The old matrix used fixed backend columns (InstructLab-Training, Mini-Trainer, PEFT, Unsloth, verl); GEPA's backends (`gepa`, `mlflow`) don't map onto any of those, so the format change is what lets GEPA be represented cleanly. (Matches the reworked matrix designed in #88, minus the speculative-decoding row.)
- Added a **GEPA row**, a GEPA section under "Implemented Algorithms" with an accurate `gepa()` example, and a GEPA installation section (`[gepa]` extra).

> Note: `README.md` is a symlink to `docs/README.md`, so the single edited file covers both the repo root README and the docs site.

## GEPA documentation pages

Full docs matching the format of the other algorithms:

- **`docs/algorithms/gepa.md`** — algorithm overview (when to use, how it works, backends, data format, custom scoring, local models, output, tips)
- **`docs/api/functions/gepa.md`** — `gepa()` function reference with full parameter tables
- **`docs/api/classes/GEPAAlgorithm.md`** — class-based API reference
- **`docs/api/backends/gepa.md`** — `GEPABackend` and `MLflowGEPABackend` reference

Navigation/index wired up:

- `_sidebar.md` — GEPA entries under Algorithms, Functions, Classes, and Backends
- `api/README.md` — `gepa()`, `GEPAAlgorithm`, and the GEPA backends added to the reference tables
- `examples/README.md` — GEPA section linking the example notebook
- `README.md` — GEPA heading now links to `/algorithms/gepa`

All parameter details were verified against `src/training_hub/algorithms/gepa.py` (the placeholder `gepa()` example from #88 used non-existent params like `model_path`/`population_size`/`generations` — corrected here to the real API: `seed_candidate`, `task_lm`, `reflection_lm`, `max_metric_calls`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)