### PR TITLE
Add JIT preemption checkpointing with pvc/s3 checkpoint storage

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -51,6 +51,7 @@
   * [Experiment Tracking & Logging](/guides/logging)
   * [Validation Loss](/guides/validation-loss)
   * [Distributed Training](/guides/distributed-training)
+  * [JIT Preemption Checkpointing](/guides/jit-checkpointing)
   * [Data Preparation](/guides/data-preparation)
   * [Continual Pretraining](/guides/continual-pretraining)
   * [Runtime Estimates](/guides/runtime-estimates)

--- a/docs/guides/jit-checkpointing.md
+++ b/docs/guides/jit-checkpointing.md
@@ -1,0 +1,175 @@
+# JIT Preemption Checkpointing
+
+This guide covers just-in-time (JIT) checkpointing with Training Hub: saving a checkpoint automatically when a training job is interrupted (SIGTERM), and resuming from it automatically on restart.
+
+## Overview
+
+Training jobs on shared infrastructure can be interrupted at any time: Kueue preemption, spot-instance reclaim, node drain, or manual scale-down. Without protection, every interruption loses all training progress.
+
+With JIT checkpointing enabled, Training Hub:
+
+1. **Catches the termination signal** (SIGTERM) sent before the pod is killed
+2. **Saves a full checkpoint** (model, optimizer, scheduler, RNG state) at the next safe point
+3. **Stops training cleanly** once the checkpoint is written
+4. **Resumes automatically** from the latest valid checkpoint when the job restarts. No manual intervention, no configuration changes
+
+[SFT](/api/functions/sft), [OSFT](/api/functions/osft), and [LoRA](/api/functions/lora_sft) all support JIT checkpointing through the same two parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enable_jit_checkpoint` | `bool` | `False` | Save a checkpoint on SIGTERM and auto-resume on restart |
+| `checkpoint_storage` | `str` | `None` | Where checkpoints live: `None`/`"pvc"` for the filesystem, or an `"s3://bucket/prefix"` URI to mirror checkpoints to S3 |
+
+## Quick Start
+
+Enable JIT checkpointing with a single parameter:
+
+```python
+from training_hub import sft
+
+result = sft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./data.jsonl",
+    ckpt_output_dir="/mnt/checkpoints/run1",
+    num_epochs=3,
+    effective_batch_size=8,
+    learning_rate=2e-5,
+    max_seq_len=2048,
+    max_tokens_per_gpu=45000,
+    enable_jit_checkpoint=True,
+)
+```
+
+The same parameter works for OSFT and LoRA:
+
+```python
+from training_hub import osft
+
+result = osft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./data.jsonl",
+    ckpt_output_dir="/mnt/checkpoints/osft-run",
+    unfreeze_rank_ratio=0.25,
+    effective_batch_size=32,
+    max_tokens_per_gpu=8192,
+    max_seq_len=2048,
+    learning_rate=5e-6,
+    enable_jit_checkpoint=True,
+)
+```
+
+```python
+from training_hub import lora_sft
+
+result = lora_sft(
+    model_path="Qwen/Qwen2.5-7B-Instruct",
+    data_path="./data.jsonl",
+    ckpt_output_dir="/mnt/checkpoints/lora-run",
+    lora_r=16,
+    num_epochs=3,
+    max_seq_len=2048,
+    enable_jit_checkpoint=True,
+)
+```
+
+If the pod is killed mid-training, the logs show the save:
+
+```
+Received signal 15; will checkpoint at the next training step boundary.
+```
+
+When the job restarts with the same `ckpt_output_dir`, training continues from where it left off: the step counter, learning-rate schedule, and epoch all pick up from the checkpoint rather than restarting at zero.
+
+## Checkpoint Storage: PVC or S3
+
+The `checkpoint_storage` parameter selects where checkpoints are kept:
+
+### PVC / filesystem (default)
+
+```python
+sft(..., enable_jit_checkpoint=True)                        # or checkpoint_storage="pvc"
+```
+
+Checkpoints stay on the filesystem at `ckpt_output_dir`. On Kubernetes, mount a persistent volume there so checkpoints survive pod restarts (the Kubeflow SDK handles the mount when you use a `pvc://` output location).
+
+### S3-compatible object storage
+
+```python
+sft(
+    ...,
+    enable_jit_checkpoint=True,
+    checkpoint_storage="s3://my-bucket/experiments/run1",
+)
+```
+
+With an `s3://` URI, in addition to the local save:
+
+- Every saved checkpoint is **mirrored to S3 in the background** (training is not blocked by uploads)
+- On restart, if the local checkpoint directory is empty, the latest complete checkpoint is **downloaded from S3 before training starts**
+
+Use S3 storage when local disk is ephemeral, for example spot nodes with `emptyDir`, where the replacement pod starts with a blank volume.
+
+**Credentials and endpoint** use the standard AWS environment variables:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+# For MinIO or other S3-compatible stores:
+export AWS_ENDPOINT_URL_S3=http://minio.my-namespace.svc:9000
+```
+
+S3 support requires `boto3`:
+
+```bash
+pip install training-hub[s3]
+```
+
+**Upload integrity:** each checkpoint upload finishes by writing an `.upload_complete` marker object. Restore only considers checkpoints that carry the marker, so a partially uploaded checkpoint is never resumed from.
+
+## How It Works
+
+JIT checkpointing is implemented with Training Hub's unified callback system (`TrainingHubCallback`): platform default callbacks are prepended before any user-provided `callbacks=[...]`, so they run first on every lifecycle event. Your own callbacks continue to work unchanged.
+
+Each backend uses the mechanism best suited to it:
+
+| Algorithm | Backend | Mechanism |
+|-----------|---------|-----------|
+| `lora_sft` | Unsloth / HuggingFace | `JITCheckpointCallback` registers the SIGTERM handler and triggers a full HF Trainer checkpoint via `TrainerControl`. Interrupted saves are marked with an `.incomplete` sentinel and skipped on resume. |
+| `sft` | instructlab-training | Delegates to the backend's native `on_demand_checkpointing`: a parent-process signal handler saves full state to `full_state/` and resume is automatic. |
+| `osft` | Mini-Trainer | Delegates to the backend's native `on_demand_checkpointing`: `GracefulShutdownHandler` performs a distributed (DCP) save to `full_state_checkpoints/step_N/` and resume is automatic. |
+
+The saved checkpoint always contains everything needed for exact resumption: model weights, optimizer state, LR scheduler state, and RNG state.
+
+## Requirements
+
+Training Hub raises a clear error, rather than silently training without protection, when the installed backend cannot honor `enable_jit_checkpoint`:
+
+| Algorithm | Requirement |
+|-----------|-------------|
+| `sft` | `instructlab-training >= 0.16.2` |
+| `osft` | `rhai-innovation-mini-trainer >= 0.8.3` |
+| `lora_sft` | no additional requirement |
+| S3 storage | `boto3` (`pip install training-hub[s3]`) |
+
+## Kubernetes Deployment Notes
+
+- **Grace period:** set `terminationGracePeriodSeconds` long enough for the checkpoint to be written after SIGTERM. 120 seconds is a reasonable start for small models; large models need more.
+- **torchrun 30-second limit:** PyTorch's elastic launcher force-kills workers ~30 seconds after SIGTERM regardless of the pod grace period ([pytorch/pytorch#119856](https://github.com/pytorch/pytorch/issues/119856)). This affects the torchrun-based backends (`sft`, `osft`) with large models.
+- **RWO volumes:** don't let a replacement pod mount the checkpoint volume while the dying pod is still saving. The volume handover can revoke the old pod's write access mid-save and corrupt the checkpoint. On plain Kubernetes Jobs, `podReplacementPolicy: Failed` prevents the overlap.
+- **Job restart semantics:** instructlab-training exits with code 0 after a successful preemption save. A plain Kubernetes Job counts that as success and will not restart the pod; restart orchestration is the platform's responsibility (e.g. Kubeflow TrainJob).
+
+## Troubleshooting
+
+**"instructlab-training does not support TrainingArgs.on_demand_checkpointing"**
+The installed instructlab-training predates on-demand checkpointing. Upgrade: `pip install "instructlab-training>=0.16.2"`.
+
+**Training restarts from step 0 instead of resuming**
+Check that the restarted job uses the same `ckpt_output_dir` and that the directory survived the restart (persistent volume, or S3 storage configured). A checkpoint directory containing an `.incomplete` sentinel is intentionally skipped.
+
+**Checkpoints not appearing in S3**
+Verify `boto3` is installed in the training environment and the AWS credential variables are set. Upload failures are logged with full tracebacks in the training logs.
+
+**Pod killed before the checkpoint finished**
+Increase `terminationGracePeriodSeconds`. For `sft`/`osft` also note the 30-second torchrun limit above.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+s3 = [
+    "boto3>=1.26",
+]
 cuda = [
     "instructlab-training[cuda]>=0.16.2",
     "rhai-innovation-mini-trainer[cuda]>=0.8.3",

--- a/src/training_hub/__init__.py
+++ b/src/training_hub/__init__.py
@@ -6,7 +6,8 @@ from .algorithms.lora_grpo import lora_grpo, grpo, LoRAGRPOAlgorithm, ARTLoRAGRP
 from .algorithms.lora_grpo_verl import VeRLLoRAGRPOBackend
 from .algorithms.gepa import gepa, GEPAAlgorithm, GEPABackend, MLflowGEPABackend
 from .algorithms.rewards import tool_call_reward, binary_reward
-from .callbacks import TrainingHubCallback, TrainingHubContext
+from .callbacks import TrainingHubCallback, TrainingHubContext, TrainingHubControl, merge_default_callbacks
+from .jit_checkpoint import JITCheckpointCallback
 from .hub_core import welcome
 from .profiling.memory_estimator import BasicEstimator, OSFTEstimatorExperimental, estimate, OSFTEstimator, LoRAEstimator, QLoRAEstimator
 from .algorithms.its_rollout import ITSRollout
@@ -46,6 +47,9 @@ __all__ = [
     'estimate',
     'TrainingHubCallback',
     'TrainingHubContext',
+    'TrainingHubControl',
+    'merge_default_callbacks',
+    'JITCheckpointCallback',
     'ITSRollout',
     'plot_loss',
 ]

--- a/src/training_hub/adapters/unsloth.py
+++ b/src/training_hub/adapters/unsloth.py
@@ -16,7 +16,11 @@ from typing import TYPE_CHECKING
 
 from transformers import TrainerCallback
 
-from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+from training_hub.callbacks import (
+    TrainingHubCallback,
+    TrainingHubContext,
+    TrainingHubControl,
+)
 
 if TYPE_CHECKING:
     from transformers import TrainerControl, TrainerState, TrainingArguments
@@ -40,9 +44,14 @@ class UnslothCallbackAdapter(TrainerCallback):
 
     Args:
         hub_callback: A TrainingHubCallback instance to adapt.
+        hub_control: Shared mutable control bag for default-flow callbacks.
     """
 
-    def __init__(self, hub_callback: TrainingHubCallback) -> None:
+    def __init__(
+        self,
+        hub_callback: TrainingHubCallback,
+        hub_control: TrainingHubControl | None = None,
+    ) -> None:
         if not isinstance(hub_callback, TrainingHubCallback):
             raise TypeError(
                 "Expected TrainingHubCallback instance, "
@@ -50,12 +59,14 @@ class UnslothCallbackAdapter(TrainerCallback):
             )
         super().__init__()
         self._hub_callback = hub_callback
+        self._hub_control = hub_control
 
     @staticmethod
     def _build_context(
         args: TrainingArguments,
         state: TrainerState,
         logs: dict | None = None,
+        hub_control: TrainingHubControl | None = None,
     ) -> TrainingHubContext:
         """Build normalized context from HuggingFace trainer state."""
         metrics = dict(logs) if logs is not None else {}
@@ -64,7 +75,6 @@ class UnslothCallbackAdapter(TrainerCallback):
         if loss is None:
             loss = metrics.get("eval_loss")
         if loss is None and state.log_history:
-            # Prefer most recent training loss; otherwise last eval_loss
             eval_loss_fallback = None
             for entry in reversed(state.log_history):
                 if "loss" in entry:
@@ -90,6 +100,7 @@ class UnslothCallbackAdapter(TrainerCallback):
             is_main_process=state.is_world_process_zero,
             output_dir=args.output_dir,
             metrics=metrics,
+            control=hub_control,
         )
 
     def _safe_call(
@@ -106,7 +117,7 @@ class UnslothCallbackAdapter(TrainerCallback):
         ):
             return
         try:
-            ctx = self._build_context(args, state, logs)
+            ctx = self._build_context(args, state, logs, self._hub_control)
             getattr(self._hub_callback, method_name)(ctx)
         except Exception:
             logger.exception(
@@ -114,6 +125,14 @@ class UnslothCallbackAdapter(TrainerCallback):
                 type(self._hub_callback).__name__,
                 method_name,
             )
+
+    def _apply_hub_control(self, control) -> None:
+        if self._hub_control is None:
+            return
+        if self._hub_control.should_save:
+            control.should_save = True
+        if self._hub_control.should_training_stop:
+            control.should_training_stop = True
 
     # --- HuggingFace TrainerCallback hooks → TrainingHubCallback hooks ---
 
@@ -124,23 +143,34 @@ class UnslothCallbackAdapter(TrainerCallback):
         self._safe_call("on_epoch_begin", args, state)
 
     def on_step_begin(self, args, state, control, **kwargs):
+        if self._hub_control is not None:
+            self._hub_control.should_save = False
         self._safe_call("on_step_begin", args, state)
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         self._safe_call("on_log", args, state, logs=logs)
 
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):
-        # HF Trainer passes evaluation metrics via the `metrics` kwarg
         self._safe_call("on_evaluate", args, state, logs=metrics)
 
     def on_save(self, args, state, control, **kwargs):
-        self._safe_call("on_save", args, state)
+        checkpoint_dir = None
+        if state.global_step:
+            checkpoint_dir = f"{args.output_dir}/checkpoint-{state.global_step}"
+        logs = {}
+        if checkpoint_dir:
+            logs["checkpoint_path"] = checkpoint_dir
+        self._safe_call("on_save", args, state, logs=logs or None)
 
     def on_step_end(self, args, state, control, **kwargs):
         self._safe_call("on_step_end", args, state)
+        self._apply_hub_control(control)
+        return control
 
     def on_epoch_end(self, args, state, control, **kwargs):
         self._safe_call("on_epoch_end", args, state)
+        self._apply_hub_control(control)
+        return control
 
     def on_train_end(self, args, state, control, **kwargs):
         self._safe_call("on_train_end", args, state)
@@ -148,14 +178,17 @@ class UnslothCallbackAdapter(TrainerCallback):
 
 def adapt_hub_callbacks(
     callbacks: list[TrainingHubCallback],
+    hub_control: TrainingHubControl | None = None,
 ) -> list[TrainerCallback]:
     """Convert a list of TrainingHubCallbacks to HuggingFace TrainerCallbacks.
 
     Args:
         callbacks: List of TrainingHubCallback instances.
+        hub_control: Optional shared control bag for default-flow callbacks.
 
     Returns:
         List of UnslothCallbackAdapter instances ready for
         trainer.add_callback().
     """
-    return [UnslothCallbackAdapter(cb) for cb in callbacks]
+    control = hub_control or TrainingHubControl()
+    return [UnslothCallbackAdapter(cb, hub_control=control) for cb in callbacks]

--- a/src/training_hub/algorithms/lora.py
+++ b/src/training_hub/algorithms/lora.py
@@ -233,11 +233,15 @@ class UnslothLoRABackend(Backend):
             jit_checkpoint_enabled,
         )
 
+        # Restore mirrored checkpoints whenever S3 storage is configured
+        # (env-gated no-op otherwise), independent of the JIT flag
+        if training_params.get("ckpt_output_dir"):
+            maybe_restore_from_s3(training_params["ckpt_output_dir"])
+
         if jit_checkpoint_enabled(
             training_params.get("enable_jit_checkpoint"),
             training_params.get("ckpt_output_dir"),
         ):
-            maybe_restore_from_s3(training_params["ckpt_output_dir"])
             resume_path = find_latest_valid_checkpoint(
                 training_params["ckpt_output_dir"]
             )

--- a/src/training_hub/algorithms/lora.py
+++ b/src/training_hub/algorithms/lora.py
@@ -8,7 +8,8 @@ from . import Algorithm, Backend, AlgorithmRegistry
 from .sft import SFTAlgorithm
 from .peft_extender import LoRAPEFTExtender, get_lora_parameters, apply_lora_defaults
 from training_hub import utils
-from training_hub.callbacks import TrainingHubCallback
+from training_hub.callbacks import TrainingHubCallback, merge_default_callbacks
+from training_hub.checkpoint_utils import apply_native_jit_params
 
 # TrainerCallback import - transformers is required for LoRA functionality
 from transformers import TrainerCallback
@@ -216,41 +217,61 @@ class UnslothLoRABackend(Backend):
         trainer.add_callback(jsonl_callback)
 
         # Add user-provided TrainingHub callbacks (adapted to HuggingFace)
-        if training_params.get('callbacks'):
+        hub_callbacks = training_params.get('callbacks') or []
+        if hub_callbacks:
             from training_hub.adapters.unsloth import adapt_hub_callbacks
-            for hf_cb in adapt_hub_callbacks(training_params['callbacks']):
+            from training_hub.callbacks import TrainingHubControl
+
+            hub_control = TrainingHubControl()
+            for hf_cb in adapt_hub_callbacks(hub_callbacks, hub_control=hub_control):
                 trainer.add_callback(hf_cb)
+
+        resume_path = None
+        from training_hub.checkpoint_utils import (
+            find_latest_valid_checkpoint,
+            jit_checkpoint_enabled,
+        )
+
+        if jit_checkpoint_enabled(
+            training_params.get("enable_jit_checkpoint"),
+            training_params.get("ckpt_output_dir"),
+        ):
+            resume_path = find_latest_valid_checkpoint(
+                training_params["ckpt_output_dir"]
+            )
 
         # Execute training with error handling for known Unsloth issues
         try:
-            trainer.train()
-        except AssertionError as e:
-            if "wrong number of dimensions" in str(e) and "int8_mixed_scaled_mm" in str(e):
-                # Known Unsloth 8-bit quantization issue: https://github.com/unslothai/unsloth/issues/3501
-                raise RuntimeError(
-                    f"❌ Unsloth 8-bit quantization compatibility issue detected.\n"
-                    f"This is a known issue with Unsloth + 8-bit quantization + some model architectures.\n"
-                    f"See: https://github.com/unslothai/unsloth/issues/3501\n\n"
-                    f"💡 Recommended solutions:\n"
-                    f"• Try 4-bit quantization instead: load_in_4bit=True, load_in_8bit=False\n"
-                    f"• Use standard training without quantization: load_in_4bit=False, load_in_8bit=False\n"
-                    f"• Update Unsloth to the latest version in case this issue is fixed\n\n"
-                    f"Original error: {e}"
-                ) from e
-            else:
-                # Re-raise other AssertionErrors
+            try:
+                trainer.train(resume_from_checkpoint=resume_path)
+            except AssertionError as e:
+                if "wrong number of dimensions" in str(e) and "int8_mixed_scaled_mm" in str(e):
+                    raise RuntimeError(
+                        f"❌ Unsloth 8-bit quantization compatibility issue detected.\n"
+                        f"This is a known issue with Unsloth + 8-bit quantization + some model architectures.\n"
+                        f"See: https://github.com/unslothai/unsloth/issues/3501\n\n"
+                        f"💡 Recommended solutions:\n"
+                        f"• Try 4-bit quantization instead: load_in_4bit=True, load_in_8bit=False\n"
+                        f"• Use standard training without quantization: load_in_4bit=False, load_in_8bit=False\n"
+                        f"• Update Unsloth to the latest version in case this issue is fixed\n\n"
+                        f"Original error: {e}"
+                    ) from e
                 raise
 
-        # Save model
-        if training_params.get('save_model', True):
-            trainer.save_model(training_params['ckpt_output_dir'])
-            tokenizer_or_processor.save_pretrained(training_params['ckpt_output_dir'])
+            # Save model
+            if training_params.get('save_model', True):
+                trainer.save_model(training_params['ckpt_output_dir'])
+                tokenizer_or_processor.save_pretrained(training_params['ckpt_output_dir'])
 
-        return {
-            'model': model,
-            'tokenizer': tokenizer_or_processor,
-            'trainer': trainer
-        }
+            return {
+                'model': model,
+                'tokenizer': tokenizer_or_processor,
+                'trainer': trainer
+            }
+        finally:
+            from training_hub.checkpoint_manager import shutdown_upload_worker
+
+            shutdown_upload_worker()
 
     @staticmethod
     def _is_vlm_model_id(model_path: str, trust_remote_code: bool = False) -> bool:
@@ -760,6 +781,7 @@ class LoRASFTAlgorithm(Algorithm):
               callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
               eval_data_path: Optional[str] = None,
               per_device_eval_batch_size: Optional[int] = None,
+              enable_jit_checkpoint: Optional[bool] = None,
               **kwargs) -> Any:
         """Execute LoRA + SFT training combining supervised fine-tuning with LoRA parameter-efficient training.
 
@@ -856,6 +878,8 @@ class LoRASFTAlgorithm(Algorithm):
 
             Callbacks / Evaluation:
             callbacks: TrainingHubCallback or list of them for lifecycle hooks
+            enable_jit_checkpoint: When True, enable SIGTERM JIT checkpointing
+                (requires ckpt_output_dir). Off by default.
             eval_data_path: Optional JSON/JSONL (or HF dataset) path for evaluation.
                             When set, enables eval_strategy=steps and fires on_evaluate.
             per_device_eval_batch_size: Per-device eval batch size (defaults to
@@ -869,6 +893,13 @@ class LoRASFTAlgorithm(Algorithm):
         """
         if isinstance(callbacks, TrainingHubCallback):
             callbacks = [callbacks]
+
+        callbacks = merge_default_callbacks(
+            callbacks,
+            enable_jit_checkpoint=bool(enable_jit_checkpoint),
+            ckpt_output_dir=ckpt_output_dir,
+            backend="lora_sft",
+        )
 
         # Build base parameters dict (required parameters)
         params = {
@@ -957,6 +988,7 @@ class LoRASFTAlgorithm(Algorithm):
             'callbacks': callbacks,
             'eval_data_path': eval_data_path,
             'per_device_eval_batch_size': per_device_eval_batch_size,
+            'enable_jit_checkpoint': enable_jit_checkpoint,
         }
 
         # Only add non-None parameters
@@ -1053,6 +1085,7 @@ class LoRASFTAlgorithm(Algorithm):
             'callbacks': list,
             'eval_data_path': str,
             'per_device_eval_batch_size': int,
+            'enable_jit_checkpoint': bool,
         }
 
         # Combine all parameter types
@@ -1138,6 +1171,7 @@ def lora_sft(model_path: str,
          callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
          eval_data_path: Optional[str] = None,
          per_device_eval_batch_size: Optional[int] = None,
+         enable_jit_checkpoint: Optional[bool] = None,
          **kwargs) -> Any:
     """Convenience function to run LoRA + SFT training.
 
@@ -1303,5 +1337,6 @@ def lora_sft(model_path: str,
         callbacks=callbacks,
         eval_data_path=eval_data_path,
         per_device_eval_batch_size=per_device_eval_batch_size,
+        enable_jit_checkpoint=enable_jit_checkpoint,
         **kwargs
     )

--- a/src/training_hub/algorithms/lora.py
+++ b/src/training_hub/algorithms/lora.py
@@ -227,6 +227,7 @@ class UnslothLoRABackend(Backend):
                 trainer.add_callback(hf_cb)
 
         resume_path = None
+        from training_hub.checkpoint_manager import maybe_restore_from_s3
         from training_hub.checkpoint_utils import (
             find_latest_valid_checkpoint,
             jit_checkpoint_enabled,
@@ -236,6 +237,7 @@ class UnslothLoRABackend(Backend):
             training_params.get("enable_jit_checkpoint"),
             training_params.get("ckpt_output_dir"),
         ):
+            maybe_restore_from_s3(training_params["ckpt_output_dir"])
             resume_path = find_latest_valid_checkpoint(
                 training_params["ckpt_output_dir"]
             )
@@ -782,6 +784,7 @@ class LoRASFTAlgorithm(Algorithm):
               eval_data_path: Optional[str] = None,
               per_device_eval_batch_size: Optional[int] = None,
               enable_jit_checkpoint: Optional[bool] = None,
+              checkpoint_storage: Optional[str] = None,
               **kwargs) -> Any:
         """Execute LoRA + SFT training combining supervised fine-tuning with LoRA parameter-efficient training.
 
@@ -894,11 +897,15 @@ class LoRASFTAlgorithm(Algorithm):
         if isinstance(callbacks, TrainingHubCallback):
             callbacks = [callbacks]
 
+        from training_hub.checkpoint_utils import apply_checkpoint_storage_env
+
+        apply_checkpoint_storage_env(checkpoint_storage)
         callbacks = merge_default_callbacks(
             callbacks,
             enable_jit_checkpoint=bool(enable_jit_checkpoint),
             ckpt_output_dir=ckpt_output_dir,
             backend="lora_sft",
+            checkpoint_storage=checkpoint_storage,
         )
 
         # Build base parameters dict (required parameters)
@@ -989,6 +996,7 @@ class LoRASFTAlgorithm(Algorithm):
             'eval_data_path': eval_data_path,
             'per_device_eval_batch_size': per_device_eval_batch_size,
             'enable_jit_checkpoint': enable_jit_checkpoint,
+            'checkpoint_storage': checkpoint_storage,
         }
 
         # Only add non-None parameters
@@ -1086,6 +1094,7 @@ class LoRASFTAlgorithm(Algorithm):
             'eval_data_path': str,
             'per_device_eval_batch_size': int,
             'enable_jit_checkpoint': bool,
+            'checkpoint_storage': str,
         }
 
         # Combine all parameter types
@@ -1172,6 +1181,7 @@ def lora_sft(model_path: str,
          eval_data_path: Optional[str] = None,
          per_device_eval_batch_size: Optional[int] = None,
          enable_jit_checkpoint: Optional[bool] = None,
+         checkpoint_storage: Optional[str] = None,
          **kwargs) -> Any:
     """Convenience function to run LoRA + SFT training.
 
@@ -1338,5 +1348,6 @@ def lora_sft(model_path: str,
         eval_data_path=eval_data_path,
         per_device_eval_batch_size=per_device_eval_batch_size,
         enable_jit_checkpoint=enable_jit_checkpoint,
+        checkpoint_storage=checkpoint_storage,
         **kwargs
     )

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -479,6 +479,18 @@ class MiniTrainerOSFTBackend(Backend):
                 "Upgrade rhai-innovation-mini-trainer to >=0.8.3."
             )
 
+        # Fail loudly if JIT was requested but mini-trainer would silently drop it
+        if (
+            algorithm_params.get('on_demand_checkpointing')
+            and 'on_demand_checkpointing' not in training_args_fields
+        ):
+            raise RuntimeError(
+                "enable_jit_checkpoint=True but the installed mini-trainer does "
+                "not support TrainingArgs.on_demand_checkpointing. "
+                "Upgrade rhai-innovation-mini-trainer to a version with "
+                "on-demand checkpointing support."
+            )
+
         # process this up here so we can exit early
         torchrun_args_pre = {k: v for k, v in algorithm_params.items() if k in torchrun_args_fields and v is not None}
         torchrun_args_pre = get_torchrun_params(torchrun_args_pre)

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -5,7 +5,8 @@ import warnings
 
 import datasets
 from training_hub.algorithms import Algorithm, Backend, AlgorithmRegistry
-from training_hub.callbacks import TrainingHubCallback
+from training_hub.callbacks import TrainingHubCallback, merge_default_callbacks
+from training_hub.checkpoint_utils import apply_native_jit_params
 from training_hub.utils import format_type_name, get_torchrun_params
 
 
@@ -82,6 +83,7 @@ class OSFTAlgorithm(Algorithm):
         # Callback parameters (keyword-only)
         *,
         callbacks: list[TrainingHubCallback] | TrainingHubCallback | None = None,
+        enable_jit_checkpoint: bool | None = None,
         **kwargs,
     ) -> any:
         """
@@ -205,6 +207,13 @@ class OSFTAlgorithm(Algorithm):
         if isinstance(callbacks, TrainingHubCallback):
             callbacks = [callbacks]
 
+        callbacks = merge_default_callbacks(
+            callbacks,
+            enable_jit_checkpoint=bool(enable_jit_checkpoint),
+            ckpt_output_dir=ckpt_output_dir,
+            backend="osft",
+        )
+
         optional_params = {
             'target_patterns': target_patterns,
             # for data processing
@@ -249,6 +258,7 @@ class OSFTAlgorithm(Algorithm):
             # model loading
             'trust_remote_code': trust_remote_code,
             'callbacks': callbacks,
+            'enable_jit_checkpoint': enable_jit_checkpoint,
         }
 
         # now do validation now that we've set everything up
@@ -264,6 +274,12 @@ class OSFTAlgorithm(Algorithm):
         all_params = dict(**required_params)
         all_params.update(optional_params)
         all_params.update(kwargs)
+
+        apply_native_jit_params(
+            all_params,
+            enable_jit_checkpoint=enable_jit_checkpoint,
+            backend="osft",
+        )
 
         return self.backend.execute_training(all_params)
 
@@ -319,6 +335,8 @@ class OSFTAlgorithm(Algorithm):
             'mlflow_experiment_name': str,
             'mlflow_run_name': str,
             'callbacks': list,
+            'enable_jit_checkpoint': bool,
+            'on_demand_checkpointing': bool,
         }
 
     def _validate_param_types(self, params: dict[str, any]):
@@ -644,6 +662,7 @@ def osft(
     # Callback parameters (keyword-only)
     *,
     callbacks: list[TrainingHubCallback] | TrainingHubCallback | None = None,
+    enable_jit_checkpoint: bool | None = None,
     **kwargs,
 ) -> any:
     """Convenience function to run Orthogonal Subspace Fine-Tuning (OSFT) training.
@@ -787,5 +806,6 @@ def osft(
         mlflow_run_name=mlflow_run_name,
         trust_remote_code=trust_remote_code,
         callbacks=callbacks,
+        enable_jit_checkpoint=enable_jit_checkpoint,
         **kwargs,
     )

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -284,7 +284,6 @@ class OSFTAlgorithm(Algorithm):
         apply_native_jit_params(
             all_params,
             enable_jit_checkpoint=enable_jit_checkpoint,
-        checkpoint_storage=checkpoint_storage,
             backend="osft",
         )
 

--- a/src/training_hub/algorithms/osft.py
+++ b/src/training_hub/algorithms/osft.py
@@ -84,6 +84,7 @@ class OSFTAlgorithm(Algorithm):
         *,
         callbacks: list[TrainingHubCallback] | TrainingHubCallback | None = None,
         enable_jit_checkpoint: bool | None = None,
+        checkpoint_storage: str | None = None,
         **kwargs,
     ) -> any:
         """
@@ -207,11 +208,15 @@ class OSFTAlgorithm(Algorithm):
         if isinstance(callbacks, TrainingHubCallback):
             callbacks = [callbacks]
 
+        from training_hub.checkpoint_utils import apply_checkpoint_storage_env
+
+        apply_checkpoint_storage_env(checkpoint_storage)
         callbacks = merge_default_callbacks(
             callbacks,
             enable_jit_checkpoint=bool(enable_jit_checkpoint),
             ckpt_output_dir=ckpt_output_dir,
             backend="osft",
+            checkpoint_storage=checkpoint_storage,
         )
 
         optional_params = {
@@ -259,6 +264,7 @@ class OSFTAlgorithm(Algorithm):
             'trust_remote_code': trust_remote_code,
             'callbacks': callbacks,
             'enable_jit_checkpoint': enable_jit_checkpoint,
+            'checkpoint_storage': checkpoint_storage,
         }
 
         # now do validation now that we've set everything up
@@ -278,6 +284,7 @@ class OSFTAlgorithm(Algorithm):
         apply_native_jit_params(
             all_params,
             enable_jit_checkpoint=enable_jit_checkpoint,
+        checkpoint_storage=checkpoint_storage,
             backend="osft",
         )
 
@@ -336,6 +343,7 @@ class OSFTAlgorithm(Algorithm):
             'mlflow_run_name': str,
             'callbacks': list,
             'enable_jit_checkpoint': bool,
+            'checkpoint_storage': str,
             'on_demand_checkpointing': bool,
         }
 
@@ -490,6 +498,12 @@ class MiniTrainerOSFTBackend(Backend):
                 "Upgrade rhai-innovation-mini-trainer to a version with "
                 "on-demand checkpointing support."
             )
+
+        # Restore latest checkpoint from S3 when checkpoint_storage=s3://
+        # and the local dir is empty (fresh pod after preemption)
+        from training_hub.checkpoint_manager import maybe_restore_from_s3
+
+        maybe_restore_from_s3(algorithm_params['output_dir'])
 
         # process this up here so we can exit early
         torchrun_args_pre = {k: v for k, v in algorithm_params.items() if k in torchrun_args_fields and v is not None}
@@ -675,6 +689,7 @@ def osft(
     *,
     callbacks: list[TrainingHubCallback] | TrainingHubCallback | None = None,
     enable_jit_checkpoint: bool | None = None,
+    checkpoint_storage: str | None = None,
     **kwargs,
 ) -> any:
     """Convenience function to run Orthogonal Subspace Fine-Tuning (OSFT) training.
@@ -819,5 +834,6 @@ def osft(
         trust_remote_code=trust_remote_code,
         callbacks=callbacks,
         enable_jit_checkpoint=enable_jit_checkpoint,
+        checkpoint_storage=checkpoint_storage,
         **kwargs,
     )

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -283,8 +283,7 @@ class SFTAlgorithm(Algorithm):
             if value is not None:
                 params[key] = value
                 
-        apply_native_jit_params(params, enable_jit_checkpoint=enable_jit_checkpoint,
-        checkpoint_storage=checkpoint_storage, backend="sft")
+        apply_native_jit_params(params, enable_jit_checkpoint=enable_jit_checkpoint, backend="sft")
         params.update(kwargs)
         
         return self.backend.execute_training(params)

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -9,7 +9,8 @@ from instructlab.training import (
 
 from . import Algorithm, Backend, AlgorithmRegistry
 from training_hub import utils
-from training_hub.callbacks import TrainingHubCallback
+from training_hub.callbacks import TrainingHubCallback, merge_default_callbacks
+from training_hub.checkpoint_utils import apply_native_jit_params
 
 
 class InstructLabTrainingSFTBackend(Backend):
@@ -87,6 +88,8 @@ class InstructLabTrainingSFTBackend(Backend):
                 **pretraining_kwargs,
             )
 
+        training_params.pop("enable_jit_checkpoint", None)
+
         # Create TrainingArgs with all provided parameters, letting it handle defaults
         training_args = TrainingArgs(**training_params)
         
@@ -150,6 +153,7 @@ class SFTAlgorithm(Algorithm):
               # Callback parameters (keyword-only)
               *,
               callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
+              enable_jit_checkpoint: Optional[bool] = None,
               **kwargs) -> Any:
         """Execute SFT training.
         
@@ -189,6 +193,8 @@ class SFTAlgorithm(Algorithm):
             mlflow_experiment_name: MLflow experiment name
             mlflow_run_name: MLflow run name
             callbacks: TrainingHubCallback or list of them for lifecycle hooks
+            enable_jit_checkpoint: When True, enable native on-demand checkpointing
+                for SIGTERM preemption (requires ckpt_output_dir). Off by default.
             **kwargs: Additional parameters passed to the backend
             
         Returns:
@@ -196,6 +202,13 @@ class SFTAlgorithm(Algorithm):
         """
         if isinstance(callbacks, TrainingHubCallback):
             callbacks = [callbacks]
+
+        callbacks = merge_default_callbacks(
+            callbacks,
+            enable_jit_checkpoint=bool(enable_jit_checkpoint),
+            ckpt_output_dir=ckpt_output_dir,
+            backend="sft",
+        )
 
         # Build parameters dict, only including non-None values
         params = {'model_path': model_path, 'data_path': data_path, 'ckpt_output_dir': ckpt_output_dir}
@@ -237,6 +250,7 @@ class SFTAlgorithm(Algorithm):
             'mlflow_experiment_name': mlflow_experiment_name,
             'mlflow_run_name': mlflow_run_name,
             'callbacks': callbacks,
+            'enable_jit_checkpoint': enable_jit_checkpoint,
         }
         
         # Only add non-None parameters (let TrainingArgs handle defaults)
@@ -244,6 +258,7 @@ class SFTAlgorithm(Algorithm):
             if value is not None:
                 params[key] = value
                 
+        apply_native_jit_params(params, enable_jit_checkpoint=enable_jit_checkpoint, backend="sft")
         params.update(kwargs)
         
         return self.backend.execute_training(params)
@@ -295,6 +310,8 @@ class SFTAlgorithm(Algorithm):
             'mlflow_experiment_name': str,
             'mlflow_run_name': str,
             'callbacks': list,
+            'enable_jit_checkpoint': bool,
+            'on_demand_checkpointing': bool,
         }
 
 
@@ -345,6 +362,7 @@ def sft(model_path: str,
         # Callback parameters (keyword-only)
         *,
         callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
+        enable_jit_checkpoint: Optional[bool] = None,
         **kwargs) -> Any:
     """Convenience function to run SFT training.
     
@@ -429,6 +447,7 @@ def sft(model_path: str,
         mlflow_experiment_name=mlflow_experiment_name,
         mlflow_run_name=mlflow_run_name,
         callbacks=callbacks,
+        enable_jit_checkpoint=enable_jit_checkpoint,
         **kwargs
     )
 

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -89,6 +89,13 @@ class InstructLabTrainingSFTBackend(Backend):
             )
 
         training_params.pop("enable_jit_checkpoint", None)
+        training_params.pop("checkpoint_storage", None)
+
+        # Restore latest checkpoint from S3 when checkpoint_storage=s3://
+        # and the local dir is empty (fresh pod after preemption)
+        from training_hub.checkpoint_manager import maybe_restore_from_s3
+
+        maybe_restore_from_s3(training_params['ckpt_output_dir'])
 
         # Older instructlab-training silently drops unknown TrainingArgs fields,
         # which would turn JIT checkpointing into a no-op — fail loudly instead.
@@ -166,6 +173,7 @@ class SFTAlgorithm(Algorithm):
               *,
               callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
               enable_jit_checkpoint: Optional[bool] = None,
+              checkpoint_storage: Optional[str] = None,
               **kwargs) -> Any:
         """Execute SFT training.
         
@@ -215,11 +223,15 @@ class SFTAlgorithm(Algorithm):
         if isinstance(callbacks, TrainingHubCallback):
             callbacks = [callbacks]
 
+        from training_hub.checkpoint_utils import apply_checkpoint_storage_env
+
+        apply_checkpoint_storage_env(checkpoint_storage)
         callbacks = merge_default_callbacks(
             callbacks,
             enable_jit_checkpoint=bool(enable_jit_checkpoint),
             ckpt_output_dir=ckpt_output_dir,
             backend="sft",
+            checkpoint_storage=checkpoint_storage,
         )
 
         # Build parameters dict, only including non-None values
@@ -263,6 +275,7 @@ class SFTAlgorithm(Algorithm):
             'mlflow_run_name': mlflow_run_name,
             'callbacks': callbacks,
             'enable_jit_checkpoint': enable_jit_checkpoint,
+            'checkpoint_storage': checkpoint_storage,
         }
         
         # Only add non-None parameters (let TrainingArgs handle defaults)
@@ -270,7 +283,8 @@ class SFTAlgorithm(Algorithm):
             if value is not None:
                 params[key] = value
                 
-        apply_native_jit_params(params, enable_jit_checkpoint=enable_jit_checkpoint, backend="sft")
+        apply_native_jit_params(params, enable_jit_checkpoint=enable_jit_checkpoint,
+        checkpoint_storage=checkpoint_storage, backend="sft")
         params.update(kwargs)
         
         return self.backend.execute_training(params)
@@ -323,6 +337,7 @@ class SFTAlgorithm(Algorithm):
             'mlflow_run_name': str,
             'callbacks': list,
             'enable_jit_checkpoint': bool,
+            'checkpoint_storage': str,
             'on_demand_checkpointing': bool,
         }
 
@@ -375,6 +390,7 @@ def sft(model_path: str,
         *,
         callbacks: Optional[list[TrainingHubCallback] | TrainingHubCallback] = None,
         enable_jit_checkpoint: Optional[bool] = None,
+        checkpoint_storage: Optional[str] = None,
         **kwargs) -> Any:
     """Convenience function to run SFT training.
     
@@ -460,6 +476,7 @@ def sft(model_path: str,
         mlflow_run_name=mlflow_run_name,
         callbacks=callbacks,
         enable_jit_checkpoint=enable_jit_checkpoint,
+        checkpoint_storage=checkpoint_storage,
         **kwargs
     )
 

--- a/src/training_hub/algorithms/sft.py
+++ b/src/training_hub/algorithms/sft.py
@@ -90,6 +90,18 @@ class InstructLabTrainingSFTBackend(Backend):
 
         training_params.pop("enable_jit_checkpoint", None)
 
+        # Older instructlab-training silently drops unknown TrainingArgs fields,
+        # which would turn JIT checkpointing into a no-op — fail loudly instead.
+        if training_params.get('on_demand_checkpointing'):
+            model_fields = getattr(TrainingArgs, 'model_fields', None)
+            if model_fields is None or 'on_demand_checkpointing' not in model_fields:
+                raise RuntimeError(
+                    "enable_jit_checkpoint=True but the installed "
+                    "instructlab-training does not support "
+                    "TrainingArgs.on_demand_checkpointing. "
+                    "Upgrade instructlab-training to >=0.16.2."
+                )
+
         # Create TrainingArgs with all provided parameters, letting it handle defaults
         training_args = TrainingArgs(**training_params)
         

--- a/src/training_hub/callbacks.py
+++ b/src/training_hub/callbacks.py
@@ -41,6 +41,17 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+# Backends with native on_demand_checkpointing (no hub JIT callback injection).
+_NATIVE_JIT_BACKENDS = frozenset({"sft", "osft"})
+
+
+@dataclass
+class TrainingHubControl:
+    """Mutable control flags for hub default callbacks (HF TrainerControl-like)."""
+
+    should_save: bool = False
+    should_training_stop: bool = False
+
 
 @dataclass
 class TrainingHubContext:
@@ -58,6 +69,7 @@ class TrainingHubContext:
         is_main_process: Whether this is rank 0 in distributed training.
         output_dir: Checkpoint output directory.
         metrics: Backend-specific metrics dict, flattened.
+        control: Mutable control bag for default-flow callbacks (optional).
     """
 
     step: int = 0
@@ -67,6 +79,7 @@ class TrainingHubContext:
     is_main_process: bool = True
     output_dir: str = ""
     metrics: dict[str, Any] = field(default_factory=dict)
+    control: TrainingHubControl | None = None
 
 
 class TrainingHubCallback:
@@ -113,3 +126,27 @@ class TrainingHubCallback:
 
     def on_train_end(self, context: TrainingHubContext) -> None:
         """Called after training completes."""
+
+
+def merge_default_callbacks(
+    user_callbacks: list[TrainingHubCallback] | TrainingHubCallback | None,
+    *,
+    enable_jit_checkpoint: bool = False,
+    ckpt_output_dir: str | None = None,
+    backend: str | None = None,
+) -> list[TrainingHubCallback]:
+    """Prepend platform default callbacks before user callbacks.
+
+    Hub defaults run first on each lifecycle event. JIT checkpointing is
+    injected only when ``enable_jit_checkpoint=True`` and ``ckpt_output_dir``
+    is set. SFT/OSFT use native ``on_demand_checkpointing`` instead.
+    """
+    from training_hub.adapters.serialize import normalize_hub_callbacks
+    from training_hub.jit_checkpoint import JITCheckpointCallback
+
+    user_cbs = normalize_hub_callbacks(user_callbacks)
+    if not enable_jit_checkpoint or not ckpt_output_dir:
+        return user_cbs
+    if backend in _NATIVE_JIT_BACKENDS:
+        return user_cbs
+    return [JITCheckpointCallback(), *user_cbs]

--- a/src/training_hub/callbacks.py
+++ b/src/training_hub/callbacks.py
@@ -134,19 +134,31 @@ def merge_default_callbacks(
     enable_jit_checkpoint: bool = False,
     ckpt_output_dir: str | None = None,
     backend: str | None = None,
+    checkpoint_storage: str | None = None,
 ) -> list[TrainingHubCallback]:
     """Prepend platform default callbacks before user callbacks.
 
     Hub defaults run first on each lifecycle event. JIT checkpointing is
     injected only when ``enable_jit_checkpoint=True`` and ``ckpt_output_dir``
-    is set. SFT/OSFT use native ``on_demand_checkpointing`` instead.
+    is set; SFT/OSFT use native ``on_demand_checkpointing`` instead. An
+    S3 sync callback is prepended for every backend when
+    ``checkpoint_storage`` is an s3:// URI.
     """
     from training_hub.adapters.serialize import normalize_hub_callbacks
-    from training_hub.jit_checkpoint import JITCheckpointCallback
+    from training_hub.checkpoint_utils import resolve_checkpoint_storage
+    from training_hub.jit_checkpoint import (
+        JITCheckpointCallback,
+        S3CheckpointSyncCallback,
+    )
 
     user_cbs = normalize_hub_callbacks(user_callbacks)
-    if not enable_jit_checkpoint or not ckpt_output_dir:
-        return user_cbs
-    if backend in _NATIVE_JIT_BACKENDS:
-        return user_cbs
-    return [JITCheckpointCallback(), *user_cbs]
+    defaults: list[TrainingHubCallback] = []
+    if (
+        enable_jit_checkpoint
+        and ckpt_output_dir
+        and backend not in _NATIVE_JIT_BACKENDS
+    ):
+        defaults.append(JITCheckpointCallback())
+    if resolve_checkpoint_storage(checkpoint_storage):
+        defaults.append(S3CheckpointSyncCallback())
+    return [*defaults, *user_cbs]

--- a/src/training_hub/checkpoint_manager.py
+++ b/src/training_hub/checkpoint_manager.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-_UPLOAD_QUEUE: queue.LifoQueue[str | None] | None = None
+_UPLOAD_QUEUE: queue.LifoQueue[tuple[str, str | None] | None] | None = None
 _UPLOAD_THREAD: threading.Thread | None = None
 _UPLOAD_LOCK = threading.Lock()
 
@@ -38,17 +38,28 @@ def _parse_s3_uri(uri: str) -> tuple[str, str]:
     return bucket, prefix.strip("/")
 
 
-def _upload_directory_to_s3(local_dir: Path, uri: str) -> None:
+def _s3_client():
+    """boto3 S3 client honoring AWS_ENDPOINT_URL(_S3) for MinIO/on-prem."""
     import boto3
 
+    endpoint = os.environ.get("AWS_ENDPOINT_URL_S3") or os.environ.get(
+        "AWS_ENDPOINT_URL"
+    )
+    return boto3.client("s3", endpoint_url=endpoint)
+
+
+def _upload_directory_to_s3(local_dir: Path, uri: str) -> None:
     bucket, prefix = _parse_s3_uri(uri)
-    client = boto3.client("s3")
+    client = _s3_client()
     for path in local_dir.rglob("*"):
         if not path.is_file():
             continue
         rel = path.relative_to(local_dir).as_posix()
         key = f"{prefix}/{rel}" if prefix else rel
         client.upload_file(str(path), bucket, key)
+    # marker written last: restore only considers checkpoints that carry it
+    marker = f"{prefix}/.upload_complete" if prefix else ".upload_complete"
+    client.put_object(Bucket=bucket, Key=marker, Body=b"")
 
 
 def _upload_worker() -> None:
@@ -58,17 +69,27 @@ def _upload_worker() -> None:
         return
 
     while True:
-        local_path = _UPLOAD_QUEUE.get()
+        item = _UPLOAD_QUEUE.get()
         try:
-            if local_path is None:
+            if item is None:
                 return
+            local_path, base_dir = item
             path = Path(local_path)
             if not path.exists():
                 continue
+            # preserve layout relative to base_dir (e.g. full_state_checkpoints/step_9)
+            rel_prefix = path.name
+            if base_dir:
+                try:
+                    rel_prefix = path.resolve().relative_to(
+                        Path(base_dir).resolve()
+                    ).as_posix()
+                except ValueError:
+                    pass
             if uri.startswith("s3://"):
-                _upload_directory_to_s3(path, uri)
+                _upload_directory_to_s3(path, f"{uri.rstrip('/')}/{rel_prefix}")
             else:
-                dest = Path(uri) / path.name
+                dest = Path(uri) / rel_prefix
                 if path.is_dir():
                     if dest.exists():
                         shutil.rmtree(dest)
@@ -100,13 +121,22 @@ def ensure_upload_worker_started() -> None:
         _UPLOAD_THREAD.start()
 
 
-def enqueue_checkpoint_upload(checkpoint_dir: str | Path) -> None:
-    """Queue a checkpoint directory for background upload (LIFO)."""
+def enqueue_checkpoint_upload(
+    checkpoint_dir: str | Path, base_dir: str | Path | None = None
+) -> None:
+    """Queue a checkpoint directory for background upload (LIFO).
+
+    base_dir: when given, the S3 key prefix preserves the checkpoint's path
+    relative to it (so nested layouts restore correctly).
+    """
     if not _upload_uri():
         return
     ensure_upload_worker_started()
     assert _UPLOAD_QUEUE is not None
-    _UPLOAD_QUEUE.put(str(Path(checkpoint_dir).resolve()))
+    _UPLOAD_QUEUE.put(
+        (str(Path(checkpoint_dir).resolve()),
+         str(Path(base_dir).resolve()) if base_dir else None)
+    )
 
 
 def shutdown_upload_worker(timeout: float = 30.0) -> None:
@@ -120,3 +150,66 @@ def shutdown_upload_worker(timeout: float = 30.0) -> None:
         _UPLOAD_THREAD = None
         _UPLOAD_QUEUE = None
     thread.join(timeout=timeout)
+
+
+def restore_latest_from_s3(uri: str, local_dir: str | Path) -> str | None:
+    """Download the latest complete checkpoint under *uri* into *local_dir*.
+
+    Checkpoints are laid out as ``<uri>/<checkpoint_name>/...`` with an
+    ``.upload_complete`` marker written last; prefixes without the marker
+    are skipped. Returns the local checkpoint path, or None when the bucket
+    holds no complete checkpoint.
+    """
+    bucket, prefix = _parse_s3_uri(uri)
+    client = _s3_client()
+
+    paginator = client.get_paginator("list_objects_v2")
+    base = f"{prefix}/" if prefix else ""
+    marker_suffix = "/.upload_complete"
+    names: list[str] = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=base):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key.endswith(marker_suffix):
+                names.append(key[len(base):-len(marker_suffix)])
+
+    def _step(name: str) -> int:
+        digits = "".join(ch for ch in name.rsplit("/", 1)[-1] if ch.isdigit())
+        return int(digits) if digits else -1
+
+    for name in sorted(names, key=_step, reverse=True):
+        dest = Path(local_dir) / name
+        dest.mkdir(parents=True, exist_ok=True)
+        ckpt_prefix = f"{base}{name}/"
+        for page in paginator.paginate(Bucket=bucket, Prefix=ckpt_prefix):
+            for obj in page.get("Contents", []):
+                rel = obj["Key"][len(ckpt_prefix):]
+                if not rel or rel == ".upload_complete":
+                    continue
+                target = dest / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                client.download_file(bucket, obj["Key"], str(target))
+        logger.info("Restored checkpoint from S3: %s -> %s", name, dest)
+        return str(dest)
+
+    return None
+
+
+def maybe_restore_from_s3(local_dir: str | Path) -> str | None:
+    """Restore latest S3 checkpoint when the upload URI is set and *local_dir*
+    holds no checkpoints yet. No-op (returns None) otherwise."""
+    uri = _upload_uri()
+    if not uri or not uri.startswith("s3://"):
+        return None
+    local = Path(local_dir)
+    if local.is_dir() and any(
+        child.is_dir() and not child.name.startswith(".")
+        and child.name not in ("data", "hf_cache", "_internal_data_processing")
+        for child in local.iterdir()
+    ):
+        return None  # local checkpoints present; native/local resume handles it
+    try:
+        return restore_latest_from_s3(uri, local)
+    except Exception:
+        logger.exception("Failed to restore checkpoint from S3 (%s)", uri)
+        return None

--- a/src/training_hub/checkpoint_manager.py
+++ b/src/training_hub/checkpoint_manager.py
@@ -1,0 +1,122 @@
+"""Background checkpoint upload queue (S3-compatible object storage).
+
+Set ``TRAINING_HUB_CHECKPOINT_UPLOAD_URI`` to enqueue each completed checkpoint
+for background upload after JIT save:
+
+* ``s3://bucket/prefix`` — uses a lazy ``boto3`` import (optional dependency;
+  install boto3 in the runtime image if S3 upload is required).
+* Any other URI — treated as a local directory; checkpoints are copied there.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import shutil
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_UPLOAD_QUEUE: queue.LifoQueue[str | None] | None = None
+_UPLOAD_THREAD: threading.Thread | None = None
+_UPLOAD_LOCK = threading.Lock()
+
+
+def _upload_uri() -> str | None:
+    return os.environ.get("TRAINING_HUB_CHECKPOINT_UPLOAD_URI")
+
+
+def _parse_s3_uri(uri: str) -> tuple[str, str]:
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Unsupported upload URI (expected s3://): {uri}")
+    without_scheme = uri[5:]
+    bucket, _, prefix = without_scheme.partition("/")
+    if not bucket:
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    return bucket, prefix.strip("/")
+
+
+def _upload_directory_to_s3(local_dir: Path, uri: str) -> None:
+    import boto3
+
+    bucket, prefix = _parse_s3_uri(uri)
+    client = boto3.client("s3")
+    for path in local_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(local_dir).as_posix()
+        key = f"{prefix}/{rel}" if prefix else rel
+        client.upload_file(str(path), bucket, key)
+
+
+def _upload_worker() -> None:
+    assert _UPLOAD_QUEUE is not None
+    uri = _upload_uri()
+    if not uri:
+        return
+
+    while True:
+        local_path = _UPLOAD_QUEUE.get()
+        try:
+            if local_path is None:
+                return
+            path = Path(local_path)
+            if not path.exists():
+                continue
+            if uri.startswith("s3://"):
+                _upload_directory_to_s3(path, uri)
+            else:
+                dest = Path(uri) / path.name
+                if path.is_dir():
+                    if dest.exists():
+                        shutil.rmtree(dest)
+                    shutil.copytree(path, dest)
+                else:
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(path, dest)
+            logger.info("Uploaded checkpoint %s to %s", path, uri)
+        except Exception:
+            logger.exception("Failed to upload checkpoint %s", local_path)
+        finally:
+            _UPLOAD_QUEUE.task_done()
+
+
+def ensure_upload_worker_started() -> None:
+    """Start the background uploader when an upload URI is configured."""
+    global _UPLOAD_QUEUE, _UPLOAD_THREAD
+    if not _upload_uri():
+        return
+    with _UPLOAD_LOCK:
+        if _UPLOAD_THREAD is not None:
+            return
+        _UPLOAD_QUEUE = queue.LifoQueue()
+        _UPLOAD_THREAD = threading.Thread(
+            target=_upload_worker,
+            name="training-hub-checkpoint-upload",
+            daemon=True,
+        )
+        _UPLOAD_THREAD.start()
+
+
+def enqueue_checkpoint_upload(checkpoint_dir: str | Path) -> None:
+    """Queue a checkpoint directory for background upload (LIFO)."""
+    if not _upload_uri():
+        return
+    ensure_upload_worker_started()
+    assert _UPLOAD_QUEUE is not None
+    _UPLOAD_QUEUE.put(str(Path(checkpoint_dir).resolve()))
+
+
+def shutdown_upload_worker(timeout: float = 30.0) -> None:
+    """Signal the upload worker to exit and wait for completion."""
+    global _UPLOAD_QUEUE, _UPLOAD_THREAD
+    with _UPLOAD_LOCK:
+        if _UPLOAD_QUEUE is None or _UPLOAD_THREAD is None:
+            return
+        _UPLOAD_QUEUE.put(None)
+        thread = _UPLOAD_THREAD
+        _UPLOAD_THREAD = None
+        _UPLOAD_QUEUE = None
+    thread.join(timeout=timeout)

--- a/src/training_hub/checkpoint_utils.py
+++ b/src/training_hub/checkpoint_utils.py
@@ -139,3 +139,31 @@ def apply_native_jit_params(
             backend,
         )
     params["on_demand_checkpointing"] = True
+
+
+UPLOAD_URI_ENV = "TRAINING_HUB_CHECKPOINT_UPLOAD_URI"
+
+
+def resolve_checkpoint_storage(checkpoint_storage: str | None) -> str | None:
+    """Validate the checkpoint_storage selector and return the S3 URI, if any.
+
+    Accepted values: None / "pvc" (filesystem only, the default) or an
+    "s3://bucket/prefix" URI (mirror checkpoints to S3, restore on resume).
+    """
+    if checkpoint_storage in (None, "", "pvc"):
+        return None
+    if isinstance(checkpoint_storage, str) and checkpoint_storage.startswith("s3://"):
+        return checkpoint_storage
+    raise ValueError(
+        "checkpoint_storage must be None, 'pvc', or an 's3://bucket/prefix' "
+        f"URI; got {checkpoint_storage!r}"
+    )
+
+
+def apply_checkpoint_storage_env(checkpoint_storage: str | None) -> None:
+    """Export the S3 upload URI so callbacks and torchrun workers inherit it."""
+    import os
+
+    uri = resolve_checkpoint_storage(checkpoint_storage)
+    if uri:
+        os.environ[UPLOAD_URI_ENV] = uri

--- a/src/training_hub/checkpoint_utils.py
+++ b/src/training_hub/checkpoint_utils.py
@@ -167,3 +167,6 @@ def apply_checkpoint_storage_env(checkpoint_storage: str | None) -> None:
     uri = resolve_checkpoint_storage(checkpoint_storage)
     if uri:
         os.environ[UPLOAD_URI_ENV] = uri
+    else:
+        # clear any URI left by an earlier S3 run in the same process
+        os.environ.pop(UPLOAD_URI_ENV, None)

--- a/src/training_hub/checkpoint_utils.py
+++ b/src/training_hub/checkpoint_utils.py
@@ -1,0 +1,141 @@
+"""Checkpoint discovery and incomplete-sentinel helpers for JIT resume."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Legacy in-dir sentinel (still honored on read for backward compatibility).
+INCOMPLETE_SENTINEL = ".incomplete"
+INCOMPLETE_SIDECAR_PREFIX = ".incomplete-checkpoint-"
+
+_HF_CHECKPOINT_RE = re.compile(r"^checkpoint-(\d+)$")
+_MINI_TRAINER_STEP_RE = re.compile(r"^step_(\d+)$")
+
+
+def incomplete_sidecar_path(output_dir: str | Path, step: int) -> Path:
+    """Return the sidecar file marking an in-progress HF checkpoint at *step*."""
+    return Path(output_dir) / f"{INCOMPLETE_SIDECAR_PREFIX}{step}"
+
+
+def mark_checkpoint_incomplete(output_dir: str | Path, step: int) -> None:
+    """Mark a checkpoint step as in-progress without pre-creating ``checkpoint-{step}``.
+
+    Uses a sidecar file in *output_dir* so HuggingFace Trainer can create the
+    checkpoint directory itself (some transformers versions rename into a new dir).
+    """
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    incomplete_sidecar_path(root, step).touch()
+
+
+def mark_checkpoint_complete(output_dir: str | Path, step: int) -> None:
+    """Clear incomplete markers for a finished checkpoint at *step*."""
+    root = Path(output_dir)
+    incomplete_sidecar_path(root, step).unlink(missing_ok=True)
+    legacy = root / f"checkpoint-{step}" / INCOMPLETE_SENTINEL
+    try:
+        legacy.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def is_valid_checkpoint_dir(
+    checkpoint_dir: Path,
+    output_dir: Path | None = None,
+) -> bool:
+    """Return True when the directory exists and has no incomplete sentinel."""
+    if not checkpoint_dir.is_dir():
+        return False
+    if (checkpoint_dir / INCOMPLETE_SENTINEL).exists():
+        return False
+    if output_dir is not None:
+        step = _checkpoint_step(checkpoint_dir, _HF_CHECKPOINT_RE)
+        if step is not None and incomplete_sidecar_path(output_dir, step).exists():
+            return False
+    return True
+
+
+def _checkpoint_step(path: Path, pattern: re.Pattern[str]) -> int | None:
+    match = pattern.match(path.name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def find_latest_valid_checkpoint(output_dir: str | None) -> str | None:
+    """Return the newest valid checkpoint path under *output_dir*, if any.
+
+    Supports HuggingFace ``checkpoint-{step}`` dirs and Mini-Trainer
+    ``full_state_checkpoints/step_{n}`` dirs. Directories containing
+    ``.incomplete`` or a matching ``.incomplete-checkpoint-{step}`` sidecar
+    are skipped.
+    """
+    if not output_dir:
+        return None
+
+    root = Path(output_dir)
+    if not root.is_dir():
+        return None
+
+    candidates: list[tuple[int, str]] = []
+
+    for child in root.iterdir():
+        if not child.is_dir() or not is_valid_checkpoint_dir(child, root):
+            continue
+        step = _checkpoint_step(child, _HF_CHECKPOINT_RE)
+        if step is not None:
+            candidates.append((step, str(child.resolve())))
+
+    mini_root = root / "full_state_checkpoints"
+    if mini_root.is_dir():
+        for child in mini_root.iterdir():
+            if not child.is_dir() or not is_valid_checkpoint_dir(child):
+                continue
+            if not (child / "training_state.pt").exists():
+                continue
+            step = _checkpoint_step(child, _MINI_TRAINER_STEP_RE)
+            if step is not None:
+                candidates.append((step, str(child.resolve())))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def jit_checkpoint_enabled(
+    enable_jit_checkpoint: bool | None,
+    ckpt_output_dir: str | None,
+) -> bool:
+    """Return True when explicit JIT opt-in and output dir are both set."""
+    return bool(enable_jit_checkpoint and ckpt_output_dir)
+
+
+def apply_native_jit_params(
+    params: dict[str, object],
+    *,
+    enable_jit_checkpoint: bool | None,
+    backend: str,
+) -> None:
+    """Enable backend-native on-demand checkpointing for SFT/OSFT.
+
+    InstructLab SFT workers call ``load_latest_full_state()`` on startup and
+    resume from ``{ckpt_output_dir}/full_state`` when on-demand checkpoints
+    exist (no extra resume parameter from Training Hub). Mini-Trainer OSFT has
+    the same auto-resume behavior for ``full_state_checkpoints/``.
+    """
+    if not (enable_jit_checkpoint and backend in {"sft", "osft"}):
+        return
+
+    if params.get("on_demand_checkpointing") is False:
+        logger.warning(
+            "enable_jit_checkpoint=True overrides on_demand_checkpointing=False "
+            "for backend %s",
+            backend,
+        )
+    params["on_demand_checkpointing"] = True

--- a/src/training_hub/jit_checkpoint.py
+++ b/src/training_hub/jit_checkpoint.py
@@ -90,24 +90,37 @@ class JITCheckpointCallback(TrainingHubCallback):
         self._handle_preemption(context)
 
     def on_save(self, context: TrainingHubContext) -> None:
-        if not context.output_dir or context.step <= 0:
+        # Clear the incomplete sidecar for the just-saved checkpoint.
+        # S3 mirroring is owned by S3CheckpointSyncCallback, not this hook.
+        if not context.is_main_process:
             return
-
-        if context.is_main_process:
+        if context.output_dir and context.step > 0:
             mark_checkpoint_complete(context.output_dir, context.step)
 
-        checkpoint_path = context.metrics.get("checkpoint_path")
-        if checkpoint_path and context.is_main_process:
-            enqueue_checkpoint_upload(checkpoint_path)
-            return
+    @staticmethod
+    def _preempt_requested_any_rank() -> bool:
+        """Aggregate the process-local SIGTERM flag across ranks (MAX), so a
+        signal seen by one rank stops all ranks at the same step boundary."""
+        flag = preempt_requested()
+        try:
+            import torch
+            import torch.distributed as dist
 
-        if context.is_main_process:
-            ckpt_dir = Path(context.output_dir) / f"checkpoint-{context.step}"
-            if ckpt_dir.is_dir():
-                enqueue_checkpoint_upload(ckpt_dir)
+            if dist.is_available() and dist.is_initialized():
+                device = (
+                    torch.device("cuda", torch.cuda.current_device())
+                    if torch.cuda.is_available()
+                    else torch.device("cpu")
+                )
+                t = torch.tensor([1 if flag else 0], device=device)
+                dist.all_reduce(t, op=dist.ReduceOp.MAX)
+                return bool(t.item())
+        except Exception:
+            logger.exception("JIT checkpoint: preemption rank-sync failed")
+        return flag
 
     def _handle_preemption(self, context: TrainingHubContext) -> None:
-        if not preempt_requested():
+        if not self._preempt_requested_any_rank():
             return
         control = context.control
         if control is None:

--- a/src/training_hub/jit_checkpoint.py
+++ b/src/training_hub/jit_checkpoint.py
@@ -1,0 +1,125 @@
+"""JIT (just-in-time) preemption checkpoint callback for HuggingFace-backed training."""
+
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+from pathlib import Path
+
+from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+from training_hub.checkpoint_manager import enqueue_checkpoint_upload
+from training_hub.checkpoint_utils import mark_checkpoint_complete, mark_checkpoint_incomplete
+
+logger = logging.getLogger(__name__)
+
+_PREEMPT_REQUESTED = False
+_ORIGINAL_SIGTERM_HANDLER: signal.Handlers | int | None = None
+
+
+def preempt_requested() -> bool:
+    """Return whether a preemption signal has been received."""
+    return _PREEMPT_REQUESTED
+
+
+def _handle_sigterm(signum: int, frame) -> None:  # noqa: ARG001
+    global _PREEMPT_REQUESTED
+    _PREEMPT_REQUESTED = True
+    logger.warning(
+        "Received signal %s; will checkpoint at the next training step boundary.",
+        signum,
+    )
+
+
+def register_preemption_handler() -> None:
+    """Register SIGTERM handler on the main thread."""
+    global _ORIGINAL_SIGTERM_HANDLER
+    if threading.current_thread() is not threading.main_thread():
+        logger.warning(
+            "JIT checkpoint: not on main thread; skipping signal registration."
+        )
+        return
+    try:
+        _ORIGINAL_SIGTERM_HANDLER = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, _handle_sigterm)
+    except (OSError, ValueError):
+        logger.exception("JIT checkpoint: failed to register SIGTERM handler")
+
+
+def restore_preemption_handler() -> None:
+    """Restore the original SIGTERM handler."""
+    global _ORIGINAL_SIGTERM_HANDLER
+    if _ORIGINAL_SIGTERM_HANDLER is None:
+        return
+    if threading.current_thread() is not threading.main_thread():
+        return
+    try:
+        signal.signal(signal.SIGTERM, _ORIGINAL_SIGTERM_HANDLER)
+    except (OSError, ValueError):
+        logger.exception("JIT checkpoint: failed to restore SIGTERM handler")
+    finally:
+        _ORIGINAL_SIGTERM_HANDLER = None
+
+
+class JITCheckpointCallback(TrainingHubCallback):
+    """Save a full checkpoint on SIGTERM at the next step/epoch boundary.
+
+    Uses ``TrainingHubControl`` (via ``context.control``) to request a
+    HuggingFace ``TrainerControl.should_save`` / ``should_training_stop``.
+    No constructor arguments — reads ``context.output_dir`` at hook time.
+
+  ponytail: ``run_on_all_ranks`` is set for future multi-GPU LoRA, but SIGTERM
+  can land between ranks' ``on_step_end`` checks and cause mismatched save
+  flags across processes. Unsloth LoRA is single-process today; a distributed
+  fix would need a collective preemption barrier before ``should_save``.
+    """
+
+    run_on_all_ranks = True
+
+    def on_train_begin(self, context: TrainingHubContext) -> None:
+        global _PREEMPT_REQUESTED
+        _PREEMPT_REQUESTED = False
+        register_preemption_handler()
+
+    def on_train_end(self, context: TrainingHubContext) -> None:
+        restore_preemption_handler()
+
+    def on_step_end(self, context: TrainingHubContext) -> None:
+        self._handle_preemption(context)
+
+    def on_epoch_end(self, context: TrainingHubContext) -> None:
+        self._handle_preemption(context)
+
+    def on_save(self, context: TrainingHubContext) -> None:
+        if not context.output_dir or context.step <= 0:
+            return
+
+        if context.is_main_process:
+            mark_checkpoint_complete(context.output_dir, context.step)
+
+        checkpoint_path = context.metrics.get("checkpoint_path")
+        if checkpoint_path and context.is_main_process:
+            enqueue_checkpoint_upload(checkpoint_path)
+            return
+
+        if context.is_main_process:
+            ckpt_dir = Path(context.output_dir) / f"checkpoint-{context.step}"
+            if ckpt_dir.is_dir():
+                enqueue_checkpoint_upload(ckpt_dir)
+
+    def _handle_preemption(self, context: TrainingHubContext) -> None:
+        if not preempt_requested():
+            return
+        control = context.control
+        if control is None:
+            logger.error(
+                "JIT checkpoint: preemption requested but no TrainingHubControl "
+                "is attached to the callback context."
+            )
+            return
+
+        if context.is_main_process and context.output_dir and context.step > 0:
+            mark_checkpoint_incomplete(context.output_dir, context.step)
+
+        control.should_save = True
+        control.should_training_stop = True

--- a/src/training_hub/jit_checkpoint.py
+++ b/src/training_hub/jit_checkpoint.py
@@ -68,10 +68,10 @@ class JITCheckpointCallback(TrainingHubCallback):
     HuggingFace ``TrainerControl.should_save`` / ``should_training_stop``.
     No constructor arguments — reads ``context.output_dir`` at hook time.
 
-  ponytail: ``run_on_all_ranks`` is set for future multi-GPU LoRA, but SIGTERM
-  can land between ranks' ``on_step_end`` checks and cause mismatched save
-  flags across processes. Unsloth LoRA is single-process today; a distributed
-  fix would need a collective preemption barrier before ``should_save``.
+    ponytail: ``run_on_all_ranks`` is set for future multi-GPU LoRA, but SIGTERM
+    can land between ranks' ``on_step_end`` checks and cause mismatched save
+    flags across processes. Unsloth LoRA is single-process today; a distributed
+    fix would need a collective preemption barrier before ``should_save``.
     """
 
     run_on_all_ranks = True

--- a/src/training_hub/jit_checkpoint.py
+++ b/src/training_hub/jit_checkpoint.py
@@ -8,7 +8,6 @@ import threading
 from pathlib import Path
 
 from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
-from training_hub.checkpoint_manager import enqueue_checkpoint_upload
 from training_hub.checkpoint_utils import mark_checkpoint_complete, mark_checkpoint_incomplete
 
 logger = logging.getLogger(__name__)
@@ -123,3 +122,30 @@ class JITCheckpointCallback(TrainingHubCallback):
 
         control.should_save = True
         control.should_training_stop = True
+
+
+class S3CheckpointSyncCallback(TrainingHubCallback):
+    """Mirror every saved checkpoint to S3 (checkpoint_storage="s3://...").
+
+    Serialization-safe for torchrun backends: no constructor arguments —
+    the S3 URI is read from TRAINING_HUB_CHECKPOINT_UPLOAD_URI inside hooks.
+    Uploads happen on rank 0 only, via the background upload queue.
+    """
+
+    def on_save(self, context: TrainingHubContext) -> None:
+        from training_hub.checkpoint_manager import enqueue_checkpoint_upload
+
+        checkpoint_path = context.metrics.get("checkpoint_path")
+        if not checkpoint_path and context.output_dir and context.step > 0:
+            candidate = f"{context.output_dir}/checkpoint-{context.step}"
+            import os
+
+            if os.path.isdir(candidate):
+                checkpoint_path = candidate
+        if checkpoint_path:
+            enqueue_checkpoint_upload(checkpoint_path, base_dir=context.output_dir or None)
+
+    def on_train_end(self, context: TrainingHubContext) -> None:
+        from training_hub.checkpoint_manager import shutdown_upload_worker
+
+        shutdown_upload_worker()

--- a/tests/test_checkpoint_storage.py
+++ b/tests/test_checkpoint_storage.py
@@ -92,3 +92,60 @@ class TestUploadLayout:
         local, base = captured[0]
         assert local == str(ckpt.resolve())
         assert base == str(tmp_path.resolve())
+
+
+class TestEnvClearedForPvc:
+    def test_s3_then_pvc_clears_stale_uri(self, monkeypatch):
+        """Switching from S3 to PVC in one process must not leak the URI."""
+        monkeypatch.delenv(UPLOAD_URI_ENV, raising=False)
+        apply_checkpoint_storage_env("s3://b/p")
+        assert os.environ[UPLOAD_URI_ENV] == "s3://b/p"
+        apply_checkpoint_storage_env(None)
+        assert UPLOAD_URI_ENV not in os.environ
+
+
+class TestTrainParamPath:
+    """Full train() param path with a mock backend: catches unsupported-kwarg
+    regressions (e.g. apply_native_jit_params signature drift) that pure
+    helper tests miss."""
+
+    class _CaptureBackend:
+        def __init__(self):
+            self.params = None
+
+        def execute_training(self, params):
+            self.params = params
+            return "ok"
+
+    def test_sft_train_params_path(self, tmp_path):
+        from training_hub.algorithms.sft import SFTAlgorithm
+
+        backend = self._CaptureBackend()
+        result = SFTAlgorithm(backend).train(
+            model_path="m",
+            data_path="d",
+            ckpt_output_dir=str(tmp_path),
+            enable_jit_checkpoint=True,
+            checkpoint_storage="pvc",
+        )
+        assert result == "ok"
+        assert backend.params["on_demand_checkpointing"] is True
+
+    def test_osft_train_params_path(self, tmp_path):
+        from training_hub.algorithms.osft import OSFTAlgorithm
+
+        backend = self._CaptureBackend()
+        result = OSFTAlgorithm(backend).train(
+            model_path="m",
+            data_path="d",
+            unfreeze_rank_ratio=0.25,
+            effective_batch_size=8,
+            max_tokens_per_gpu=4096,
+            max_seq_len=512,
+            learning_rate=1e-5,
+            ckpt_output_dir=str(tmp_path),
+            enable_jit_checkpoint=True,
+            checkpoint_storage="pvc",
+        )
+        assert result == "ok"
+        assert backend.params["on_demand_checkpointing"] is True

--- a/tests/test_checkpoint_storage.py
+++ b/tests/test_checkpoint_storage.py
@@ -1,0 +1,94 @@
+"""Tests for checkpoint_storage selection (pvc/s3) and S3 sync plumbing."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from training_hub.callbacks import merge_default_callbacks
+from training_hub.checkpoint_utils import (
+    UPLOAD_URI_ENV,
+    apply_checkpoint_storage_env,
+    resolve_checkpoint_storage,
+)
+from training_hub.jit_checkpoint import JITCheckpointCallback, S3CheckpointSyncCallback
+
+
+class TestResolveCheckpointStorage:
+    def test_none_and_pvc_mean_filesystem_only(self):
+        assert resolve_checkpoint_storage(None) is None
+        assert resolve_checkpoint_storage("") is None
+        assert resolve_checkpoint_storage("pvc") is None
+
+    def test_s3_uri_passes_through(self):
+        assert resolve_checkpoint_storage("s3://bucket/prefix") == "s3://bucket/prefix"
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError, match="checkpoint_storage"):
+            resolve_checkpoint_storage("gs://bucket/x")
+
+    def test_apply_env(self, monkeypatch):
+        monkeypatch.delenv(UPLOAD_URI_ENV, raising=False)
+        apply_checkpoint_storage_env("pvc")
+        assert UPLOAD_URI_ENV not in os.environ
+        apply_checkpoint_storage_env("s3://b/p")
+        assert os.environ[UPLOAD_URI_ENV] == "s3://b/p"
+
+
+class TestMergeDefaultsWithStorage:
+    def test_s3_sync_prepended_for_hub_jit_backend(self):
+        cbs = merge_default_callbacks(
+            None,
+            enable_jit_checkpoint=True,
+            ckpt_output_dir="/tmp/x",
+            backend="lora_sft",
+            checkpoint_storage="s3://b/p",
+        )
+        assert isinstance(cbs[0], JITCheckpointCallback)
+        assert isinstance(cbs[1], S3CheckpointSyncCallback)
+
+    def test_s3_sync_prepended_even_for_native_backends(self):
+        cbs = merge_default_callbacks(
+            None,
+            enable_jit_checkpoint=True,
+            ckpt_output_dir="/tmp/x",
+            backend="osft",
+            checkpoint_storage="s3://b/p",
+        )
+        # native backend: no JIT callback, but S3 sync still present
+        assert len(cbs) == 1
+        assert isinstance(cbs[0], S3CheckpointSyncCallback)
+
+    def test_pvc_adds_no_sync_callback(self):
+        cbs = merge_default_callbacks(
+            None,
+            enable_jit_checkpoint=True,
+            ckpt_output_dir="/tmp/x",
+            backend="sft",
+            checkpoint_storage="pvc",
+        )
+        assert cbs == []
+
+
+class TestUploadLayout:
+    def test_enqueue_preserves_relative_layout(self, monkeypatch, tmp_path: Path):
+        """Nested checkpoint dirs keep their relative path in the queue item."""
+        import training_hub.checkpoint_manager as cm
+
+        monkeypatch.setenv(UPLOAD_URI_ENV, "s3://b/p")
+        captured = []
+
+        class FakeQueue:
+            def put(self, item):
+                captured.append(item)
+
+        monkeypatch.setattr(cm, "_UPLOAD_QUEUE", FakeQueue())
+        monkeypatch.setattr(cm, "ensure_upload_worker_started", lambda: None)
+
+        ckpt = tmp_path / "full_state_checkpoints" / "step_9"
+        ckpt.mkdir(parents=True)
+        cm.enqueue_checkpoint_upload(ckpt, base_dir=tmp_path)
+
+        local, base = captured[0]
+        assert local == str(ckpt.resolve())
+        assert base == str(tmp_path.resolve())

--- a/tests/test_jit_checkpoint.py
+++ b/tests/test_jit_checkpoint.py
@@ -1,0 +1,157 @@
+"""Tests for checkpoint_utils and JIT checkpoint integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from training_hub.callbacks import TrainingHubControl, merge_default_callbacks
+from training_hub.checkpoint_utils import (
+    INCOMPLETE_SENTINEL,
+    find_latest_valid_checkpoint,
+    is_valid_checkpoint_dir,
+    jit_checkpoint_enabled,
+    mark_checkpoint_complete,
+    mark_checkpoint_incomplete,
+)
+from training_hub.jit_checkpoint import JITCheckpointCallback
+
+
+class TestCheckpointUtils:
+    def test_incomplete_sentinel_skipped_on_resume(self, tmp_path: Path):
+        valid = tmp_path / "checkpoint-10"
+        valid.mkdir()
+        incomplete = tmp_path / "checkpoint-20"
+        incomplete.mkdir()
+        (incomplete / INCOMPLETE_SENTINEL).touch()
+
+        assert find_latest_valid_checkpoint(str(tmp_path)) == str(valid.resolve())
+
+    def test_latest_hf_checkpoint_wins(self, tmp_path: Path):
+        (tmp_path / "checkpoint-3").mkdir()
+        (tmp_path / "checkpoint-12").mkdir()
+        assert find_latest_valid_checkpoint(str(tmp_path)).endswith("checkpoint-12")
+
+    def test_mini_trainer_layout(self, tmp_path: Path):
+        step_dir = tmp_path / "full_state_checkpoints" / "step_7"
+        step_dir.mkdir(parents=True)
+        (step_dir / "training_state.pt").touch()
+        assert find_latest_valid_checkpoint(str(tmp_path)) == str(step_dir.resolve())
+
+    def test_mark_complete_removes_sentinel(self, tmp_path: Path):
+        ckpt = tmp_path / "checkpoint-1"
+        ckpt.mkdir()
+        mark_checkpoint_incomplete(ckpt)
+        assert not is_valid_checkpoint_dir(ckpt)
+        mark_checkpoint_complete(ckpt)
+        assert is_valid_checkpoint_dir(ckpt)
+
+    def test_jit_checkpoint_enabled_requires_both(self):
+        assert not jit_checkpoint_enabled(False, "/tmp")
+        assert not jit_checkpoint_enabled(True, None)
+        assert jit_checkpoint_enabled(True, "/tmp")
+
+
+class TestMergeDefaultCallbacks:
+    def test_prepends_jit_for_lora_backend(self):
+        merged = merge_default_callbacks(
+            [],
+            enable_jit_checkpoint=True,
+            ckpt_output_dir="/ckpt",
+            backend="lora_sft",
+        )
+        assert len(merged) == 1
+        assert isinstance(merged[0], JITCheckpointCallback)
+
+    def test_skips_jit_for_native_backends(self):
+        for backend in ("sft", "osft"):
+            merged = merge_default_callbacks(
+                [],
+                enable_jit_checkpoint=True,
+                ckpt_output_dir="/ckpt",
+                backend=backend,
+            )
+            assert merged == []
+
+    def test_user_callbacks_after_defaults(self):
+        from training_hub.callbacks import TrainingHubCallback
+
+        class UserCb(TrainingHubCallback):
+            pass
+
+        merged = merge_default_callbacks(
+            [UserCb()],
+            enable_jit_checkpoint=True,
+            ckpt_output_dir="/ckpt",
+            backend="lora_sft",
+        )
+        assert isinstance(merged[0], JITCheckpointCallback)
+        assert type(merged[1]).__name__ == "UserCb"
+
+
+class TestJITCheckpointCallback:
+    def test_preemption_sets_control_flags(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(
+            "training_hub.jit_checkpoint.preempt_requested",
+            lambda: True,
+        )
+        cb = JITCheckpointCallback()
+        control = TrainingHubControl()
+        ctx = SimpleNamespace(
+            output_dir=str(tmp_path),
+            step=5,
+            is_main_process=True,
+            metrics={},
+            control=control,
+        )
+        cb.on_step_end(ctx)
+        assert control.should_save is True
+        assert control.should_training_stop is True
+        assert (tmp_path / "checkpoint-5" / INCOMPLETE_SENTINEL).exists()
+
+    def test_no_preempt_is_noop(self):
+        cb = JITCheckpointCallback()
+        control = TrainingHubControl()
+        ctx = SimpleNamespace(
+            output_dir="/out",
+            step=1,
+            is_main_process=True,
+            metrics={},
+            control=control,
+        )
+        cb.on_step_end(ctx)
+        assert control.should_save is False
+        assert control.should_training_stop is False
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util").util.find_spec("transformers") is None,
+    reason="transformers not installed",
+)
+class TestUnslothControlWiring:
+    def test_step_end_returns_hf_control_flags(self):
+        from training_hub.adapters.unsloth import adapt_hub_callbacks
+        from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+
+        class Preempt(TrainingHubCallback):
+            run_on_all_ranks = True
+
+            def on_step_end(self, context: TrainingHubContext) -> None:
+                assert context.control is not None
+                context.control.should_save = True
+                context.control.should_training_stop = True
+
+        adapter = adapt_hub_callbacks([Preempt()])[0]
+        args = SimpleNamespace(output_dir="/out")
+        state = SimpleNamespace(
+            global_step=2,
+            epoch=0.0,
+            is_world_process_zero=True,
+            log_history=[],
+        )
+        control = SimpleNamespace(should_save=False, should_training_stop=False)
+        result = adapter.on_step_end(args, state, control)
+        assert result.should_save is True
+        assert result.should_training_stop is True

--- a/tests/test_jit_checkpoint.py
+++ b/tests/test_jit_checkpoint.py
@@ -10,7 +10,9 @@ import pytest
 from training_hub.callbacks import TrainingHubControl, merge_default_callbacks
 from training_hub.checkpoint_utils import (
     INCOMPLETE_SENTINEL,
+    INCOMPLETE_SIDECAR_PREFIX,
     find_latest_valid_checkpoint,
+    incomplete_sidecar_path,
     is_valid_checkpoint_dir,
     jit_checkpoint_enabled,
     mark_checkpoint_complete,
@@ -20,7 +22,16 @@ from training_hub.jit_checkpoint import JITCheckpointCallback
 
 
 class TestCheckpointUtils:
-    def test_incomplete_sentinel_skipped_on_resume(self, tmp_path: Path):
+    def test_incomplete_sidecar_skipped_on_resume(self, tmp_path: Path):
+        valid = tmp_path / "checkpoint-10"
+        valid.mkdir()
+        incomplete = tmp_path / "checkpoint-20"
+        incomplete.mkdir()
+        incomplete_sidecar_path(tmp_path, 20).touch()
+
+        assert find_latest_valid_checkpoint(str(tmp_path)) == str(valid.resolve())
+
+    def test_legacy_in_dir_sentinel_still_skipped(self, tmp_path: Path):
         valid = tmp_path / "checkpoint-10"
         valid.mkdir()
         incomplete = tmp_path / "checkpoint-20"
@@ -40,13 +51,21 @@ class TestCheckpointUtils:
         (step_dir / "training_state.pt").touch()
         assert find_latest_valid_checkpoint(str(tmp_path)) == str(step_dir.resolve())
 
-    def test_mark_complete_removes_sentinel(self, tmp_path: Path):
-        ckpt = tmp_path / "checkpoint-1"
-        ckpt.mkdir()
-        mark_checkpoint_incomplete(ckpt)
-        assert not is_valid_checkpoint_dir(ckpt)
-        mark_checkpoint_complete(ckpt)
-        assert is_valid_checkpoint_dir(ckpt)
+    def test_mark_complete_removes_sidecar(self, tmp_path: Path):
+        mark_checkpoint_incomplete(tmp_path, 1)
+        sidecar = incomplete_sidecar_path(tmp_path, 1)
+        assert sidecar.exists()
+        assert not is_valid_checkpoint_dir(tmp_path / "checkpoint-1", tmp_path)
+
+        (tmp_path / "checkpoint-1").mkdir()
+        mark_checkpoint_complete(tmp_path, 1)
+        assert not sidecar.exists()
+        assert is_valid_checkpoint_dir(tmp_path / "checkpoint-1", tmp_path)
+
+    def test_incomplete_does_not_precreate_checkpoint_dir(self, tmp_path: Path):
+        mark_checkpoint_incomplete(tmp_path, 5)
+        assert incomplete_sidecar_path(tmp_path, 5).exists()
+        assert not (tmp_path / "checkpoint-5").exists()
 
     def test_jit_checkpoint_enabled_requires_both(self):
         assert not jit_checkpoint_enabled(False, "/tmp")
@@ -109,7 +128,8 @@ class TestJITCheckpointCallback:
         cb.on_step_end(ctx)
         assert control.should_save is True
         assert control.should_training_stop is True
-        assert (tmp_path / "checkpoint-5" / INCOMPLETE_SENTINEL).exists()
+        assert incomplete_sidecar_path(tmp_path, 5).exists()
+        assert not (tmp_path / "checkpoint-5").exists()
 
     def test_no_preempt_is_noop(self):
         cb = JITCheckpointCallback()
@@ -155,3 +175,26 @@ class TestUnslothControlWiring:
         result = adapter.on_step_end(args, state, control)
         assert result.should_save is True
         assert result.should_training_stop is True
+
+    def test_on_save_uses_global_step_not_best_checkpoint(self):
+        from training_hub.adapters.unsloth import adapt_hub_callbacks
+        from training_hub.callbacks import TrainingHubCallback, TrainingHubContext
+
+        captured: dict[str, str] = {}
+
+        class CaptureSave(TrainingHubCallback):
+            def on_save(self, context: TrainingHubContext) -> None:
+                captured["path"] = context.metrics["checkpoint_path"]
+
+        adapter = adapt_hub_callbacks([CaptureSave()])[0]
+        args = SimpleNamespace(output_dir="/runs/out")
+        state = SimpleNamespace(
+            global_step=42,
+            best_model_checkpoint="/runs/out/checkpoint-10",
+            epoch=1.0,
+            is_world_process_zero=True,
+            log_history=[],
+        )
+        control = SimpleNamespace()
+        adapter.on_save(args, state, control)
+        assert captured["path"] == "/runs/out/checkpoint-42"


### PR DESCRIPTION
## Summary

Adds JIT (just-in-time) preemption checkpointing to Training Hub as default-flow callbacks, so any consumer (Kubeflow SDK, Ray, direct use) gets SIGTERM-safe checkpoint-and-resume for free — no SDK-side instrumentation needed.

**API** (all of `sft()`, `osft()`, `lora_sft()`):

```python
lora_sft(
    ...,
    enable_jit_checkpoint=True,          # SIGTERM -> save checkpoint -> stop; auto-resume on restart
    checkpoint_storage="s3://bucket/x",  # or "pvc"/None (default): filesystem only
)
```

## Design

- **One unified API, per-backend mechanisms.** `merge_default_callbacks()` prepends hub default callbacks before user callbacks (hub hooks run first, per design discussion):
  - `lora_sft` (Unsloth/HF): new `JITCheckpointCallback` — SIGTERM handler, save via HF `TrainerControl.should_save` (full trainer state), `.incomplete` sentinel for interrupted saves, resume via `trainer.train(resume_from_checkpoint=...)` decided in the backend before training starts.
  - `sft` (instructlab-training) / `osft` (mini-trainer): delegate to the backends' native `on_demand_checkpointing` — they already own SIGTERM handling, distributed save, and auto-resume. Re-implementing in a callback would double-register signal handlers.
- **Loud failure over silent no-op:** older instructlab-training / mini-trainer silently drop unknown `TrainingArgs` fields; requesting JIT on those now raises with an upgrade hint (instructlab-training >=0.16.2, mini-trainer >=0.8.3).
- **`checkpoint_storage` selector:** `None`/`"pvc"` = filesystem (SDK mounts the PVC and passes a path — unchanged behavior). `"s3://bucket/prefix"` = `S3CheckpointSyncCallback` mirrors every saved checkpoint to S3 in the background (layout-preserving, `.upload_complete` marker written last), and on restart with an empty local dir the latest complete checkpoint is restored from S3 before training resumes. MinIO/on-prem supported via `AWS_ENDPOINT_URL(_S3)`.

## Testing

Cluster e2e (OpenShift, A100, real `oc delete pod` SIGTERM, pod restart, resume, completion):

| Leg | Result |
|---|---|
| lora_sft kill/resume (hub callback) | ✅ 5/5 checks |
| sft kill/resume (instructlab native, 0.16.2) | ✅ 5/5 |
| osft kill/resume (mini-trainer native, 0.8.3+) | ✅ 5/5 |
| Edge: eval-enabled JIT save | ✅ |
| Edge: injected corrupt `.incomplete` checkpoint skipped on resume | ✅ |
| Unit tests | ✅ 50/50 |

## Draft — remaining before ready-for-review

- [ ] S3 e2e on cluster (MinIO harness written; blocked on cluster access at time of drafting)
- [ ] Docs: `enable_jit_checkpoint`, `checkpoint_storage`, backend version floors
- [ ] Declare boto3 as an optional extra (e.g. `[s3]`) in `pyproject.toml`
- [ ] Multi-node distributed validation

## Findings for reviewers / platform team

- instructlab-training exits 0 after a preemption save — a plain k8s Job marks it Complete and never restarts it (`podReplacementPolicy` + replacement policy considerations apply for the SDK/controller).
- instructlab auto-resume crashes permanently on a truncated `full_state` (no sentinel validation upstream).
- RWO PVC: a replacement pod mounting the volume while the dying pod is still saving corrupts the checkpoint (SELinux relabel revokes the old pod's write access). `podReplacementPolicy: Failed` avoids the overlap.

Jira: RHOAIENG-38119



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added just-in-time checkpointing to preserve training progress during preemption and resume automatically.
  * Added configurable filesystem or S3-compatible checkpoint storage with background synchronization and restoration.
  * Added validation to resume from the latest complete checkpoint while ignoring incomplete checkpoints.
  * Added callback support for requesting checkpoint saves and safely stopping training.
* **Documentation**
  * Added a guide covering JIT checkpointing, storage options, deployment, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->